### PR TITLE
feat: add retry up to 3 times for resource proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 # 3.1.7 (2025-09-xx)
 - Added Dark / Bright theme switch
+- Resource proxy retries failed requests up to three times and honors `Retry-After` header or wait 100ms to prevent HTTP 4XX status codes on client side
 
 # 3.1.6 (2025-09-01)
 - EPG Config View added


### PR DESCRIPTION
After noticing many temporary 4XX HTTP status codes when retrieving covers, we should try repeating the request as currently implemented and only then return the last status code in the event of a failed request. 