### PR TITLE
feat: STRM export – Naming styles & flat layout for improved media center compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ If we assume the variable `station` contains the value `WINK`,
 this script receives the template with the concatenated name `US_WINK_PREFIX` which should be defined in `templates` section,
 and assigns it to the variable `station_prefix`.
 
+# 3.1.4 (???)
+- Extended STRM export functionality with:
+  - Support for various media tools (Kodi, Plex, Emby, Jellyfin), with consideration for recommended naming conventions and file organization.
+  - Optional flat directory structure via 'flat' parameter (nested folder structures are not supported by some media scanners).
+
 # 3.1.3 (2025-06-06)
 - Fixed xtream codes series info duplicate fields problem.
 - Fixed series info container_extension problem.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ designed for processing, filtering, and serving media playlists with minimal res
 ## 🔧 Core Features:
 
 - **Advanced Playlist Processing**: Filter, rename, map, and sort entries with ease.
-- **Flexible Proxy Support**: Acts as a reverse/redirect proxy for EXTM3U, Xtream Codes, HDHomeRun, and STRM (Kodi) formats.
+- **Flexible Proxy Support**: Acts as a reverse/redirect proxy for EXTM3U, Xtream Codes, HDHomeRun, and STRM formats (Kodi, Plex, Emby, Jellyfin) with:
+  - app-specific naming conventions
+  - flat directory structure option (for compatibility reasons of some media scanners)
 - **Multi-Source Handling**: Supports multiple input and output sources. Merge various playlists and generate custom outputs.
 - **Scheduled Updates**: Keep playlists fresh with automatic updates in server mode.
 - **Web Delivery**: Run as a CLI tool to create m3u playlist to serve with web servers like Nginx or Apache.
@@ -786,10 +788,11 @@ Each format has different properties
 `strm`
 - directory: _mandatory_,
 - username: _optional_,
-- underscore_whitespace: _optional_,  true|false, default false
-- cleanup:  _optional_,  true|false, default false
-- kodi_style:  _optional_,  true|false, default false
-- strm_props: _optional_,  list of strings,
+- underscore_whitespace: _optional_, true|false, default false
+- cleanup: _optional_, true|false, default false
+- style: _mandatory_, kodi|plex|emby|jellyfin
+- flat: _optional_, true|false, default false
+- strm_props: _optional_, list of strings,
 
 `hdhomerun`
 - device: _mandatory_,
@@ -831,12 +834,20 @@ Target options are:
 - `share_live_streams` to share live stream connections  in reverse proxy mode.
 - `remove_duplicates` tries to remove duplicates by `url`.
 
-`strm` output has additional options
-- `underscore_whitespace` replaces all whitespaces with `_` in the path.
-- `cleanup` deletes the directory given at `filename`. Don't point at existing media folder or everything will be deleted.
-- `kodi_style` tries to rename `filename` with [kodi style](https://kodi.wiki/view/Naming_video_files/TV_shows).
-- `strm_props` is a list of properties written to the strm file.
-  If `kodi_style` set to `true` the property `#KODIPROP:seekable=true|false` is added. If `strm_props` is not given `#KODIPROP:inputstream=inputstream.ffmpeg`, `"#KODIPROP:http-reconnect=true` are set too for `kody_style`.
+`strm` output has additional options:
+- `underscore_whitespace`: replaces all whitespaces with `_` in the path
+- `cleanup`: deletes the directory given at `filename`. Don't point at existing media folder or everything will be deleted
+- `style`: determines naming convention (kodi, plex, emby, jellyfin)
+- `flat`: creates flat directory structure with category tags in folder names
+- `strm_props`: list of properties written to the strm file
+
+Supported styles:
+- Kodi: `Movie Name (Year) {tmdb=ID}/Movie Name (Year).strm`
+- Plex: `Movie Name (Year) {tmdb-ID}/Movie Name (Year).strm`
+- Emby: `Movie Name (Year) [tmdbid=ID]/Movie Name (Year).strm`
+- Jellyfin: `Movie Name (Year) [tmdbid-ID]/Movie Name (Year).strm`
+
+If style is set to 'kodi', the property `#KODIPROP:seekable=true|false` is added. And if `strm_props` is not given `#KODIPROP:inputstream=inputstream.ffmpeg`, `"#KODIPROP:http-reconnect=true` are set too for style `kodi`.
 
 `m3u` output has additional options
 - `include_type_in_url`, default false, if true adds the stream type `live`, `movie`, `series` to the url of the stream.
@@ -966,8 +977,9 @@ sources:
         options:
           ignore_logo: true
           underscore_whitespace: false
-          kodi_style: true
+          style: kodi
           cleanup: true
+          flat: true
         sort:
           order: asc
         filter: "!PROV1_ALL!"

--- a/frontend/src/model/server-config.ts
+++ b/frontend/src/model/server-config.ts
@@ -8,6 +8,13 @@ export enum SortOrder {
     desc = "desc"
 }
 
+export enum ExportStyle {
+    kodi = "kodi",
+    plex = "plex",
+    emby = "emby",
+    jellyfin = "jellyfin"
+}
+
 export enum TargetType {
     m3u = "m3u",
     xtream = "xtream",
@@ -78,12 +85,15 @@ export interface TargetConfig {
             resolve_vod: boolean,
             resolve_vod_delay: number,
             // strm
+            style: ExportStyle,
+            flat?: boolean,
             cleanup: boolean,
-            kodi_style: boolean,
             directory: string,
             username?: string, // hdhomerun & strm
             underscore_whitespace: boolean,
             strm_props?: string[],
+            /** @deprecated Use style="kodi" instead */
+            kodi_style?: boolean,
             // hdhomerun
             device: String,
             use_output?: TargetType,

--- a/src/model/config_target.rs
+++ b/src/model/config_target.rs
@@ -12,6 +12,19 @@ use std::fmt::Display;
 use std::sync::Arc;
 use arc_swap::{ArcSwapOption};
 
+#[derive(Debug, Copy, Clone, serde::Serialize, serde::Deserialize, Sequence, PartialEq, Eq, Hash, Default)]
+pub enum ExportStyle {
+    #[serde(rename = "kodi")]
+    #[default]
+    Kodi,
+    #[serde(rename = "plex")]
+    Plex,
+    #[serde(rename = "emby")]
+    Emby,
+    #[serde(rename = "jellyfin")]
+    Jellyfin,
+}
+
 #[derive(Debug, Copy, Clone, serde::Serialize, serde::Deserialize, Sequence, PartialEq, Eq, Hash)]
 pub enum TargetType {
     #[serde(rename = "m3u")]
@@ -131,15 +144,16 @@ pub struct StrmTargetOutput {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub username: Option<String>,
     #[serde(default)]
+    pub style: ExportStyle,
+    #[serde(default)]
+    pub flat: bool,
+    #[serde(default)]
     pub underscore_whitespace: bool,
     #[serde(default)]
     pub cleanup: bool,
-    #[serde(default)]
-    pub kodi_style: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub strm_props: Option<Vec<String>>,
 }
-
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct HdHomeRunTargetOutput {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -28,6 +28,7 @@ mod config_log;
 mod config_healthcheck;
 mod config_cache;
 
+// Re-export modules for easier access
 pub use self::config_cache::*;
 pub use self::config::*;
 pub use self::playlist::*;

--- a/src/model/xtream_const.rs
+++ b/src/model/xtream_const.rs
@@ -37,6 +37,7 @@ pub const XC_TAG_VOD_INFO_MOVIE_DATA: &str = "movie_data";
 pub const XC_TAG_VOD_INFO_TMDB_ID: &str = "tmdb_id";
 pub const XC_TAG_VOD_INFO_STREAM_ID: &str = "stream_id";
 pub const XC_TAG_VOD_INFO_ADDED: &str = "added";
+pub const XC_TAG_VOD_INFO_RELEASEDATE: &str = "release_date";
 
 pub const XC_FILE_SERIES_INFO: &str = "xtream_series_info";
 pub const XC_FILE_VOD_INFO: &str = "xtream_vod_info";

--- a/src/processing/processor/playlist.rs
+++ b/src/processing/processor/playlist.rs
@@ -17,7 +17,6 @@ use crate::model::{FetchedPlaylist, FieldGetAccessor, FieldSetAccessor, Playlist
 use crate::model::{InputStats, PlaylistStats, SourceStats, TargetStats};
 use crate::processing::playlist_watch::process_group_watch;
 use crate::processing::processor::xtream_series::playlist_resolve_series;
-use crate::processing::processor::xtream_vod::playlist_resolve_vod;
 use crate::repository::playlist_repository::persist_playlist;
 use crate::tuliprox_error::{get_errors_notify_message, notify_err, TuliproxError, TuliproxErrorKind};
 use crate::utils::debug_if_enabled;
@@ -28,6 +27,7 @@ use std::time::Instant;
 use crate::model::Epg;
 use crate::processing::parser::xmltv::flatten_tvguide;
 use crate::processing::processor::epg::process_playlist_epg;
+use crate::processing::processor::xtream_vod::playlist_resolve_vod;
 use crate::processing::processor::sort::sort_playlist;
 use crate::utils::StepMeasure;
 

--- a/src/repository/playlist_repository.rs
+++ b/src/repository/playlist_repository.rs
@@ -4,7 +4,7 @@ use crate::model::{Config, ConfigTarget, TargetOutput};
 use crate::model::{PlaylistGroup, PlaylistItemType};
 use crate::model::Epg;
 use crate::repository::epg_repository::epg_write;
-use crate::repository::kodi_repository::kodi_write_strm_playlist;
+use crate::repository::kodi_repository::write_strm_playlist;
 use crate::repository::m3u_repository::m3u_write_playlist;
 use crate::repository::storage::{ensure_target_storage_path, get_target_id_mapping_file};
 use crate::repository::target_id_mapping::TargetIdMapping;
@@ -51,7 +51,7 @@ pub async fn persist_playlist(playlist: &mut [PlaylistGroup], epg: Option<&Epg>,
         let result = match output {
             TargetOutput::Xtream(_xtream_output) => xtream_write_playlist(target, cfg, playlist).await,
             TargetOutput::M3u(m3u_output) => m3u_write_playlist(cfg, target, m3u_output, &target_path, playlist).await,
-            TargetOutput::Strm(strm_output) => kodi_write_strm_playlist(target, strm_output, cfg, playlist).await,
+            TargetOutput::Strm(strm_output) => write_strm_playlist(target, strm_output, cfg, playlist).await,
             TargetOutput::HdHomeRun(_hdhomerun_output) => Ok(()),
         };
 

--- a/src/utils/constants.rs
+++ b/src/utils/constants.rs
@@ -60,7 +60,8 @@ pub fn filter_request_header(key: &str) -> bool {
     true
 }
 
-pub struct KodiStyle {
+/// Configuration for media export naming styles (Kodi, Plex, Emby, Jellyfin)
+pub struct ExportStyleConfig {
     pub year: Regex,
     pub season: Regex,
     pub episode: Regex,
@@ -86,7 +87,7 @@ pub struct Constants {
     pub re_whitespace: Regex,
     pub re_hls_uri: Regex,
     pub sanitize: AtomicBool,
-    pub kodi_style: KodiStyle,
+    pub export_style_config: ExportStyleConfig,
     pub country_codes: HashSet<&'static str>,
     pub allowed_output_formats: Vec<String>,
 }
@@ -111,10 +112,10 @@ pub static CONSTANTS: LazyLock<Constants> = LazyLock::new(||
         re_hls_uri: Regex::new(r#"URI="([^"]+)""#).unwrap(),
 
         sanitize: AtomicBool::new(true),
-        kodi_style: KodiStyle {
+        export_style_config: ExportStyleConfig {
             season: Regex::new(r"[Ss]\d{1,2}").unwrap(),
             episode: Regex::new(r"[Ee]\d{1,2}").unwrap(),
-            year: Regex::new(r"\d{4}").unwrap(),
+            year: Regex::new(r"(\d{4})").unwrap(),
             whitespace: Regex::new(r"\s+").unwrap(),
             alphanumeric: Regex::new(r"[^\w\s]").unwrap(),
         },


### PR DESCRIPTION
---

**📝 Pull Request Description**

This PR enhances the STRM export functionality by adding configurable naming styles and an optional flat directory structure. These changes improve compatibility with widely used media library tools and allow tuliprox to integrate more cleanly into diverse setups.

---

### ✅ Key Features

**1. Naming Style Presets**
A new `style` option supports naming conventions aligned with the requirements of popular media libraries. Each style influences both folder and file structure.

* **Kodi**

  * Movie: `/Movie Name (Year) {tmdb=123}/Movie Name (Year).strm`
  * Series: `/Show Name (Year) {tmdb=123}/Season 01/Show Name S01E01.strm`

* **Plex**

  * Movie: `/Movie Name (Year) {tmdb-123}/Movie Name (Year).strm`
  * Series: `/Show Name (Year) {tmdb-123}/Season 01/Show Name - s01e01.strm`

* **Emby**

  * Movie: `/Movie Name (Year)/Movie Name (Year) [tmdbid=123].strm`
  * Series: `/Show Name (Year) [tmdbid=123]/Season 01/Show Name - S01E01.strm`

* **Jellyfin**

  * Movie: `/Movie Name (Year) [tmdbid-123]/Movie Name (Year).strm`
  * Series: `/Show Name (Year) [tmdbid-123]/Season 01/Show Name - S01E01.strm`

**2. Flat Directory Structure**
The new `flat: true` option disables deep nesting. Instead, category information is included in folder names. This is useful for simpler scanners or flat-file setups.

---

### 🚀 Future Enhancements

This feature lays the groundwork for upcoming improvements:

* **Custom Templating**: Allow users to define file and folder formats using placeholder syntax.
* **Metadata-Based Clustering**: Group STRM exports by release year or decade using cached metadata (e.g., `./2010-2020/...`).

---

### 🙏 Request for Review

This change affects the core export logic and adds significant flexibility.
Please test across different configurations (especially with real Plex, Kodi, Jellyfin, etc.) and provide feedback on naming, layout, and edge case handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - STRM export now supports multiple media platforms: Kodi, Plex, Emby, and Jellyfin, each with their own naming conventions.
  - Added an option to export STRM files into a flat directory structure for improved compatibility with certain media scanners.
  - Enhanced VOD metadata handling with support for release date extraction and normalization.

- **Documentation**
  - Updated documentation to clarify STRM export options, naming styles, and configuration examples.

- **Refactor**
  - Modularized and generalized STRM file naming logic to support multiple export styles.
  - Improved filename sanitization and directory structure logic for exports.

- **Bug Fixes**
  - Improved compatibility with media scanners that require flat directory structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->