### PR TITLE
log sanitize ipv4 and ipv6

### DIFF
--- a/src/utils/constants.rs
+++ b/src/utils/constants.rs
@@ -95,7 +95,7 @@ pub static CONSTANTS: LazyLock<Constants> = LazyLock::new(||
     Constants {
         re_credentials: Regex::new(r"((username|password|token)=)[^&]*").unwrap(),
         re_ipv4: Regex::new(r"\b((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\b").unwrap(),
-        re_ipv6: Regex::new(r"\b([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}\b|\b::([0-9a-fA-F]{1,4}:){0,6}[0-9a-fA-F]{1,4}\b|\b([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}\b").unwrap(),
+        re_ipv6: Regex::new(r"\b([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}\b|\b::([0-9a-fA-F]{1,4}:){0,6}[0-9a-fA-F]{1,4}\b|\b([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}\b|\b::ffff:(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b").unwrap(),
         re_stream_url: Regex::new(r"(?i)^(?P<scheme>https?://)[^/]+/(?P<ctx>live|video|movie|series|m3u-stream|resource)/[^/]+/[^/]+/").unwrap(),
         re_url: Regex::new(r"(.*://).*?/(.*)").unwrap(),
         re_base_href: Regex::new(r#"(href|src)="/([^"]*)""#).unwrap(),

--- a/src/utils/constants.rs
+++ b/src/utils/constants.rs
@@ -69,9 +69,9 @@ pub struct KodiStyle {
 }
 
 pub struct Constants {
-    pub re_username: Regex,
-    pub re_password: Regex,
-    pub re_token: Regex,
+    pub re_credentials: Regex,
+    pub re_ipv4: Regex,
+    pub re_ipv6: Regex,
     pub re_stream_url: Regex,
     pub re_url: Regex,
     pub re_base_href: Regex,
@@ -93,9 +93,9 @@ pub struct Constants {
 
 pub static CONSTANTS: LazyLock<Constants> = LazyLock::new(||
     Constants {
-        re_username: Regex::new(r"(username=)[^&]*").unwrap(),
-        re_password: Regex::new(r"(password=)[^&]*").unwrap(),
-        re_token: Regex::new(r"(token=)[^&]*").unwrap(),
+        re_credentials: Regex::new(r"((username|password|token)=)[^&]*").unwrap(),
+        re_ipv4: Regex::new(r"\b((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\b").unwrap(),
+        re_ipv6: Regex::new(r"\b([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}\b|\b::([0-9a-fA-F]{1,4}:){0,6}[0-9a-fA-F]{1,4}\b|\b([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}\b").unwrap(),
         re_stream_url: Regex::new(r"(?i)^(?P<scheme>https?://)[^/]+/(?P<ctx>live|video|movie|series|m3u-stream|resource)/[^/]+/[^/]+/").unwrap(),
         re_url: Regex::new(r"(.*://).*?/(.*)").unwrap(),
         re_base_href: Regex::new(r#"(href|src)="/([^"]*)""#).unwrap(),

--- a/src/utils/network/epg.rs
+++ b/src/utils/network/epg.rs
@@ -15,7 +15,7 @@ async fn download_epg_file(url: &str, client: &Arc<reqwest::Client>, input: &Con
     let persist_file_path = prepare_file_path(input.persist.as_deref(), working_dir, "")
         .map(|path| add_prefix_to_filename(&path, format!("{file_prefix}_epg_").as_str(), Some("xml")));
 
-    request::get_input_text_content_as_file(Arc::clone(client), input, working_dir, url, persist_file_path).await
+    request::get_input_epg_content_as_file(Arc::clone(client), input, working_dir, url, persist_file_path).await
 }
 
 pub async fn get_xmltv(client: Arc<reqwest::Client>, _cfg: &Config, input: &ConfigInput, working_dir: &str) -> (Option<TVGuide>, Vec<TuliproxError>) {


### PR DESCRIPTION
log sanitize ipv4 and ipv6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved detection and masking of sensitive information, now including IPv4 and IPv6 addresses.

- **Refactor**
  - Streamlined sensitive data sanitization for more consistent and extensible protection.
  - Updated naming and visibility of functions related to EPG content handling for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->