### PR TITLE
Avoid holding stream lock while releasing providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Async persist cache write pipe so response caching no longer blocks the async runtime
 - M3U playlist exports now stream async to keep the runtime responsive
 - Shared stream burst buffer zero copy data buffer to reduce memory usage.
+- Shared stream shutdown now drops registry locks before releasing provider handles to prevent cross-lock stalls.
 
 
 # 3.2.0 (2025-11-14)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a concurrency issue in stream management that could cause service stalls during shutdown by optimizing lock handling in registry cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->