### PR TITLE
 Persist cache pipe via tokio::fs to avoid blocking the runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Avoid blocking the runtime when warming cache
 - Normalize FileLockManager paths so aliases share the same lock
 - Use async file operations for playlist persistence to avoid blocking async paths
+- Persist cache write pipe using `tokio::fs` so response caching no longer blocks the async runtime
 
 # 3.2.0 (2025-11-14)
 - Added `name` attribute to Staged Input.

--- a/backend/src/api/api_utils.rs
+++ b/backend/src/api/api_utils.rs
@@ -32,7 +32,7 @@ use shared::utils::{
 };
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::io::BufWriter;
+use tokio::io::BufWriter;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
@@ -1076,7 +1076,7 @@ async fn build_stream_response(
             None
         };
         if let Some(resource_path) = cache_resource_path {
-            if let Ok(file) = create_new_file_for_write(&resource_path) {
+            if let Ok(file) = create_new_file_for_write(&resource_path).await {
                 let writer = BufWriter::new(file);
                 let add_cache_content = get_add_cache_content(resource_url, &app_state.cache);
                 let stream = PersistPipeStream::new(byte_stream, writer, add_cache_content);

--- a/backend/src/api/model/streams/persist_pipe_stream.rs
+++ b/backend/src/api/model/streams/persist_pipe_stream.rs
@@ -1,45 +1,34 @@
-use std::io::Write;
+use std::collections::VecDeque;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::task::{Context, Poll};
 use bytes::Bytes;
 use log::error;
+use tokio::io::{AsyncWrite, AsyncWriteExt};
 use tokio_stream::Stream;
 use crate::api::model::StreamError;
 
 /// `PersistPipeStream`
 ///
-/// A stream wrapper that pipes data from an input stream to a writer while tracking
-/// the total number of bytes processed. Upon completion, it triggers a user-provided
-/// callback with the total size of the data written.
-/// - `callback`: A user-provided function that is called with the total size of the processed data once the stream is completed.
-///
-/// # Stream Implementation
-/// - Implements the `Stream` trait to poll the underlying stream for data.
-/// - For each chunk of data:
-///   - Writes it to the writer.
-///   - Updates the size tracker.
-/// - When the stream is exhausted:
-///   - Calls `on_complete()` to finalize the operation and trigger the callback.
+/// Pipes bytes from an upstream stream to an async writer while tracking total size.
+/// Once the stream completes and the writer is flushed, the provided callback is invoked
+/// with the total number of bytes written.
 pub struct PersistPipeStream<S, W> {
     inner: S,
     completed: bool,
     writer: W,
     size: AtomicUsize,
     callback: Arc<dyn Fn(usize) + Send + Sync>,
+    pending_writes: VecDeque<Bytes>,
+    current_offset: usize,
 }
 
 impl<S, W> PersistPipeStream<S, W>
 where
     S: Stream + Unpin,
-    W: Write + Unpin + 'static,
+    W: AsyncWrite + Unpin + 'static,
 {
-    ///   - Creates a new `PersistPipeStream` instance.
-    ///   - Arguments:
-    ///     - `inner`: The input stream providing the data.
-    ///     - `writer`: The writer to which the data is written.
-    ///     - `callback`: A callback function to be called with the total size upon stream completion.
     pub fn new(inner: S, writer: W, callback: Arc<dyn Fn(usize) + Send + Sync>) -> Self {
         Self {
             inner,
@@ -47,26 +36,63 @@ where
             writer,
             size: AtomicUsize::new(0),
             callback,
+            pending_writes: VecDeque::new(),
+            current_offset: 0,
         }
     }
 
-    fn on_complete(&mut self) {
+    fn enqueue_chunk(&mut self, bytes: Bytes) {
+        self.pending_writes.push_back(bytes);
+    }
+
+    fn poll_pending_writes(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        while let Some(chunk) = self.pending_writes.front() {
+            if self.current_offset >= chunk.len() {
+                if let Some(finished) = self.pending_writes.pop_front() {
+                    self.size.fetch_add(finished.len(), Ordering::SeqCst);
+                }
+                self.current_offset = 0;
+                continue;
+            }
+
+            let remaining = &chunk[self.current_offset..];
+            match Pin::new(&mut self.writer).poll_write(cx, remaining) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Ok(written)) => {
+                    if written == 0 {
+                        // Avoid tight loop if writer makes no progress.
+                        return Poll::Pending;
+                    }
+                    self.current_offset += written;
+                }
+                Poll::Ready(Err(err)) => {
+                    error!("Error writing to resource file: {err}");
+                    self.pending_writes.pop_front();
+                    self.current_offset = 0;
+                }
+            }
+        }
+
+        self.current_offset = 0;
+        Poll::Ready(())
+    }
+
+    fn poll_flush(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        match Pin::new(&mut self.writer).poll_flush(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Ok(())) => Poll::Ready(()),
+            Poll::Ready(Err(err)) => {
+                error!("Error flushing resource file: {err}");
+                Poll::Ready(())
+            }
+        }
+    }
+
+    fn finalize(&mut self) {
         if !self.completed {
             self.completed = true;
             let size = self.size.load(Ordering::SeqCst);
-            if self.writer.flush().is_ok() {
-                (self.callback)(size);
-            }
-        }
-    }
-
-    fn on_data(&mut self, data: &Result<Bytes, StreamError>) {
-        if let Ok(bytes) = data {
-            self.size.fetch_add(bytes.len(), Ordering::SeqCst);
-            let bytes_to_write = bytes.clone();
-            if let Err(e) = self.writer.write_all(&bytes_to_write) {
-                error!("Error writing to resource file: {e}");
-            }
+            (self.callback)(size);
         }
     }
 }
@@ -74,20 +100,39 @@ where
 impl<S, W> Stream for PersistPipeStream<S, W>
 where
     S: Stream<Item = Result<bytes::Bytes, StreamError>> + Unpin,
-    W: Write + Unpin + 'static,
+    W: AsyncWrite + Unpin + 'static,
 {
     type Item = Result<Bytes, StreamError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
+
+        if !this.pending_writes.is_empty() {
+            if let Poll::Pending = this.poll_pending_writes(cx) {
+                return Poll::Pending;
+            }
+        }
+
         match Pin::new(&mut this.inner).poll_next(cx) {
             Poll::Pending => Poll::Pending,
             Poll::Ready(None) => {
-                this.on_complete();
+                if let Poll::Pending = this.poll_pending_writes(cx) {
+                    return Poll::Pending;
+                }
+                if let Poll::Pending = this.poll_flush(cx) {
+                    return Poll::Pending;
+                }
+                this.finalize();
                 Poll::Ready(None)
             }
             Poll::Ready(Some(item)) => {
-                this.on_data(&item);
+                if let Ok(bytes) = &item {
+                    this.enqueue_chunk(bytes.clone());
+                }
+                // Try to drain pending bytes after queuing new data.
+                if let Poll::Pending = this.poll_pending_writes(cx) {
+                    // fall through: we still return the chunk to the caller even if persistence is pending
+                }
                 Poll::Ready(Some(item))
             }
         }

--- a/backend/src/utils/file/file_utils.rs
+++ b/backend/src/utils/file/file_utils.rs
@@ -10,6 +10,7 @@ use crate::utils::debug_if_enabled;
 use shared::utils::{API_PROXY_FILE, CONFIG_FILE, CONFIG_PATH, MAPPING_FILE, SOURCE_FILE, USER_FILE};
 use log::{debug, error};
 use path_clean::PathClean;
+use tokio::fs as tokio_fs;
 
 pub fn file_writer<W>(w: W) -> BufWriter<W>
 where
@@ -198,8 +199,13 @@ pub fn append_or_crate_file(path: &Path) -> std::io::Result<File> {
 }
 
 #[inline]
-pub fn create_new_file_for_write(path: &Path) -> std::io::Result<File> {
-    OpenOptions::new().write(true).create(true).truncate(true).open(path)
+pub async fn create_new_file_for_write(path: &Path) -> tokio::io::Result<tokio_fs::File> {
+    tokio_fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(path)
+        .await
 }
 
 #[inline]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Response caching now uses fully asynchronous file writes, preventing cache persistence from blocking the async runtime and improving responsiveness.
* **Stability**
  * Background persistence is buffered and drained incrementally, reducing I/O stalls and improving reliability of large or bursty responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->