### PR TITLE
Staged input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added `replace` built-in function for mapper scripts 
 - New WebUI features
 - Added `token_ttl_mins` to web_auth config to define auth token expiration duration.
+- Staged sources. Side loading playlist. Load from staged, serve from provider. 
 
 # 3.1.4 (2025-06-17)
 - share live stream refactored

--- a/README.md
+++ b/README.md
@@ -563,6 +563,22 @@ Each input has the following attributes:
   + `xtream_live_stream_without_extension` default false, if set to true `.ts` extension is not added to the stream link.
   + `xtream_live_stream_use_prefix` default true, if set to true `/live/` prefix is added to the stream link.
 - `aliases`  for alias definitions for the same provider with different credentials
+- `staged` for side loading processed playlists. 
+Instead of fully configuring everything yourself, you can “stage” a source — meaning you provide a ready-made playlist
+from somewhere else. The system will only use that staged playlist when updating.
+For actual streaming and fetching details, it will still use the main provider’s settings.
+In plain words: If you don’t want to deal with Tuliprox mapping, or you already have a playlist in another online tool,
+you can plug that playlist in as a staged input. It won’t replace the main provider — it’s just there to update the list.
+All streaming and proxying and info still come from the original provider configuration.
+
+`staged` has the following properties:
+- `type` is optional, default is `m3u`. Valid values are `m3u` and `xtream`
+- `url` for type `m3u` is the download url or a local filename (can be gzip) of the input-source. For type `xtream`it is `http://<hostname>:<port>`
+- `headers` is optional
+- `method` can be `GET` or `POST`
+- `username` only mandatory for type `xtream`
+- `pasword`only mandatory for type `xtream`
+
 
 `persist` should be different for `m3u` and `xtream` types. For `m3u` use full filename like `./playlist_{}.m3u`.
 For `xtream` use a prefix like `./playlist_`

--- a/backend/src/api/endpoints/hls_api.rs
+++ b/backend/src/api/endpoints/hls_api.rs
@@ -7,7 +7,7 @@ use crate::api::model::AppState;
 use crate::api::model::UserSession;
 use crate::api::model::{create_custom_video_stream_response, CustomVideoStreamType};
 use crate::auth::Fingerprint;
-use crate::model::ConfigInput;
+use crate::model::{ConfigInput, InputSource};
 use crate::model::ProxyUserCredentials;
 use crate::processing::parser::hls::{
     get_hls_session_token_and_url_from_token, rewrite_hls, RewriteHlsProps,
@@ -91,10 +91,10 @@ pub(in crate::api) async fn handle_hls_stream_request(
         }
     };
 
+    let input_source = InputSource::from(input).with_url(request_url);
     match request::download_text_content(
         Arc::clone(&app_state.http_client.load()),
-        input,
-        &request_url,
+        &input_source,
         None,
     )
     .await

--- a/backend/src/api/endpoints/v1_api.rs
+++ b/backend/src/api/endpoints/v1_api.rs
@@ -4,7 +4,7 @@ use crate::api::endpoints::user_api::user_api_register;
 use crate::api::model::AppState;
 use crate::auth::create_access_token;
 use crate::auth::validator_admin;
-use crate::model::{TargetUser};
+use crate::model::{InputSource, TargetUser};
 use crate::model::{ConfigInput, ConfigInputOptions};
 use crate::processing::processor::playlist;
 use crate::repository::user_repository::store_api_user;
@@ -272,7 +272,8 @@ async fn config_batch_content(
     if let Some(config_input) = app_state.app_config.get_input_by_id(input_id) {
         // The url is changed at this point, we need the raw url for the batch file
          if let Some(batch_url) = config_input.t_batch_url.as_ref() {
-            return match download_text_content(Arc::clone(&app_state.http_client.load()), &config_input, batch_url, None).await {
+            let input_source = InputSource::from(&*config_input).with_url(batch_url.to_owned());
+            return match download_text_content(Arc::clone(&app_state.http_client.load()), &input_source, None).await {
                 Ok((content, _path)) => {
                     // Return CSV with explicit content-type
                     try_unwrap_body!(axum::response::Response::builder()

--- a/backend/src/api/endpoints/xtream_api.rs
+++ b/backend/src/api/endpoints/xtream_api.rs
@@ -15,7 +15,7 @@ use crate::api::model::UserApiRequest;
 use crate::api::model::XtreamAuthorizationResponse;
 use crate::api::model::{create_custom_video_stream_response, CustomVideoStreamType};
 use crate::auth::Fingerprint;
-use crate::model::ProxyUserCredentials;
+use crate::model::{InputSource, ProxyUserCredentials};
 use crate::model::{AppConfig, ConfigTarget};
 use crate::model::{Config, ConfigInput};
 use crate::repository::playlist_repository::get_target_id_mapping;
@@ -1078,10 +1078,10 @@ async fn xtream_get_short_epg(
                         }
 
                         // TODO serve epg from own db
+                        let input_source = InputSource::from(&*input).with_url(info_url);
                         return match request::download_text_content(
                             Arc::clone(&app_state.http_client.load()),
-                            &input,
-                            info_url.as_str(),
+                            &input_source,
                             None,
                         )
                         .await
@@ -1228,11 +1228,11 @@ async fn xtream_get_catchup_response(
         crate::model::XC_TAG_STREAM_ID,
         pli.provider_id
     )));
+    let input_source = InputSource::from(&*input).with_url(info_url);
     let content = try_result_bad_request!(
         xtream::get_xtream_stream_info_content(
             Arc::clone(&app_state.http_client.load()),
-            info_url.as_str(),
-            &input
+            &input_source
         )
         .await
     );

--- a/backend/src/model/input_source.rs
+++ b/backend/src/model/input_source.rs
@@ -1,0 +1,43 @@
+use std::collections::HashMap;
+use shared::model::InputFetchMethod;
+use crate::model::{ConfigInput, StagedInput};
+
+#[derive(Clone, Debug)]
+pub struct InputSource {
+    pub url: String,
+    pub username: Option<String>,
+    pub password: Option<String>,
+    pub method: InputFetchMethod,
+    pub headers: HashMap<String, String>,
+}
+
+impl InputSource {
+    pub fn with_url(&self, url: String) -> Self {
+        Self {
+            url,
+            username: self.username.clone(),
+            password: self.password.clone(),
+            method: self.method,
+            headers: self.headers.clone(),
+        }
+    }
+}
+
+macro_rules! impl_input_source_from {
+    ($input_type:ty) => {
+        impl From<&$input_type> for InputSource {
+            fn from(input: &$input_type) -> Self {
+                Self {
+                    url: input.url.clone(),
+                    username: input.username.clone(),
+                    password: input.password.clone(),
+                    method: input.method,
+                    headers: input.headers.clone(),
+                }
+            }
+        }
+    };
+}
+
+impl_input_source_from!(ConfigInput);
+impl_input_source_from!(StagedInput);

--- a/backend/src/model/mod.rs
+++ b/backend/src/model/mod.rs
@@ -6,6 +6,7 @@ mod xtream;
 mod healthcheck;
 mod playlist_categories;
 mod config;
+mod input_source;
 
 pub use self::playlist::*;
 pub use self::mapping::*;
@@ -16,3 +17,4 @@ pub use self::healthcheck::*;
 pub use self::playlist_categories::*;
 pub use shared::model::xtream_const::*;
 pub use self::config::*;
+pub use self::input_source::*;

--- a/backend/src/processing/processor/playlist.rs
+++ b/backend/src/processing/processor/playlist.rs
@@ -234,6 +234,15 @@ fn is_target_enabled(target: &ConfigTarget, user_targets: &ProcessTargets) -> bo
     (!user_targets.enabled && target.enabled) || (user_targets.enabled && user_targets.has_target(target.id))
 }
 
+async fn playlist_download_from_input(client: &Arc<reqwest::Client>, config: &Arc<Config>, input: &ConfigInput) -> (Vec<PlaylistGroup>, Vec<TuliproxError>) {
+    let working_dir = &config.working_dir;
+    match input.input_type {
+        InputType::M3u => m3u::get_m3u_playlist(Arc::clone(client), config, input, working_dir).await,
+        InputType::Xtream => xtream::get_xtream_playlist(config, Arc::clone(client), input, working_dir).await,
+        InputType::M3uBatch | InputType::XtreamBatch => (vec![], vec![])
+    }
+}
+
 async fn process_source(client: Arc<reqwest::Client>, cfg: Arc<AppConfig>, source_idx: usize,
                         user_targets: Arc<ProcessTargets>, event_manager: Option<Arc<EventManager>>)
                         -> (Vec<InputStats>, Vec<TargetStats>, Vec<TuliproxError>) {
@@ -249,14 +258,9 @@ async fn process_source(client: Arc<reqwest::Client>, cfg: Arc<AppConfig>, sourc
             if is_input_enabled(input, &user_targets) {
                 let config = cfg.config.load();
                 let working_dir = &config.working_dir;
-
                 source_downloaded = true;
                 let start_time = Instant::now();
-                let (mut playlistgroups, mut error_list) = match input.input_type {
-                    InputType::M3u => m3u::get_m3u_playlist(Arc::clone(&client), &config, input, working_dir).await,
-                    InputType::Xtream => xtream::get_xtream_playlist(&config, Arc::clone(&client), input, working_dir).await,
-                    InputType::M3uBatch | InputType::XtreamBatch => (vec![], vec![])
-                };
+                let (mut playlistgroups, mut error_list) = playlist_download_from_input(&client, &config, input).await;
                 let (tvguide, mut tvguide_errors) = if error_list.is_empty() {
                     epg::get_xmltv(Arc::clone(&client), input, working_dir).await
                 } else {
@@ -600,8 +604,8 @@ pub async fn exec_processing(client: Arc<reqwest::Client>, app_config: Arc<AppCo
     info!("🌷 Update process finished! Took {elapsed} secs.");
 }
 
-#[cfg(test)]
-mod tests {
+// #[cfg(test)]
+// mod tests {
     // #[test]
     // fn test_jaro_winkeler() {
     //     let data = [("yessport5", "heyessport5gold"), ("yessport5", "heyesport5gold")];
@@ -615,4 +619,4 @@ mod tests {
     //     // println!("sorensen dice {:?}", strsim::sorensen_dice(data.0, data.1));
     // }
 
-}
+// }

--- a/backend/src/processing/processor/xtream.rs
+++ b/backend/src/processing/processor/xtream.rs
@@ -1,6 +1,6 @@
 use shared::error::{info_err, notify_err};
 use shared::error::{str_to_io_error, TuliproxError, TuliproxErrorKind};
-use crate::model::{AppConfig, Config, ConfigInput};
+use crate::model::{AppConfig, Config, ConfigInput, InputSource};
 use crate::model::{FetchedPlaylist};
 use shared::model::{PlaylistEntry, PlaylistItem, PlaylistItemType, XtreamCluster};
 use crate::model::normalize_release_date;
@@ -21,7 +21,8 @@ pub(in crate::processing) async fn playlist_resolve_download_playlist_item(clien
     let mut result = None;
     let provider_id = pli.get_provider_id()?;
     if let Some(info_url) = xtream::get_xtream_player_api_info_url(input, cluster, provider_id) {
-        result = match xtream::get_xtream_stream_info_content(client, &info_url, input).await {
+        let input_source = InputSource::from(input).with_url(info_url);
+        result = match xtream::get_xtream_stream_info_content(client, &input_source).await {
             Ok(content) => Some(content),
             Err(err) => {
                 errors.push(info_err!(format!("{err}")));

--- a/backend/src/utils/network/m3u.rs
+++ b/backend/src/utils/network/m3u.rs
@@ -1,15 +1,20 @@
 use std::sync::Arc;
 use shared::error::TuliproxError;
 use shared::model::PlaylistGroup;
-use crate::model::{Config, ConfigInput};
+use crate::model::{Config, ConfigInput, InputSource};
 use crate::processing::parser::m3u;
 use crate::utils::prepare_file_path;
 use crate::utils::request;
 
 pub async fn get_m3u_playlist(client: Arc<reqwest::Client>, cfg: &Config, input: &ConfigInput, working_dir: &str) -> (Vec<PlaylistGroup>, Vec<TuliproxError>) {
-    let url = input.url.clone();
+    let input_source: InputSource = {
+        match input.staged.as_ref() {
+            None => input.into(),
+            Some(staged) => staged.into(),
+        }
+    };
     let persist_file_path = prepare_file_path(input.persist.as_deref(), working_dir, "");
-    match request::get_input_text_content(client, input, working_dir, &url, persist_file_path).await {
+    match request::get_input_text_content(client, &input_source, working_dir, persist_file_path).await {
         Ok(text) => {
             (m3u::parse_m3u(cfg, input, text.lines()), vec![])
         }

--- a/frontend/public/assets/i18n/en.json
+++ b/frontend/public/assets/i18n/en.json
@@ -233,7 +233,8 @@
     "STATUS":  "Status",
     "UI_ENABLED":  "Ui",
     "COMMENT": "Comment",
-    "PLAYLIST": "Playlist"
+    "PLAYLIST": "Playlist",
+    "STAGED": "Staged"
   },
   "TITLE": {
     "USER_BOUQUET_EDITOR": "User group editor"

--- a/frontend/scss/app/_component.scss
+++ b/frontend/scss/app/_component.scss
@@ -39,6 +39,7 @@
 @forward "components/playlist/input/input_table";
 @forward "components/playlist/input/input_type";
 @forward "components/playlist/input/batch_input_content_view";
+@forward "components/playlist/input/staged_input_view";
 @forward "components/playlist/playlist_mappings";
 @forward "components/playlist/playlist_processing";
 @forward "components/playlist/source_selector";

--- a/frontend/scss/app/components/_custom_dialog.scss
+++ b/frontend/scss/app/components/_custom_dialog.scss
@@ -6,15 +6,15 @@
   right: 0;
   bottom: 0;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
-  background-color: rgba(0, 0, 0, 0.3);
+  background-color: rgba(0, 0, 0, 0.5);
   z-index: 1000;
   animation: fadeIn 0.2s ease-out;
 }
 
 .tp__custom-dialog-modal {
-  /* Additional styles for modal dialogs */
+  padding-top: clamp(0vh, 15vh, 30vh);
 }
 
 .tp__custom-dialog {

--- a/frontend/scss/app/components/_table.scss
+++ b/frontend/scss/app/components/_table.scss
@@ -2,7 +2,6 @@
   display: flex;
   flex-flow: column;
   gap: var(--gap-default);
-  padding: var(--padding-default) 0;
   background-color: var(--card-background-color);
   border-radius: var(--border-radius);
   border: 1px solid var(--border-color);

--- a/frontend/scss/app/components/playlist/input/_staged_input_view.scss
+++ b/frontend/scss/app/components/playlist/input/_staged_input_view.scss
@@ -1,0 +1,29 @@
+.tp__staged-input-view {
+  display: flex;
+  flex-flow: column;
+  box-sizing: border-box;
+  overflow: auto;
+  gap: var(--gap-small);
+
+  &__row {
+    display: flex;
+    flex-flow: row;
+    gap: var(--gap-small);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    padding: var(--padding-micro) var(--padding-mini);
+    background-color: var(--table-card-background-color);
+    overflow: hidden;
+
+    label {
+      font-weight: bold;
+      white-space: nowrap;
+      vertical-align: middle;
+      color: var(--modest-text-color);
+
+      &:after {
+        content: ":";
+      }
+    }
+  }
+}

--- a/frontend/src/app/components/playlist/input/input_headers.rs
+++ b/frontend/src/app/components/playlist/input/input_headers.rs
@@ -1,21 +1,20 @@
-use shared::model::{ConfigInputDto};
-use std::rc::Rc;
+use std::collections::HashMap;
 use yew::prelude::*;
 
 #[derive(Properties, Clone, PartialEq, Debug)]
 pub struct InputHeadersProps {
-    pub input: Rc<ConfigInputDto>,
+    pub headers: HashMap<String, String>,
 }
 
 #[function_component]
 pub fn InputHeaders(props: &InputHeadersProps) -> Html {
-    if props.input.headers.is_empty() {
+    if props.headers.is_empty() {
         html! {}
     } else {
        html! {
             <div class="tp__input-headers">
                 <ul>
-                    { props.input.headers.iter().map(|(key, value)| html! { <li>{ key } {":"} {value}</li> }).collect::<Html>() }
+                    { props.headers.iter().map(|(key, value)| html! { <li>{ key } {":"} {value}</li> }).collect::<Html>() }
                 </ul>
             </div>
         }

--- a/frontend/src/app/components/playlist/input/mod.rs
+++ b/frontend/src/app/components/playlist/input/mod.rs
@@ -2,8 +2,10 @@ mod input_options;
 mod input_headers;
 mod input_type_view;
 mod batch_input_content_view;
+mod staged_input_view;
 
 pub use self::input_options::*;
 pub use self::input_headers::*;
 pub use self::input_type_view::*;
 pub use self::batch_input_content_view::*;
+pub use self::staged_input_view::*;

--- a/frontend/src/app/components/playlist/input/staged_input_view.rs
+++ b/frontend/src/app/components/playlist/input/staged_input_view.rs
@@ -1,0 +1,49 @@
+use crate::app::components::{Chip, HideContent, InputHeaders};
+use shared::model::{InputType, StagedInputDto};
+use yew::prelude::*;
+use yew_i18n::{use_translation};
+use crate::html_if;
+
+#[derive(Properties, Clone, PartialEq, Debug)]
+pub struct StagedInputViewProps {
+    pub input: Option<StagedInputDto>,
+}
+
+#[function_component]
+pub fn StagedInputView(props: &StagedInputViewProps) -> Html {
+    let translate = use_translation();
+
+    match props.input.as_ref() {
+        Some(input) => {
+            let label = match input.input_type {
+                InputType::M3u => "LABEL.M3U",
+                InputType::Xtream => "LABEL.XTREAM",
+                InputType::M3uBatch => "LABEL.M3U_BATCH",
+                InputType::XtreamBatch => "LABEL.XTREAM_BATCH",
+            };
+            html! {
+                <div class="tp__staged-input-view">
+                    <Chip label={translate.t(label)} class={input.input_type.to_string()} />
+                    <div class="tp__staged-input-view__row">
+                        <label>{translate.t("LABEL.URL")}</label>
+                        { &input.url }
+                    </div>
+                    {
+                        html_if!(input.username.is_some() || input.password.is_some(), {
+                        <div class="tp__staged-input-view__row">
+                            <label>{translate.t("LABEL.USERNAME")}</label>
+                            { input.username.as_ref().map_or_else(String::new, |username| username.clone()) }
+                        </div>
+                        })
+                    }
+                    <div class="tp__staged-input-view__row">
+                        <label>{translate.t("LABEL.PASSWORD")}</label>
+                        <HideContent content={input.password.as_ref().map_or_else(String::new, |password| password.clone())}></HideContent>
+                    </div>
+                    <InputHeaders headers={input.headers.clone()} />
+                </div>
+            }
+        },
+        None => html! {}
+    }
+}

--- a/frontend/src/app/components/playlist/input_table.rs
+++ b/frontend/src/app/components/playlist/input_table.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 use crate::app::components::popup_menu::PopupMenu;
-use crate::app::components::{convert_bool_to_chip_style, AppIcon, BatchInputContentView, Chip, HideContent, InputHeaders, InputOptions, InputTypeView, RevealContent, Table, TableDefinition};
+use crate::app::components::{convert_bool_to_chip_style, AppIcon, BatchInputContentView, Chip, HideContent, InputHeaders, InputOptions, InputTypeView, RevealContent, StagedInputView, Table, TableDefinition};
 use std::rc::Rc;
 use std::str::FromStr;
 use yew::platform::spawn_local;
@@ -9,10 +9,11 @@ use yew_i18n::use_translation;
 use shared::error::{create_tuliprox_error_result, TuliproxError, TuliproxErrorKind};
 use shared::model::{ConfigInputAliasDto, ConfigInputDto, SortOrder};
 use crate::app::components::menu_item::MenuItem;
+use crate::html_if;
 use crate::model::DialogResult;
 use crate::services::{DialogService};
 
-const HEADERS: [&str; 14] = [
+const HEADERS: [&str; 15] = [
 "TABLE.EMPTY",
 "TABLE.ENABLED",
 "TABLE.NAME",
@@ -27,6 +28,7 @@ const HEADERS: [&str; 14] = [
 "TABLE.METHOD",
 "TABLE.EPG",
 "TABLE.HEADERS",
+"TABLE.STAGED",
 ];
 
 #[derive(Clone, PartialEq)]
@@ -115,8 +117,12 @@ pub fn InputTable(props: &InputTableProps) -> Html {
                             9 => html! { dto.priority.to_string() },
                             10 => html! { dto.max_connections.to_string() },
                             11 => html! { dto.method.to_string() },
-                            12 => html! {  },
-                            13 => html! { <InputHeaders input={dto.clone()} /> },
+                            12 => html! { /* TODO */ },
+                            13 => html! { <InputHeaders headers={dto.headers.clone()} /> },
+                            14 => html_if!(dto.staged.is_some(),
+                                 { <RevealContent preview={ html!{ dto.staged.as_ref().map_or_else(String::new, |s| s.url.clone())} }>
+                                      <StagedInputView input={ dto.staged.clone() } />
+                                   </RevealContent> }),
                             _ => html! {""},
                         }
                     },

--- a/shared/src/model/config/macros.rs
+++ b/shared/src/model/config/macros.rs
@@ -13,11 +13,9 @@ macro_rules! check_input_credentials {
                 if $this.username.is_some() || $this.password.is_some() {
                     return Err(info_err!("Input types of m3u should not use username or password".to_owned()));
                 }
-                if $this.username.is_none() && $this.password.is_none() {
-                    let (username, password) = $crate::utils::get_credentials_from_url_str(&$this.url);
-                    $this.username = username;
-                    $this.password = password;
-                }
+                let (username, password) = $crate::utils::get_credentials_from_url_str(&$this.url);
+                $this.username = username;
+                $this.password = password;
             }
             InputType::M3uBatch => {
                 if $definition {

--- a/shared/src/model/config/macros.rs
+++ b/shared/src/model/config/macros.rs
@@ -1,13 +1,20 @@
 #[macro_export]
 macro_rules! check_input_credentials {
     ($this:ident, $input_type:expr, $definition:expr ) => {
+        $this.url = $this.url.trim().to_string();
+        if $this.url.is_empty() {
+            return Err(info_err!("url for input is mandatory".to_string()));
+        }
+     $this.username = $crate::utils::get_trimmed_string(&$this.username);
+     $this.password = $crate::utils::get_trimmed_string(&$this.password);
+
      match $input_type {
             InputType::M3u => {
                 if $this.username.is_some() || $this.password.is_some() {
                     return Err(info_err!("Input types of m3u should not use username or password".to_owned()));
                 }
                 if $this.username.is_none() && $this.password.is_none() {
-                    let (username, password) = get_credentials_from_url_str(&$this.url);
+                    let (username, password) = $crate::utils::get_credentials_from_url_str(&$this.url);
                     $this.username = username;
                     $this.password = password;
                 }
@@ -20,12 +27,6 @@ macro_rules! check_input_credentials {
                 }
                 if $this.username.is_some() || $this.password.is_some() {
                     return Err(info_err!("Input types of m3u-batch should not define username or password".to_owned()));
-                }
-                if $this.max_connections > 0 {
-                    return Err(info_err!("input type m3u-batch should not define max_connections attribute ".to_owned()));
-                }
-                if $this.priority != 0 {
-                    return Err(info_err!("input type m3u-batch should not define priority attribute ".to_owned()));
                 }
             }
             InputType::Xtream => {
@@ -42,6 +43,27 @@ macro_rules! check_input_credentials {
                 if $this.username.is_some() || $this.password.is_some() {
                     return Err(info_err!("input type xtream-batch should not define username or password attribute ".to_owned()));
                 }
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! check_input_connections {
+    ($this:ident, $input_type:expr) => {
+
+     match $input_type {
+            InputType::M3u |InputType::Xtream  => {
+            }
+            InputType::M3uBatch => {
+                if $this.max_connections > 0 {
+                    return Err(info_err!("input type m3u-batch should not define max_connections attribute ".to_owned()));
+                }
+                if $this.priority != 0 {
+                    return Err(info_err!("input type m3u-batch should not define priority attribute ".to_owned()));
+                }
+            }
+            InputType::XtreamBatch => {
                 if $this.max_connections > 0 {
                     return Err(info_err!("input type xtream-batch should not define max_connections attribute ".to_owned()));
                 }
@@ -54,3 +76,4 @@ macro_rules! check_input_credentials {
 }
 
 pub use check_input_credentials;
+pub use check_input_connections;


### PR DESCRIPTION
Instead of fully configuring everything yourself, you can “stage” a source — meaning you provide a ready-made playlist
from somewhere else. The system will only use that staged playlist when updating.
For actual streaming and fetching details, it will still use the main provider’s settings.
In plain words: If you don’t want to deal with Tuliprox mapping, or you already have a playlist in another online tool,
you can plug that playlist in as a staged input. It won’t replace the main provider — it’s just there to update the list.
All streaming and proxying and info still come from the original provider configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Staged input support to side-load per-provider playlists without altering main provider settings; playlist table shows a new “Staged” column with expandable details and header key-values.
  - Added “Staged” label to UI translations and a staged input view component.

- Style
  - Dialogs align to top with darker backdrop and responsive top padding.
  - Removed table wrapper padding; added styles for staged input view.

- Documentation
  - README and CHANGELOG updated with staged input usage, types, and properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->