### PR TITLE
Series info can have release_date and releaseDate as fields, which sh…

### DIFF
--- a/src/api/endpoints/xtream_api.rs
+++ b/src/api/endpoints/xtream_api.rs
@@ -21,7 +21,7 @@ use crate::model::{get_backdrop_path_value, FieldGetAccessor, PlaylistEntry, Pla
 use crate::repository::playlist_repository::get_target_id_mapping;
 use crate::repository::storage::{get_target_storage_path, hex_encode};
 use crate::repository::{storage_const, user_repository, xtream_repository};
-use crate::utils::HLS_EXT;
+use crate::utils::{get_non_empty_str, HLS_EXT};
 use crate::utils::generate_playlist_uuid;
 use crate::utils::get_u32_from_serde_value;
 use crate::utils::request::{extract_extension_from_url, sanitize_sensitive_info};
@@ -526,15 +526,6 @@ create_xtream_player_api_resource!(xtream_player_api_live_resource, XtreamApiStr
 create_xtream_player_api_resource!(xtream_player_api_series_resource, XtreamApiStreamContext::Series);
 create_xtream_player_api_resource!(xtream_player_api_movie_resource, XtreamApiStreamContext::Movie);
 
-fn get_non_empty<'a>(first: &'a str, second: &'a str, third: &'a str) -> &'a str {
-    if !first.is_empty() {
-        first
-    } else if !second.is_empty() {
-        second
-    } else {
-        third
-    }
-}
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 struct XtreamApiTimeShiftRequest {
@@ -552,11 +543,11 @@ async fn xtream_player_api_timeshift_stream(
     axum::extract::State(app_state): axum::extract::State<Arc<AppState>>,
     axum::extract::Form(api_form_req): axum::extract::Form<UserApiRequest>,
 ) -> impl IntoResponse + Send {
-    let username = get_non_empty(&timeshift_request.username, &api_query_req.username, &api_form_req.username);
-    let password = get_non_empty(&timeshift_request.password, &api_query_req.password, &api_form_req.password);
-    let stream_id = get_non_empty(&timeshift_request.stream_id, &api_query_req.stream, &api_form_req.stream);
-    let duration = get_non_empty(&timeshift_request.duration, &api_query_req.duration, &api_form_req.duration);
-    let start = get_non_empty(&timeshift_request.start, &api_query_req.start, &api_form_req.start);
+    let username = get_non_empty_str(&timeshift_request.username, &api_query_req.username, &api_form_req.username);
+    let password = get_non_empty_str(&timeshift_request.password, &api_query_req.password, &api_form_req.password);
+    let stream_id = get_non_empty_str(&timeshift_request.stream_id, &api_query_req.stream, &api_form_req.stream);
+    let duration = get_non_empty_str(&timeshift_request.duration, &api_query_req.duration, &api_form_req.duration);
+    let start = get_non_empty_str(&timeshift_request.start, &api_query_req.start, &api_form_req.start);
     let action_path = format!("{duration}/{start}");
     xtream_player_api_stream(&req_headers, &api_query_req, &app_state, XtreamApiStreamRequest::from(XtreamApiStreamContext::Timeshift, username, password, stream_id, &action_path)).await
 }

--- a/src/utils/network/request.rs
+++ b/src/utils/network/request.rs
@@ -403,7 +403,7 @@ pub fn extract_extension_from_url(url: &str) -> Option<&str> {
         if let Some(last_slash_pos) = url[protocol_pos + 3..].rfind('/') {
             let path = &url[protocol_pos + 3 + last_slash_pos + 1..];
             if let Some(last_dot_pos) = path.rfind('.') {
-                return ensure_extension(&path[..last_dot_pos]);
+                return ensure_extension(&path[last_dot_pos..]);
             }
         }
     } else if let Some(last_dot_pos) = url.rfind('.') {

--- a/src/utils/network/request.rs
+++ b/src/utils/network/request.rs
@@ -390,18 +390,25 @@ pub fn sanitize_sensitive_info(query: &str) -> Cow<str> {
     Cow::Owned(result)
 }
 
+#[inline]
+fn ensure_extension(ext: &str) -> Option<&str> {
+    if ext.len() > 4 {
+        return None;
+    }
+    Some(ext)
+}
 
 pub fn extract_extension_from_url(url: &str) -> Option<&str> {
     if let Some(protocol_pos) = url.find("://") {
         if let Some(last_slash_pos) = url[protocol_pos + 3..].rfind('/') {
             let path = &url[protocol_pos + 3 + last_slash_pos + 1..];
             if let Some(last_dot_pos) = path.rfind('.') {
-                return Some(&path[last_dot_pos..]);
+                return ensure_extension(&path[..last_dot_pos]);
             }
         }
     } else if let Some(last_dot_pos) = url.rfind('.') {
         if last_dot_pos > url.rfind('/').unwrap_or(0) {
-            return Some(&url[last_dot_pos..]);
+            return ensure_extension(&url[last_dot_pos..]);
         }
     }
     None
@@ -506,7 +513,7 @@ pub fn get_base_url_from_str(url: &str) -> Option<String> {
 }
 
 pub fn create_client(cfg: &Config) -> reqwest::ClientBuilder {
-    let mut client = reqwest::Client::builder();
+    let mut client = reqwest::Client::builder().redirect(reqwest::redirect::Policy::limited(10));
 
     if let Some(proxy_cfg) = cfg.proxy.as_ref() {
         let proxy = match reqwest::Proxy::all(&proxy_cfg.url) {

--- a/src/utils/string_utils.rs
+++ b/src/utils/string_utils.rs
@@ -57,6 +57,16 @@ pub fn generate_random_string(length: usize) -> String {
     random_string
 }
 
+pub fn get_non_empty_str<'a>(first: &'a str, second: &'a str, third: &'a str) -> &'a str {
+    if !first.is_empty() {
+        first
+    } else if !second.is_empty() {
+        second
+    } else {
+        third
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::collections::HashSet;


### PR DESCRIPTION
Series info can have release_date and releaseDate as fields, which should be handled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved handling of release date fields for series and episodes, ensuring more consistent recognition of differently named or cased fields.
	- Added a utility to select the first non-empty string among multiple options for better data consistency.
- **Bug Fixes**
	- File extension extraction now ignores extensions longer than four characters, improving accuracy.
	- HTTP client now limits redirects to a maximum of 10, enhancing reliability and safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->