### PR TITLE
Avoid blocking the runtime when warming cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
-# 3.1.9 (2025-11-xx)
+# 3.3.0 (2025-11-xx)
+- Avoid blocking the runtime when warming cache
+
+# 3.2.0 (2025-11-14)
 - Added `name` attribute to Staged Input.
 - Real-time active provider connection monitoring (dashboard + websocket)
 - Source editor: block selection, batch-mode UI and automatic layout

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,7 +1102,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "3.1.8"
+version = "3.2.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -1114,9 +1114,9 @@ dependencies = [
  "futures-signals",
  "gloo-render 0.2.0",
  "gloo-storage 0.3.0",
- "gloo-timers 0.3.0",
+ "gloo-timers 0.2.6",
  "gloo-utils 0.2.0",
- "implicit-clone 0.6.0",
+ "implicit-clone",
  "js-sys",
  "log",
  "prost",
@@ -1627,6 +1627,8 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
 dependencies = [
+ "futures-channel",
+ "futures-core",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -2156,15 +2158,6 @@ checksum = "f8a9aa791c7b5a71b636b7a68207fdebf171ddfc593d9c8506ec4cbc527b6a84"
 dependencies = [
  "implicit-clone-derive",
  "indexmap",
-]
-
-[[package]]
-name = "implicit-clone"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1689b939ee35e3a075b0834b5672efd43aec8a6e81a1c6002b76a5ca2f211ae0"
-dependencies = [
- "implicit-clone-derive",
 ]
 
 [[package]]
@@ -3789,7 +3782,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "3.1.8"
+version = "3.3.0"
 dependencies = [
  "base64",
  "bitflags 2.10.0",
@@ -4338,7 +4331,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuliprox"
-version = "3.1.8"
+version = "3.2.1"
 dependencies = [
  "arc-swap",
  "async-compression",
@@ -5055,7 +5048,7 @@ dependencies = [
  "console_error_panic_hook",
  "futures",
  "gloo 0.10.0",
- "implicit-clone 0.4.9",
+ "implicit-clone",
  "indexmap",
  "js-sys",
  "prokio",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuliprox"
-version = "3.1.8"
+version = "3.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "frontend"
-version = "3.1.8"
+version = "3.2.1"
 edition = "2021"
 
 [dependencies]
-shared = { version = "3.1.8", path = "../shared" }
+shared = { version = "3.3.0", path = "../shared" }
 chrono = "0"
 yew = "0.21"
 yew-router = "0.18"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shared"
-version = "3.1.8"
+version = "3.2.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Cache warm-up changed to avoid blocking the runtime, improving responsiveness during startup/refresh.
* **Documentation**
  * Changelog updated with the new 3.3.0 entry.
* **Chores**
  * Package versions bumped for backend, frontend, and shared; frontend now depends on the updated shared package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->