### PR TITLE
Feature/toastr

### DIFF
--- a/frontend/scss/app/components/_toastr.scss
+++ b/frontend/scss/app/components/_toastr.scss
@@ -1,4 +1,4 @@
-.tp__toastr-container {
+.tp__toastr__container {
   position: fixed;
   top: 1rem;
   right: 1rem;
@@ -10,31 +10,43 @@
 }
 
 .tp__toast {
+  display: flex;
+  flex-flow: row;
+  align-items: center;
   padding: var(--padding-small) var(--padding-default);
   border-radius: 6px;
   font-size: 14px;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
   animation: fadeIn 0.3s ease-out;
+
+  .svg-icon {
+    width: 1.2rem;
+    height: 1.2rem;
+  }
 }
 
 .tp__toast.success {
   background-color: var(--toastr-success-background-color);
-  color: var(--toastr-success-color)
+  color: var(--toastr-success-color);
+  fill: var(--toastr-success-color);
 }
 
 .tp__toast.error {
   background-color: var(--toastr-error-background-color);
-  color: var(--toastr-error-color)
+  color: var(--toastr-error-color);
+  fill: var(--toastr-error-color);
 }
 
 .tp__toast.info {
   background-color: var(--toastr-info-background-color);
-  color: var(--toastr-info-color)
+  color: var(--toastr-info-color);
+  fill: var(--toastr-info-color);
 }
 
 .tp__toast.warning {
   background-color: var(--toastr-warning-background-color);
-  color: var(--toastr-warning-color)
+  color: var(--toastr-warning-color);
+  fill: var(--toastr-warning-color);
 }
 
 @keyframes fadeIn {

--- a/frontend/src/app/components/home.rs
+++ b/frontend/src/app/components/home.rs
@@ -10,6 +10,7 @@ use yew::suspense::use_future;
 use yew_i18n::use_translation;
 use crate::app::components::loading_indicator::{BusyIndicator};
 use crate::provider::DialogProvider;
+use crate::services::{ToastCloseMode, ToastOptions};
 
 #[function_component]
 pub fn Home() -> Html {
@@ -41,7 +42,8 @@ pub fn Home() -> Html {
                         services_ctx_clone.toastr.error(msg);
                     },
                     EventMessage::ConfigChange(config_type) => {
-                        services_ctx_clone.toastr.warning(format!("{}: {config_type}", translate_clone.t("MESSAGES.CONFIG_CHANGED")));
+                        services_ctx_clone.toastr.warning_with_options(format!("{}: {config_type}", translate_clone.t("MESSAGES.CONFIG_CHANGED")),
+                                                                       ToastOptions { close_mode: ToastCloseMode::Manual });
                     },
                     EventMessage::PlaylistUpdate(update_state) => {
                         match update_state {

--- a/frontend/src/app/components/toastr.rs
+++ b/frontend/src/app/components/toastr.rs
@@ -1,14 +1,16 @@
-use log::info;
 use crate::hooks::use_service_context;
-use crate::services::{Toast, ToastType};
+use crate::services::{Toast, ToastCloseMode, ToastType};
 use yew::prelude::*;
 use yew_hooks::use_mount;
+use crate::app::components::IconButton;
 
 #[function_component]
 pub fn ToastrView() -> Html {
     let service_ctx = use_service_context();
     let toasts = use_state(Vec::<Toast>::new);
+
     {
+        // Subscribe to toast updates when component mounts
         let service_ctx = service_ctx.clone();
         let toasts = toasts.clone();
         use_mount(move || service_ctx.toastr.subscribe(move |new_toasts| {
@@ -19,25 +21,53 @@ pub fn ToastrView() -> Html {
     if toasts.is_empty() {
         html! {}
     } else {
-        info!("view toassts {}", toasts.len());
         html! {
-            <div class="tp__toastr-container">
-               { for toasts.iter().map(render_toast) }
+            <div class="tp__toastr__container">
+                {
+                    // Render each toast and show an "X" icon button when close mode is Manual
+                    for toasts.iter().cloned().map({
+                        let service_ctx = service_ctx.clone();
+                        move |toast| {
+                            // Decide visual style per toast type
+                            let type_class = match toast.toast_type {
+                                ToastType::Success => "success",
+                                ToastType::Info => "info",
+                                ToastType::Warning => "warning",
+                                ToastType::Error => "error",
+                            };
+
+                            // Create close button only for Manual close mode
+                            let close_btn = if matches!(toast.close_mode, ToastCloseMode::Manual) {
+                                let on_close = {
+                                    let service_ctx = service_ctx.clone();
+                                    let id = toast.id;
+                                    // IconButton emits (name, MouseEvent); we only need to know it was clicked
+                                    Callback::from(move |(_name, _e)| {
+                                        service_ctx.toastr.dismiss(id);
+                                    })
+                                };
+
+                                html! {
+                                    <IconButton
+                                        name={"toastr-close"}
+                                        icon={"Close"}
+                                        onclick={on_close}
+                                    />
+                                }
+                            } else {
+                                html! {}
+                            };
+
+                            html! {
+                                <div key={toast.id} class={classes!("tp__toast", type_class)}>
+                                    <span class="tp__toast__message">{ toast.message.clone() }</span>
+                                    { close_btn }
+                                </div>
+                            }
+                        }
+                    })
+                }
             </div>
         }
-    }
-}
-
-fn render_toast(toast: &Toast) -> Html {
-    let class = match toast.toast_type {
-        ToastType::Success => "tp__toast success",
-        ToastType::Error => "tp__toast error",
-        ToastType::Info => "tp__toast info",
-        ToastType::Warning => "tp__toast warning",
-    };
-    html! {
-        <div key={toast.id} class={classes!(class)}>
-            { &toast.message }
-        </div>
     }
 }

--- a/frontend/src/hooks/use_server_status.rs
+++ b/frontend/src/hooks/use_server_status.rs
@@ -50,12 +50,8 @@ pub fn use_server_status(
                             }
                         };
                         if let Some(treemap) = server_status.active_provider_connections.as_mut() {
-                            if connections == 0 {
-                                treemap.remove(&provider);
-                            } else {
-                                treemap.insert(provider, connections);
-                            }
-                        } else if connections > 0 {
+                            treemap.insert(provider, connections);
+                        } else {
                             let mut treemap = BTreeMap::new();
                             treemap.insert(provider, connections);
                             server_status.active_provider_connections = Some(treemap);

--- a/frontend/src/services/toastr_service.rs
+++ b/frontend/src/services/toastr_service.rs
@@ -1,5 +1,5 @@
 use gloo_timers::callback::Timeout;
-use std::cell::{RefCell};
+use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -12,11 +12,31 @@ pub enum ToastType {
     Warning,
 }
 
-#[derive(Default, Clone, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ToastCloseMode {
+    Auto(u32),
+    Manual,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct ToastOptions {
+    pub close_mode: ToastCloseMode,
+}
+
+impl Default for ToastOptions {
+    fn default() -> Self {
+        Self {
+            close_mode: ToastCloseMode::Auto(3500),
+        }
+    }
+}
+
+#[derive(Clone, PartialEq)]
 pub struct Toast {
     pub id: u32,
     pub message: String,
     pub toast_type: ToastType,
+    pub close_mode: ToastCloseMode,
 }
 
 #[derive(Default, Clone)]
@@ -39,6 +59,7 @@ impl ToastrState {
 }
 
 type ToastrSubscriber = Rc<RefCell<Option<Box<dyn Fn(Vec<Toast>)>>>>;
+
 pub struct ToastrService {
     pub counter: AtomicU32,
     pub state: Rc<RefCell<ToastrState>>,
@@ -64,42 +85,106 @@ impl ToastrService {
         self.subscriber.borrow_mut().replace(Box::new(callback));
     }
 
-    fn show(&self, msg: impl Into<String>, toast_type: ToastType, duration_ms: u32) {
+    pub fn show_with_options(
+        &self,
+        msg: impl Into<String>,
+        toast_type: ToastType,
+        options: ToastOptions,
+    ) {
         let mut state = self.state.borrow_mut();
         let toast = Toast {
             id: self.counter.fetch_add(1, Ordering::Acquire),
             message: msg.into(),
             toast_type: toast_type.clone(),
+            close_mode: options.close_mode,
         };
         let toast_id = toast.id;
         state.add_toast(toast);
+
         if let Some(subscriber) = self.subscriber.borrow().as_ref() {
             subscriber(state.toasts.clone());
         }
-        let state_ref = self.state.clone();
-        let subscriber_ref = self.subscriber.clone();
-        Timeout::new(duration_ms, move || {
-            let mut state = state_ref.borrow_mut();
-            state.remove_toast(toast_id);
-            if let Some(subscriber) = subscriber_ref.borrow().as_ref() {
-                subscriber(state.toasts.clone());
-            }
-        }).forget();
+        drop(state);
+
+        if let ToastCloseMode::Auto(duration_ms) = options.close_mode {
+            let state_ref = self.state.clone();
+            let subscriber_ref = self.subscriber.clone();
+            Timeout::new(duration_ms, move || {
+                let mut state = state_ref.borrow_mut();
+                state.remove_toast(toast_id);
+                if let Some(subscriber) = subscriber_ref.borrow().as_ref() {
+                    subscriber(state.toasts.clone());
+                }
+            })
+            .forget();
+        }
     }
 
     pub fn success(&self, msg: impl Into<String>) {
-        self.show(msg, ToastType::Success, 3000);
+        self.show_with_options(
+            msg,
+            ToastType::Success,
+            ToastOptions {
+                close_mode: ToastCloseMode::Auto(3000),
+            },
+        );
     }
 
     pub fn error(&self, msg: impl Into<String>) {
-        self.show(msg, ToastType::Error, 4000);
+        self.show_with_options(
+            msg,
+            ToastType::Error,
+            ToastOptions {
+                close_mode: ToastCloseMode::Auto(4000),
+            },
+        );
     }
 
     pub fn info(&self, msg: impl Into<String>) {
-        self.show(msg, ToastType::Info, 3500);
+        self.show_with_options(
+            msg,
+            ToastType::Info,
+            ToastOptions {
+                close_mode: ToastCloseMode::Auto(3500),
+            },
+        );
     }
 
     pub fn warning(&self, msg: impl Into<String>) {
-        self.show(msg, ToastType::Warning, 3500);
+        self.show_with_options(
+            msg,
+            ToastType::Warning,
+            ToastOptions {
+                close_mode: ToastCloseMode::Auto(3500),
+            },
+        );
+    }
+
+    // Show a Success toast with custom options
+    pub fn success_with_options(&self, msg: impl Into<String>, options: ToastOptions) {
+        self.show_with_options(msg, ToastType::Success, options);
+    }
+
+    // Show an Error toast with custom options
+    pub fn error_with_options(&self, msg: impl Into<String>, options: ToastOptions) {
+        self.show_with_options(msg, ToastType::Error, options);
+    }
+
+    // Show an Info toast with custom options
+    pub fn info_with_options(&self, msg: impl Into<String>, options: ToastOptions) {
+        self.show_with_options(msg, ToastType::Info, options);
+    }
+
+    pub fn warning_with_options(&self, msg: impl Into<String>, options: ToastOptions) {
+        self.show_with_options(msg, ToastType::Warning, options);
+    }
+
+    // manual close
+    pub fn dismiss(&self, id: u32) {
+        let mut state = self.state.borrow_mut();
+        state.remove_toast(id);
+        if let Some(subscriber) = self.subscriber.borrow().as_ref() {
+            subscriber(state.toasts.clone());
+        }
     }
 }


### PR DESCRIPTION
Added tostr manual close option

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Toast notifications now support both automatic and manual close modes, allowing certain messages to remain visible until dismissed by the user.
  * Added customizable auto-close durations for toast notifications.
  * Introduced a close button for manually dismissible toasts.

* **Improvements**
  * Enhanced visual alignment and icon sizing in toast notifications for a more polished appearance.
  * Updated color and fill styling for better consistency across toast variants.

* **Behavior Changes**
  * Some notifications, such as configuration change warnings, now require manual dismissal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->