### PR TITLE
Add order: none handling to playlist sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added detailed shared-stream/buffer/provider logging to trace lag, cache persistence, and session/provider lifecycle events.
 - Connection registration failures now trigger an explicit disconnect so zombie sockets don’t linger.
 - Shared stream shutdown now drops registry locks before releasing provider handles to prevent cross-lock stalls.
+- Added `order: none` support for group/channel sorting so mappings can opt out of any reordering and keep the source order.
 
 
 # 3.2.0 (2025-11-14)

--- a/README.md
+++ b/README.md
@@ -864,13 +864,13 @@ Has three top level attributes
 
 #### `groups`
 Used for sorting at the group (category) level.
-It has one top-level attribute `order` which can be set to `asc`or `desc`.
+It has one top-level attribute `order` which can be set to `asc`, `desc`, or `none` to preserve the source order for that level.
 #### `channels`
 Used for sorting the channels within a group/category.
 This is a list of sort configurations for groups. Each configuration has the following top-level entries:
 - `field` - can be  `title`, `name`, `caption` or `url`.
 - `group_pattern` - a regular expression like `'^TR.:\s?(.*)'` matched against group title.
-- `order` - can be `asc` or `desc`
+- `order` - can be `asc`, `desc`, or `none` (which skips sorting for that group_pattern and keeps the playlist order coming from the sources).
 - `sequence` _optional_  - a list of regexp matching field values (based on `field`). These are used to sort based on index. The `order` is ignored for this entries.
 
 The pattern should be selected taking into account the processing sequence.

--- a/backend/src/processing/processor/sort.rs
+++ b/backend/src/processing/processor/sort.rs
@@ -10,6 +10,9 @@ fn playlist_comparator(
     value_a: &str,
     value_b: &str,
 ) -> Ordering {
+    if matches!(order, SortOrder::None) {
+        return Ordering::Equal;
+    }
     if let Some(regex_list) = sequence {
         let mut match_a = None;
         let mut match_b = None;
@@ -123,10 +126,15 @@ pub(in crate::processing::processor) fn sort_playlist(target: &ConfigTarget, new
     if let Some(sort) = &target.sort {
         let match_as_ascii = sort.match_as_ascii;
         if let Some(group_sort) = &sort.groups {
-            new_playlist.sort_by(|a, b| playlistgroup_comparator(a, b, group_sort, match_as_ascii));
+            if group_sort.order != SortOrder::None {
+                new_playlist.sort_by(|a, b| playlistgroup_comparator(a, b, group_sort, match_as_ascii));
+            }
         }
         if let Some(channel_sorts) = &sort.channels {
             for channel_sort in channel_sorts {
+                if channel_sort.order == SortOrder::None {
+                    continue;
+                }
                 let regexp = &channel_sort.group_pattern;
                 for group in new_playlist.iter_mut() {
                     let group_title = if match_as_ascii { deunicode(&group.title) } else { group.title.clone() };

--- a/shared/src/model/config/sort.rs
+++ b/shared/src/model/config/sort.rs
@@ -23,6 +23,8 @@ pub enum SortOrder {
     Asc,
     #[serde(rename = "desc")]
     Desc,
+    #[serde(rename = "none")]
+    None,
 }
 
 impl Display for SortOrder {
@@ -30,6 +32,7 @@ impl Display for SortOrder {
         let str = match self {
             SortOrder::Asc => "asc".to_string(),
             SortOrder::Desc => "desc".to_string(),
+            SortOrder::None => "none".to_string(),
         };
         write!(f, "{str}")
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `order: none` option for group and channel sorting configuration to preserve original source order without applying reordering.

* **Documentation**
  * Updated sorting configuration documentation to describe the new `order: none` option and its effects on playlist ordering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->