### PR TITLE
fix hls stream session

### DIFF
--- a/backend/src/api/endpoints/hls_api.rs
+++ b/backend/src/api/endpoints/hls_api.rs
@@ -55,6 +55,35 @@ fn hls_response(hls_content: String) -> impl IntoResponse + Send {
         .body(hls_content))
 }
 
+async fn release_prepared_hls_manifest_session(
+    app_state: &Arc<AppState>,
+    username: &str,
+    session_token: &str,
+    addr: &std::net::SocketAddr,
+) {
+    let _transition_guard = app_state
+        .active_users
+        .acquire_playback_transition(username, session_token)
+        .await;
+    app_state
+        .active_users
+        .release_unbound_session_reservation(username, session_token, None, false)
+        .await;
+    app_state
+        .active_users
+        .clear_unbound_session_addr(username, session_token, addr)
+        .await;
+}
+
+async fn terminate_failed_hls_manifest_session(app_state: &Arc<AppState>, username: &str, session_token: &str) {
+    let _transition_guard = app_state
+        .active_users
+        .acquire_playback_transition(username, session_token)
+        .await;
+    app_state.active_users.terminate_session(username, session_token).await;
+    app_state.active_provider.clear_provider_reservation(session_token).await;
+}
+
 fn normalize_xtream_live_hls_url(hls_url: &str, input: &ConfigInput) -> String {
     if !input.input_type.is_xtream() || !input.has_flag(ConfigInputFlags::XtreamLiveStreamUsePrefix) {
         return hls_url.to_string();
@@ -272,36 +301,14 @@ pub(in crate::api) async fn handle_hls_stream_request(
             };
             let hls_content = rewrite_hls(user, &rewrite_hls_props);
             if let Some(session_token) = session_token.as_deref() {
-                let _transition_guard = app_state
-                    .active_users
-                    .acquire_playback_transition(&user.username, session_token)
-                    .await;
-                app_state
-                    .active_users
-                    .release_unbound_session_reservation(&user.username, session_token, None, false)
-                    .await;
-                app_state
-                    .active_users
-                    .clear_unbound_session_addr(&user.username, session_token, &fingerprint.addr)
-                    .await;
+                release_prepared_hls_manifest_session(app_state, &user.username, session_token, &fingerprint.addr).await;
             }
             hls_response(hls_content).into_response()
         }
         Err(err) => {
             error!("Failed to download m3u8 {}", sanitize_sensitive_info(err.to_string().as_str()));
             if let Some(session_token) = session_token.as_deref() {
-                let _transition_guard = app_state
-                    .active_users
-                    .acquire_playback_transition(&user.username, session_token)
-                    .await;
-                app_state
-                    .active_users
-                    .release_unbound_session_reservation(&user.username, session_token, None, false)
-                    .await;
-                app_state
-                    .active_users
-                    .clear_unbound_session_addr(&user.username, session_token, &fingerprint.addr)
-                    .await;
+                terminate_failed_hls_manifest_session(app_state, &user.username, session_token).await;
             }
 
             let custom_stream_response = app_state.app_config.custom_stream_response.load();

--- a/backend/src/api/model/active_user_manager.rs
+++ b/backend/src/api/model/active_user_manager.rs
@@ -2261,41 +2261,35 @@ impl ActiveUserManager {
                 return;
             };
 
-            // Collect all addresses associated with this session.
-            let mut addrs = Vec::new();
-            let session = &connection_data.sessions[session_index];
-            if !session.addr.ip().is_unspecified() {
-                addrs.push(session.addr);
-            }
-            for addr in &session.active_addrs {
-                if *addr != session.addr && !addrs.contains(addr) {
-                    addrs.push(*addr);
-                }
-            }
-
-            // Release all streams for these addresses.
+            let counted_kind = connection_data.sessions[session_index]
+                .lifecycle
+                .is_counted()
+                .then(|| {
+                    connection_data.sessions[session_index]
+                        .connection_kind
+                        .unwrap_or(ConnectionKind::Normal)
+                });
             let mut removed_count = 0;
-            for addr in &addrs {
-                if let Some(stream_idx) = connection_data
-                    .streams
-                    .iter()
-                    .position(|stream| stream.addr == *addr && !stream.preserved)
-                {
-                    if let Some(kind) = connection_data.stream_kinds.remove(&connection_data.streams[stream_idx].uid) {
+            let mut connection_changed = false;
+            let mut released_stream_kind = false;
+            let mut stream_idx = 0;
+            while stream_idx < connection_data.streams.len() {
+                if connection_data.streams[stream_idx].session_token.as_deref() == Some(session_token) {
+                    let uid = connection_data.streams[stream_idx].uid;
+                    if let Some(kind) = connection_data.stream_kinds.remove(&uid) {
                         connection_data.decrement_kind(kind);
+                        released_stream_kind = true;
+                        connection_changed = true;
                     }
-                    connection_data.stream_normal_priorities.remove(&connection_data.streams[stream_idx].uid);
+                    connection_data.stream_normal_priorities.remove(&uid);
                     connection_data.streams.swap_remove(stream_idx);
                     removed_count += 1;
+                } else {
+                    stream_idx += 1;
                 }
             }
 
-            // Release counted lease if held.
-            let mut connection_changed = false;
-            if connection_data.sessions[session_index].lifecycle.is_counted() {
-                let kind = connection_data.sessions[session_index]
-                    .connection_kind
-                    .unwrap_or(ConnectionKind::Normal);
+            if let Some(kind) = counted_kind.filter(|_| !released_stream_kind) {
                 connection_data.decrement_kind(kind);
                 connection_changed = true;
             }
@@ -2361,34 +2355,36 @@ impl ActiveUserManager {
                     continue;
                 };
 
-                // Release counted lease if held.
-                if connection_data.sessions[session_index].lifecycle.is_counted() {
-                    let kind = connection_data.sessions[session_index]
-                        .connection_kind
-                        .unwrap_or(ConnectionKind::Normal);
-                    connection_data.decrement_kind(kind);
-                    connection_changed = true;
-                }
+                let counted_kind = connection_data.sessions[session_index]
+                    .lifecycle
+                    .is_counted()
+                    .then(|| {
+                        connection_data.sessions[session_index]
+                            .connection_kind
+                            .unwrap_or(ConnectionKind::Normal)
+                    });
 
-                // Release stream kinds for all streams belonging to this session.
-                let session_streams: Vec<_> = connection_data
-                    .streams
-                    .iter()
-                    .filter(|stream| stream.session_token.as_deref() == Some(token))
-                    .map(|stream| stream.uid)
-                    .collect();
-                for uid in session_streams {
+                let mut released_stream_kind = false;
+                let mut stream_idx = 0;
+                while stream_idx < connection_data.streams.len() {
+                    if connection_data.streams[stream_idx].session_token.as_deref() != Some(token) {
+                        stream_idx += 1;
+                        continue;
+                    }
+
+                    let uid = connection_data.streams[stream_idx].uid;
                     if let Some(kind) = connection_data.stream_kinds.remove(&uid) {
                         connection_data.decrement_kind(kind);
+                        released_stream_kind = true;
                         connection_changed = true;
                     }
                     connection_data.stream_normal_priorities.remove(&uid);
-                    // Remove non-preserved streams.
-                    if let Some(idx) =
-                        connection_data.streams.iter().position(|s| s.uid == uid && !s.preserved)
-                    {
-                        connection_data.streams.swap_remove(idx);
-                    }
+                    connection_data.streams.swap_remove(stream_idx);
+                }
+
+                if let Some(kind) = counted_kind.filter(|_| !released_stream_kind) {
+                    connection_data.decrement_kind(kind);
+                    connection_changed = true;
                 }
 
                 // Expire and remove the session.
@@ -3447,6 +3443,71 @@ mod tests {
             .get_and_update_user_session(&user.username, &token)
             .await;
         assert!(after.is_none(), "session should be removed after terminate");
+    }
+
+    #[tokio::test]
+    async fn terminate_session_removes_preserved_adaptive_stream() {
+        let config = Config::default();
+        let geoip = Arc::new(ArcSwapOption::<GeoIp>::default());
+        let event_manager = Arc::new(EventManager::new());
+        let manager = ActiveUserManager::new(&config, &geoip, &event_manager);
+
+        let addr: SocketAddr = "127.0.0.1:55412".parse().unwrap();
+        let fingerprint = Fingerprint::new("fp-terminate-preserved".to_string(), "127.0.0.1".to_string(), addr);
+        let mut user = ProxyUserCredentials::default();
+        user.username = "user-terminate-preserved".to_string();
+        user.max_connections = 1;
+
+        let token = manager
+            .create_user_session(CreateUserSessionParams {
+                user: &user,
+                session_token: "tok-terminate-preserved",
+                virtual_id: 8003,
+                provider: "provider-terminate-preserved",
+                stream_url: "http://localhost/test.m3u8",
+                addr: &addr,
+                connection_permission: UserConnectionPermission::Allowed,
+                connection_kind: Some(ConnectionKind::Normal),
+                socket_bound: false,
+            })
+            .await;
+
+        manager.add_connection(&addr).await;
+        manager
+            .update_connection(ActiveUserConnectionParams {
+                uid: 8003,
+                meter_uid: 0,
+                username: &user.username,
+                max_connections: user.max_connections,
+                soft_connections: 0,
+                connection_kind: ConnectionKind::Normal,
+                priority: 0,
+                soft_priority: 0,
+                fingerprint: &fingerprint,
+                provider: "provider-terminate-preserved".intern(),
+                stream_channel: &test_adaptive_channel(8003),
+                user_agent: Cow::Borrowed("ua"),
+                session_token: Some(&token),
+            })
+            .await
+            .expect("adaptive stream should be registered");
+
+        let released = manager.release_connection(&addr).await;
+        assert!(released.addr_removed);
+        assert!(released.removed_streams.is_empty(), "adaptive stream should be preserved first");
+
+        manager.terminate_session(&user.username, &token).await;
+
+        let connections = manager.connections.read().await;
+        let connection_data = connections
+            .by_key
+            .get(&user.username)
+            .expect("user data should remain inspectable");
+        assert!(
+            connection_data.streams.is_empty(),
+            "terminating a session must remove its preserved adaptive stream"
+        );
+        assert!(connection_data.sessions.iter().all(|session| session.token != token));
     }
 
     #[tokio::test]

--- a/backend/src/api/model/active_user_manager.rs
+++ b/backend/src/api/model/active_user_manager.rs
@@ -240,6 +240,40 @@ impl UserConnectionData {
         }
     }
 
+    fn remove_streams_for_session_and_release_counted(
+        &mut self,
+        session_token: &str,
+        counted_kind: Option<ConnectionKind>,
+    ) -> (u32, bool) {
+        let mut removed_count = 0;
+        let mut connection_changed = false;
+        let mut released_stream_kind = false;
+        let mut stream_idx = 0;
+        while stream_idx < self.streams.len() {
+            if self.streams[stream_idx].session_token.as_deref() != Some(session_token) {
+                stream_idx += 1;
+                continue;
+            }
+
+            let uid = self.streams[stream_idx].uid;
+            if let Some(kind) = self.stream_kinds.remove(&uid) {
+                self.decrement_kind(kind);
+                released_stream_kind = true;
+                connection_changed = true;
+            }
+            self.stream_normal_priorities.remove(&uid);
+            self.streams.swap_remove(stream_idx);
+            removed_count += 1;
+        }
+
+        if let Some(kind) = counted_kind.filter(|_| !released_stream_kind) {
+            self.decrement_kind(kind);
+            connection_changed = true;
+        }
+
+        (removed_count, connection_changed)
+    }
+
     fn try_promote_soft_stream(&mut self) -> Option<PromotionAction> {
         if self.counts.normal >= self.max_connections || (u32::from(self.counts.soft)) <= u32::from(self.soft_connections) {
             return None;
@@ -2269,30 +2303,8 @@ impl ActiveUserManager {
                         .connection_kind
                         .unwrap_or(ConnectionKind::Normal)
                 });
-            let mut removed_count = 0;
-            let mut connection_changed = false;
-            let mut released_stream_kind = false;
-            let mut stream_idx = 0;
-            while stream_idx < connection_data.streams.len() {
-                if connection_data.streams[stream_idx].session_token.as_deref() == Some(session_token) {
-                    let uid = connection_data.streams[stream_idx].uid;
-                    if let Some(kind) = connection_data.stream_kinds.remove(&uid) {
-                        connection_data.decrement_kind(kind);
-                        released_stream_kind = true;
-                        connection_changed = true;
-                    }
-                    connection_data.stream_normal_priorities.remove(&uid);
-                    connection_data.streams.swap_remove(stream_idx);
-                    removed_count += 1;
-                } else {
-                    stream_idx += 1;
-                }
-            }
-
-            if let Some(kind) = counted_kind.filter(|_| !released_stream_kind) {
-                connection_data.decrement_kind(kind);
-                connection_changed = true;
-            }
+            let (removed_count, connection_changed) = connection_data
+                .remove_streams_for_session_and_release_counted(session_token, counted_kind);
 
             // Expire and remove the session immediately. Unlike `release_unbound_session_reservation`
             // which keeps the expired session for TTL-based GC cleanup, terminate_session explicitly
@@ -2364,28 +2376,9 @@ impl ActiveUserManager {
                             .unwrap_or(ConnectionKind::Normal)
                     });
 
-                let mut released_stream_kind = false;
-                let mut stream_idx = 0;
-                while stream_idx < connection_data.streams.len() {
-                    if connection_data.streams[stream_idx].session_token.as_deref() != Some(token) {
-                        stream_idx += 1;
-                        continue;
-                    }
-
-                    let uid = connection_data.streams[stream_idx].uid;
-                    if let Some(kind) = connection_data.stream_kinds.remove(&uid) {
-                        connection_data.decrement_kind(kind);
-                        released_stream_kind = true;
-                        connection_changed = true;
-                    }
-                    connection_data.stream_normal_priorities.remove(&uid);
-                    connection_data.streams.swap_remove(stream_idx);
-                }
-
-                if let Some(kind) = counted_kind.filter(|_| !released_stream_kind) {
-                    connection_data.decrement_kind(kind);
-                    connection_changed = true;
-                }
+                let (_, session_connection_changed) = connection_data
+                    .remove_streams_for_session_and_release_counted(token, counted_kind);
+                connection_changed |= session_connection_changed;
 
                 // Expire and remove the session.
                 connection_data.sessions.swap_remove(session_index);
@@ -6726,6 +6719,7 @@ mod tests {
         assert_eq!(session.addr, first_addr);
         assert_eq!(session.active_addrs, vec![first_addr]);
     }
+
 
     #[tokio::test]
     async fn get_eviction_candidates_keeps_preserved_streams_evictable() {

--- a/backend/src/api/model/active_user_manager.rs
+++ b/backend/src/api/model/active_user_manager.rs
@@ -1543,6 +1543,19 @@ impl ActiveUserManager {
         }
     }
 
+    fn collect_promotions_after_capacity_release(connection_data: &mut UserConnectionData) -> Vec<PromotionAction> {
+        let mut promotions = Vec::new();
+        while let Some(action) = connection_data.try_promote_soft_stream() {
+            let promoted_stream = connection_data.streams.iter().find(|stream| stream.uid == action.uid).cloned();
+            if let Some(stream) = promoted_stream.as_ref() {
+                Self::promote_session_for_stream(connection_data, stream);
+            }
+            promotions.push(action);
+        }
+        while connection_data.try_promote_soft_session_reservation() {}
+        promotions
+    }
+
     fn bump_session_transition_version(session: &mut UserSession) -> u64 {
         session.transition_version = session.transition_version.saturating_add(1);
         session.transition_version
@@ -2281,7 +2294,7 @@ impl ActiveUserManager {
     /// Unlike `release_unbound_session_reservation`, this terminates regardless of
     /// whether streams are currently active, and always removes associated streams.
     pub async fn terminate_session(&self, username: &str, session_token: &str) {
-        let (connection_changed, removed_count) = {
+        let (connection_changed, removed_count, promotions) = {
             let mut user_connections = self.connections.write().await;
             let Some(connection_data) = user_connections.by_key.get_mut(username) else {
                 return;
@@ -2317,15 +2330,20 @@ impl ActiveUserManager {
                 connection_data.grace_ts = 0;
             }
 
+            let promotions = Self::collect_promotions_after_capacity_release(connection_data);
+
             let divergence_snapshot = Self::collect_divergence_snapshot(connection_data, username);
             drop(user_connections);
             self.log_divergence_snapshot(divergence_snapshot).await;
 
-            (connection_changed, removed_count)
+            (connection_changed, removed_count, promotions)
         };
 
         if connection_changed {
             self.log_active_user().await;
+        }
+        for action in promotions {
+            self.emit_promotion_update(username, action).await;
         }
         debug!(
             "Terminated session {session_token} for user {username}, released {removed_count} streams"
@@ -2339,7 +2357,7 @@ impl ActiveUserManager {
     ///
     /// Removes all sessions whose `addr` or `active_addrs` contains `kick_addr`.
     pub async fn terminate_sessions_for_addr(&self, username: &str, kick_addr: &SocketAddr) {
-        let (connection_changed, removed_count) = {
+        let (connection_changed, removed_count, promotions) = {
             let mut user_connections = self.connections.write().await;
             let Some(connection_data) = user_connections.by_key.get_mut(username) else {
                 return;
@@ -2391,15 +2409,20 @@ impl ActiveUserManager {
                 connection_data.grace_ts = 0;
             }
 
+            let promotions = Self::collect_promotions_after_capacity_release(connection_data);
+
             let divergence_snapshot = Self::collect_divergence_snapshot(connection_data, username);
             drop(user_connections);
             self.log_divergence_snapshot(divergence_snapshot).await;
 
-            (connection_changed, removed_count)
+            (connection_changed, removed_count, promotions)
         };
 
         if connection_changed {
             self.log_active_user().await;
+        }
+        for action in promotions {
+            self.emit_promotion_update(username, action).await;
         }
         debug!(
             "Terminated {removed_count} sessions for user {username} at addr {kick_addr}"
@@ -3501,6 +3524,159 @@ mod tests {
             "terminating a session must remove its preserved adaptive stream"
         );
         assert!(connection_data.sessions.iter().all(|session| session.token != token));
+    }
+
+    #[tokio::test]
+    async fn terminate_session_promotes_soft_stream_after_releasing_capacity() {
+        let config = Config::default();
+        let geoip = Arc::new(ArcSwapOption::<GeoIp>::default());
+        let event_manager = Arc::new(EventManager::new());
+        let manager = ActiveUserManager::new(&config, &geoip, &event_manager);
+
+        let normal_addr: SocketAddr = "127.0.0.1:55413".parse().unwrap();
+        let soft_addr: SocketAddr = "127.0.0.1:55414".parse().unwrap();
+        let soft_addr_two: SocketAddr = "127.0.0.1:55415".parse().unwrap();
+        let normal_fp = Fingerprint::new("fp-terminate-normal".to_string(), "127.0.0.1".to_string(), normal_addr);
+        let soft_fp = Fingerprint::new("fp-terminate-soft".to_string(), "127.0.0.1".to_string(), soft_addr);
+        let soft_fp_two = Fingerprint::new("fp-terminate-soft-2".to_string(), "127.0.0.1".to_string(), soft_addr_two);
+        let mut user = ProxyUserCredentials::default();
+        user.username = "user-terminate-promote".to_string();
+        user.max_connections = 1;
+        user.soft_connections = 2;
+
+        manager.add_connection(&normal_addr).await;
+        manager.add_connection(&soft_addr).await;
+        manager.add_connection(&soft_addr_two).await;
+
+        let normal_token = manager
+            .create_user_session(CreateUserSessionParams {
+                user: &user,
+                session_token: "tok-terminate-normal",
+                virtual_id: 8101,
+                provider: "provider-normal",
+                stream_url: "http://localhost/normal.ts",
+                addr: &normal_addr,
+                connection_permission: UserConnectionPermission::Allowed,
+                connection_kind: Some(ConnectionKind::Normal),
+                socket_bound: false,
+            })
+            .await;
+        let soft_token = manager
+            .create_user_session(CreateUserSessionParams {
+                user: &user,
+                session_token: "tok-terminate-soft",
+                virtual_id: 8102,
+                provider: "provider-soft",
+                stream_url: "http://localhost/soft.ts",
+                addr: &soft_addr,
+                connection_permission: UserConnectionPermission::Allowed,
+                connection_kind: Some(ConnectionKind::Soft),
+                socket_bound: false,
+            })
+            .await;
+        let soft_token_two = manager
+            .create_user_session(CreateUserSessionParams {
+                user: &user,
+                session_token: "tok-terminate-soft-2",
+                virtual_id: 8103,
+                provider: "provider-soft-2",
+                stream_url: "http://localhost/soft-2.ts",
+                addr: &soft_addr_two,
+                connection_permission: UserConnectionPermission::Allowed,
+                connection_kind: Some(ConnectionKind::Soft),
+                socket_bound: false,
+            })
+            .await;
+
+        manager
+            .update_connection(ActiveUserConnectionParams {
+                uid: 8101,
+                meter_uid: 0,
+                username: &user.username,
+                max_connections: user.max_connections,
+                soft_connections: user.soft_connections,
+                connection_kind: ConnectionKind::Normal,
+                priority: 0,
+                soft_priority: 0,
+                fingerprint: &normal_fp,
+                provider: "provider-normal".intern(),
+                stream_channel: &test_channel(8101),
+                user_agent: Cow::Borrowed("ua-normal"),
+                session_token: Some(&normal_token),
+            })
+            .await
+            .expect("normal stream should be registered");
+        manager
+            .update_connection(ActiveUserConnectionParams {
+                uid: 8102,
+                meter_uid: 0,
+                username: &user.username,
+                max_connections: user.max_connections,
+                soft_connections: user.soft_connections,
+                connection_kind: ConnectionKind::Soft,
+                priority: -5,
+                soft_priority: 9,
+                fingerprint: &soft_fp,
+                provider: "provider-soft".intern(),
+                stream_channel: &test_channel(8102),
+                user_agent: Cow::Borrowed("ua-soft"),
+                session_token: Some(&soft_token),
+            })
+            .await
+            .expect("soft stream should be registered");
+        manager
+            .update_connection(ActiveUserConnectionParams {
+                uid: 8103,
+                meter_uid: 0,
+                username: &user.username,
+                max_connections: user.max_connections,
+                soft_connections: user.soft_connections,
+                connection_kind: ConnectionKind::Soft,
+                priority: -3,
+                soft_priority: 9,
+                fingerprint: &soft_fp_two,
+                provider: "provider-soft-2".intern(),
+                stream_channel: &test_channel(8103),
+                user_agent: Cow::Borrowed("ua-soft-2"),
+                session_token: Some(&soft_token_two),
+            })
+            .await
+            .expect("second soft stream should be registered");
+
+        {
+            let mut connections = manager.connections.write().await;
+            let connection_data = connections
+                .by_key
+                .get_mut(&user.username)
+                .expect("user data should exist");
+            connection_data.soft_connections = 1;
+        }
+
+        manager.terminate_session(&user.username, &normal_token).await;
+
+        let connections = manager.connections.read().await;
+        let connection_data = connections
+            .by_key
+            .get(&user.username)
+            .expect("user data should remain inspectable");
+        assert_eq!(connection_data.counts.normal, 1);
+        assert_eq!(connection_data.counts.soft, 1);
+        let promoted_uid = [8102_u32, 8103_u32]
+            .into_iter()
+            .find(|uid| connection_data.stream_kinds.get(uid) == Some(&ConnectionKind::Normal))
+            .expect("one soft stream should be promoted to normal");
+        let promoted_token = if promoted_uid == 8102 {
+            soft_token.as_str()
+        } else {
+            soft_token_two.as_str()
+        };
+        let promoted_session = connection_data
+            .sessions
+            .iter()
+            .find(|session| session.token == promoted_token)
+            .expect("promoted soft session should remain");
+        assert_eq!(promoted_session.connection_kind, Some(ConnectionKind::Normal));
+        assert!(matches!(promoted_session.lifecycle, PlaybackLifecycle::Active));
     }
 
     #[tokio::test]


### PR DESCRIPTION
fix hls stream session

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session cleanup on HLS manifest download failures to ensure resources are released and sessions are terminated correctly.
  * Fixed removal and lease accounting for preserved adaptive streams to prevent mismatches and stale state.
  * Made session termination more reliable when removing streams tied to a session.

* **Refactor**
  * Consolidated internal session cleanup logic for greater consistency and efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->