### PR TITLE
  Use Arc<Bytes> for shared-stream burst buffer snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Avoid blocking the runtime when warming cache
 - Normalize FileLockManager paths so aliases share the same lock
 - Use async file operations for playlist persistence to avoid blocking async paths
+- Shared stream burst buffer now reuses `Arc<Bytes>` so new subscribers no longer clone the entire burst data set.
 
 # 3.2.0 (2025-11-14)
 - Added `name` attribute to Staged Input.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Enhanced shared stream burst buffer implementation to improve efficiency in handling concurrent subscribers through optimized data management patterns.

* **Refactor**
  * Updated stream management internal structures to support more efficient operations while maintaining existing API compatibility.

* **Documentation**
  * Updated changelog to document burst buffer optimization enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->