### PR TITLE
make shared burst buffer size configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Multi Strm outputs with same type is now allowed. 
 - Added new mapper function `pad(text | number, number, char, optional position: "<" | ">" | "^")`
 - Added new mapper function `format` for simple in-text replacement like `format("Hello {}! Hello {}!", "Bob", "World")`
+- Added `reverse_proxy.stream.shared_burst_buffer_mb` to control shared-stream burst buffer size (default 12 MB).
 
 # 3.1.8 (2025-11-06)
 - Fixed HLS streaming issues caused by session eviction and incorrect headers.

--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Attributes:
 - `throttle` Allowed units are `KB/s`,`MB/s`,`KiB/s`,`MiB/s`,`kbps`,`mbps`,`Mibps`. Default unit is `kbps`
 - `grace_period_millis`  default set to 300 milliseconds.
 - `grace_period_timeout_secs` default set to 2 seconds.
+- `shared_burst_buffer_mb` optional (default `12`). Minimum burst buffer size (in MB) used for shared streams.
 
 ##### 1.6.1.1 `retry`
 If set to `true` on connection loss to provider, the stream will be reconnected.

--- a/backend/src/model/config/stream.rs
+++ b/backend/src/model/config/stream.rs
@@ -37,6 +37,7 @@ pub struct StreamConfig {
     pub forced_retry_interval_secs: u32,
     pub throttle_str: Option<String>,
     pub throttle_kbps: u64,
+    pub shared_burst_buffer_mb: u64,
 }
 
 macros::from_impl!(StreamConfig);
@@ -50,6 +51,7 @@ impl From<&StreamConfigDto> for StreamConfig {
             forced_retry_interval_secs: dto.forced_retry_interval_secs,
             throttle_str: dto.throttle.clone(),
             throttle_kbps: dto.throttle.as_ref().map_or(0u64, |throttle| parse_to_kbps(throttle).unwrap_or(0u64)),
+            shared_burst_buffer_mb: dto.shared_burst_buffer_mb,
         }
     }
 }
@@ -64,6 +66,7 @@ impl From<&StreamConfig> for StreamConfigDto {
             forced_retry_interval_secs: instance.forced_retry_interval_secs,
             throttle: instance.throttle_str.clone(),
             throttle_kbps: instance.throttle_kbps,
+            shared_burst_buffer_mb: instance.shared_burst_buffer_mb,
         }
     }
 }

--- a/config/config.yml
+++ b/config/config.yml
@@ -70,3 +70,5 @@ reverse_proxy:
     max_attempts: 3
     backoff_millis: 250
     backoff_multiplier: 1.0
+  stream:
+    shared_burst_buffer_mb: 12 # default 12 MB

--- a/frontend/public/assets/i18n/en.json
+++ b/frontend/public/assets/i18n/en.json
@@ -54,6 +54,7 @@
     "GRACE_PERIOD_TIMEOUT": "Grace period timeout sec",
     "BUFFER_ENABLED": "Buffer Enabled",
     "BUFFER_SIZE": "Buffer Size",
+    "SHARED_BURST_BUFFER_BYTES": "Shared burst buffer (MB)",
     "ENABLED": "Enabled",
     "SIZE": "Size",
     "CACHE_DIR": "Cache dir",

--- a/frontend/src/app/components/config/reverse_proxy_config_view.rs
+++ b/frontend/src/app/components/config/reverse_proxy_config_view.rs
@@ -26,6 +26,7 @@ const LABEL_THROTTLE_KBPS: &str = "LABEL.THROTTLE_KBPS";
 const LABEL_RATE_LIMIT: &str = "LABEL.RATE_LIMIT";
 const LABEL_PERIOD_MILLIS: &str = "LABEL.PERIOD_MILLIS";
 const LABEL_BURST_SIZE: &str = "LABEL.BURST_SIZE";
+const LABEL_SHARED_BURST_BUFFER_MB: &str = "LABEL.SHARED_BURST_BUFFER_BYTES";
 
 const LABEL_SETTINGS: &str = "LABEL.SETTINGS";
 const LABEL_RESOURCE_REWRITE_DISABLED: &str = "LABEL.RESOURCE_REWRITE_DISABLED";
@@ -81,6 +82,7 @@ generate_form_reducer!(
         GracePeriodTimeoutSecs => grace_period_timeout_secs: u64,
         //ForcedRetryIntervalSecs => forced_retry_interval_secs: u32,
         ThrottleKbps => throttle_kbps: u64,
+        SharedBurstBufferMb => shared_burst_buffer_mb: u64,
     }
 );
 
@@ -237,6 +239,7 @@ pub fn ReverseProxyConfigView() -> Html {
                 { config_field!(stream_state.form, translate.t(LABEL_GRACE_PERIOD_TIMEOUT_SECS), grace_period_timeout_secs) }
                 //{ config_field!(stream_state.form, translate.t(LABEL_FORCED_RETRY_INTERVAL_SECS), forced_retry_interval_secs) }
                 { config_field!(stream_state.form, translate.t(LABEL_THROTTLE_KBPS), throttle_kbps) }
+                { config_field!(stream_state.form, translate.t(LABEL_SHARED_BURST_BUFFER_MB), shared_burst_buffer_mb) }
             </Card>
         }
     };
@@ -373,6 +376,7 @@ pub fn ReverseProxyConfigView() -> Html {
                 { edit_field_number_u64!(stream_state, translate.t(LABEL_GRACE_PERIOD_TIMEOUT_SECS), grace_period_timeout_secs, StreamConfigFormAction::GracePeriodTimeoutSecs) }
                 //{ edit_field_number!(stream_state, translate.t(LABEL_FORCED_RETRY_INTERVAL_SECS), forced_retry_interval_secs, StreamConfigFormAction::ForcedRetryIntervalSecs) }
                 { edit_field_number_u64!(stream_state, translate.t(LABEL_THROTTLE_KBPS), throttle_kbps, StreamConfigFormAction::ThrottleKbps) }
+                { edit_field_number_u64!(stream_state, translate.t(LABEL_SHARED_BURST_BUFFER_MB), shared_burst_buffer_mb, StreamConfigFormAction::SharedBurstBufferMb) }
             </Card>
             <Card class="tp__config-view__card">
                 <h1>{translate.t(LABEL_GEOIP)}</h1>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable shared stream burst buffer size via the `reverse_proxy.stream.shared_burst_buffer_mb` parameter (default 12 MB).
  * Added UI support to view and edit the new burst buffer configuration setting.

* **Documentation**
  * Updated README and changelog documenting the new configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->