### PR TITLE
feat: add remote media input foundations

### DIFF
--- a/backend/src/api/endpoints/api_playlist_utils.rs
+++ b/backend/src/api/endpoints/api_playlist_utils.rs
@@ -148,6 +148,13 @@ pub(in crate::api::endpoints) async fn get_playlist_for_custom_provider(
                     )
                         .into_response();
                 }
+                InputType::Emby | InputType::Jellyfin | InputType::Plex => {
+                    return (
+                        axum::http::StatusCode::BAD_REQUEST,
+                        axum::Json(json!({ "error": "Remote media-server inputs are not supported on this endpoint yet"})),
+                    )
+                        .into_response();
+                }
             };
             if result.is_empty() {
                 let error_strings: Vec<String> = errors.iter().map(ToString::to_string).collect();

--- a/backend/src/api/model/metadata_update_manager.rs
+++ b/backend/src/api/model/metadata_update_manager.rs
@@ -4260,6 +4260,23 @@ mod tests {
     }
 
     #[test]
+    fn task_needs_provider_connection_skips_remote_media_probe_stream() {
+        let task = UpdateTask::ProbeStream {
+            probe_scope: Arc::from("input_remote"),
+            unique_id: "u1".to_string(),
+            url: "http://example.com/stream.mkv".to_string(),
+            item_type: PlaylistItemType::Video,
+            reason: ResolveReason::MissingDetails.into(),
+            delay: 0,
+        };
+
+        for input_type in [InputType::Emby, InputType::Jellyfin, InputType::Plex] {
+            assert!(!InputWorker::task_needs_provider_connection(&task, input_type));
+        }
+        assert!(InputWorker::task_needs_provider_connection(&task, InputType::M3u));
+    }
+
+    #[test]
     fn task_needs_provider_connection_keeps_non_library_probe_stream() {
         let task = UpdateTask::ProbeStream {
             probe_scope: Arc::from("input_a"),

--- a/backend/src/api/model/metadata_update_manager.rs
+++ b/backend/src/api/model/metadata_update_manager.rs
@@ -3343,8 +3343,10 @@ impl InputWorker {
     fn task_needs_provider_connection(task: &UpdateTask, input_type: InputType) -> bool {
         match task {
             UpdateTask::ProbeLive { .. } => true,
-            // Local library probing is fully local and must not depend on provider capacity.
-            UpdateTask::ProbeStream { .. } => !matches!(input_type, InputType::Library),
+            // Local library and remote media-server probing must not depend on IPTV provider capacity.
+            UpdateTask::ProbeStream { .. } => {
+                !(matches!(input_type, InputType::Library) || input_type.is_remote_media_server())
+            },
             // Resolve tasks handle their own probe connection acquisition internally.
             // This avoids holding a provider connection for the entire duration of
             // info fetch + TMDB resolve + probe, reducing "provider exhausted" errors.

--- a/backend/src/api/model/provider_lineup_manager.rs
+++ b/backend/src/api/model/provider_lineup_manager.rs
@@ -1039,6 +1039,7 @@ mod tests {
             input_type: InputType::Xtream, // You can use a default value here
             max_connections,
             priority,
+            remote: None,
             aliases: None,
             headers: HashMap::default(),
             options: None,

--- a/backend/src/model/config/input.rs
+++ b/backend/src/model/config/input.rs
@@ -11,8 +11,8 @@ use shared::model::{
     RemoteMediaInputConfigDto, RemotePlaybackConfigDto, StagedInputDto, XtreamCluster,
 };
 use shared::utils::{
-    get_credentials_from_url, parse_provider_scheme_url_parts, sanitize_sensitive_info, Internable, BATCH_SCHEME_PREFIX,
-    PROVIDER_SCHEME_PREFIX,
+    get_credentials_from_url, is_non_blank_optional_string, parse_provider_scheme_url_parts, sanitize_sensitive_info,
+    Internable, BATCH_SCHEME_PREFIX, PROVIDER_SCHEME_PREFIX,
 };
 use shared::{check_input_connections, write_if_some};
 use shared::{check_input_credentials, concat_string };
@@ -159,10 +159,6 @@ impl RemoteMediaInputConfig {
             || is_non_blank_optional_string(&self.machine_id)
             || is_non_blank_optional_string(&self.server_name)
     }
-}
-
-fn is_non_blank_optional_string(value: &Option<String>) -> bool {
-    value.as_ref().is_some_and(|value| !value.trim().is_empty())
 }
 
 pub struct InputUserInfo {

--- a/backend/src/model/config/input.rs
+++ b/backend/src/model/config/input.rs
@@ -5,8 +5,15 @@ use log::warn;
 use shared::foundation::Filter;
 use shared::{apply_flags, create_bitset};
 use shared::error::TuliproxError;
-use shared::model::{ClusterSource, ConfigInputAliasDto, ConfigInputDto, ConfigInputOptionsDto, InputFetchMethod, InputType, StagedInputDto, XtreamCluster};
-use shared::utils::{get_credentials_from_url, parse_provider_scheme_url_parts, sanitize_sensitive_info, Internable, PROVIDER_SCHEME_PREFIX};
+use shared::model::{
+    ClusterSource, ConfigInputAliasDto, ConfigInputDto, ConfigInputOptionsDto, InputFetchMethod, InputType,
+    RemoteCatalogConfigDto, RemoteEnrichmentConfigDto, RemoteImagePolicyDto, RemoteLibrarySelectorDto,
+    RemoteMediaInputConfigDto, RemotePlaybackConfigDto, StagedInputDto, XtreamCluster,
+};
+use shared::utils::{
+    get_credentials_from_url, parse_provider_scheme_url_parts, sanitize_sensitive_info, Internable, BATCH_SCHEME_PREFIX,
+    PROVIDER_SCHEME_PREFIX,
+};
 use shared::{check_input_connections, write_if_some};
 use shared::{check_input_credentials, concat_string };
 use std::borrow::Cow;
@@ -98,6 +105,55 @@ impl From<&ConfigInputOptionsDto> for ConfigInputOptions {
 
 static DEFAULT_CONFIG_INPUT_OPTIONS: LazyLock<ConfigInputOptions> =
     LazyLock::new(|| ConfigInputOptions::from(&ConfigInputOptionsDto::default()));
+
+#[derive(Debug, Clone)]
+pub struct RemoteMediaInputConfig {
+    pub libraries: Vec<RemoteLibrarySelectorDto>,
+    pub catalog: RemoteCatalogConfigDto,
+    pub playback: RemotePlaybackConfigDto,
+    pub enrichment: RemoteEnrichmentConfigDto,
+    pub image_policy: RemoteImagePolicyDto,
+    pub token: Option<String>,
+    pub api_key: Option<String>,
+    pub user_id: Option<String>,
+    pub account_token: Option<String>,
+    pub server_id: Option<String>,
+    pub machine_id: Option<String>,
+    pub server_name: Option<String>,
+    pub prefer_https: bool,
+    pub allow_relay: bool,
+}
+
+impl From<&RemoteMediaInputConfigDto> for RemoteMediaInputConfig {
+    fn from(dto: &RemoteMediaInputConfigDto) -> Self {
+        Self {
+            libraries: dto.libraries.clone(),
+            catalog: dto.catalog.clone(),
+            playback: dto.playback.clone(),
+            enrichment: dto.enrichment.clone(),
+            image_policy: dto.image_policy,
+            token: dto.token.clone(),
+            api_key: dto.api_key.clone(),
+            user_id: dto.user_id.clone(),
+            account_token: dto.account_token.clone(),
+            server_id: dto.server_id.clone(),
+            machine_id: dto.machine_id.clone(),
+            server_name: dto.server_name.clone(),
+            prefer_https: dto.prefer_https,
+            allow_relay: dto.allow_relay,
+        }
+    }
+}
+
+impl RemoteMediaInputConfig {
+    pub fn has_any_emby_jellyfin_auth(&self) -> bool { self.token.is_some() || self.api_key.is_some() }
+
+    pub fn has_any_plex_token(&self) -> bool { self.account_token.is_some() || self.token.is_some() }
+
+    pub fn has_plex_server_selector(&self) -> bool {
+        self.server_id.is_some() || self.machine_id.is_some() || self.server_name.is_some()
+    }
+}
 
 pub struct InputUserInfo {
     pub base_url: String,
@@ -254,6 +310,7 @@ pub struct ConfigInput {
     pub persist: Option<String>,
     pub enabled: bool,
     pub options: Option<ConfigInputOptions>,
+    pub remote: Option<RemoteMediaInputConfig>,
     pub aliases: Option<Vec<ConfigInputAlias>>,
     pub priority: i16,
     pub max_connections: u16,
@@ -434,6 +491,110 @@ impl ConfigInput {
         self.options.as_ref().map_or(default, |o| o.has_all_flags(flags))
     }
 
+    fn prepare_remote_media_input(&self) -> Result<(), TuliproxError> {
+        if !self.input_type.is_remote_media_server() {
+            return Ok(());
+        }
+
+        if self.url.starts_with(BATCH_SCHEME_PREFIX) || self.url.starts_with(PROVIDER_SCHEME_PREFIX) {
+            return Err(TuliproxError::ConfigInput(format!(
+                "remote media-server input does not support batch:// or provider:// URLs (input: {})",
+                self.name
+            )));
+        }
+        if self.aliases.as_ref().is_some_and(|aliases| !aliases.is_empty()) {
+            return Err(TuliproxError::ConfigInput(format!(
+                "remote media-server input does not support aliases (input: {})",
+                self.name
+            )));
+        }
+        if self.staged.as_ref().is_some_and(|staged| staged.enabled) {
+            return Err(TuliproxError::ConfigInput(format!(
+                "remote media-server input does not support staged inputs (input: {})",
+                self.name
+            )));
+        }
+        if self.epg.is_some() {
+            return Err(TuliproxError::ConfigInput(format!(
+                "remote media-server input does not support EPG configuration (input: {})",
+                self.name
+            )));
+        }
+        if self.panel_api.is_some() {
+            return Err(TuliproxError::ConfigInput(format!(
+                "remote media-server input does not support panel_api configuration (input: {})",
+                self.name
+            )));
+        }
+        if self.max_connections > 0 {
+            return Err(TuliproxError::ConfigInput(format!(
+                "remote media-server input uses remote.playback.max_streams instead of max_connections (input: {})",
+                self.name
+            )));
+        }
+
+        let Some(remote) = self.remote.as_ref() else {
+            return Err(TuliproxError::ConfigInput(format!(
+                "remote configuration is mandatory for input type {} (input: {})",
+                self.input_type, self.name
+            )));
+        };
+        if remote.libraries.is_empty() {
+            return Err(TuliproxError::ConfigInput(format!(
+                "remote media-server input requires at least one selected library (input: {})",
+                self.name
+            )));
+        }
+        if remote.catalog.page_size == 0 {
+            return Err(TuliproxError::ConfigInput(format!(
+                "remote catalog page_size must be greater than zero (input: {})",
+                self.name
+            )));
+        }
+        if remote.catalog.concurrency == 0 {
+            return Err(TuliproxError::ConfigInput(format!(
+                "remote catalog concurrency must be greater than zero (input: {})",
+                self.name
+            )));
+        }
+
+        match self.input_type {
+            InputType::Emby | InputType::Jellyfin => {
+                if self.url.trim().is_empty() {
+                    return Err(TuliproxError::ConfigInput(format!(
+                        "url is mandatory for input type {} (input: {})",
+                        self.input_type, self.name
+                    )));
+                }
+                let has_login = self.username.as_ref().is_some_and(|u| !u.trim().is_empty())
+                    && self.password.as_ref().is_some_and(|p| !p.trim().is_empty());
+                if !remote.has_any_emby_jellyfin_auth() && !has_login {
+                    return Err(TuliproxError::ConfigInput(format!(
+                        "remote input type {} requires remote token/api_key or username/password bootstrap credentials (input: {})",
+                        self.input_type, self.name
+                    )));
+                }
+            }
+            InputType::Plex => {
+                if !remote.has_any_plex_token() {
+                    return Err(TuliproxError::ConfigInput(format!(
+                        "remote input type plex requires remote.account_token or remote.token (input: {})",
+                        self.name
+                    )));
+                }
+                if !remote.has_plex_server_selector() {
+                    return Err(TuliproxError::ConfigInput(format!(
+                        "remote input type plex requires a server selector such as remote.machine_id, remote.server_id, or remote.server_name (input: {})",
+                        self.name
+                    )));
+                }
+            }
+            InputType::M3u | InputType::Xtream | InputType::M3uBatch | InputType::XtreamBatch | InputType::Library => {}
+        }
+
+        Ok(())
+    }
+
     pub fn prepare(&mut self, provider_configs: &[Arc<ConfigProvider>]) -> Result<Option<PathBuf>, TuliproxError> {
         // Defensive fallback: From<&ConfigInputDto> for ConfigInput sets options, but ConfigInput can
         // still be built via Default::default(), batch/internal/test paths, so prepare() normalizes
@@ -451,6 +612,10 @@ impl ConfigInput {
         let mut used_provider_configs: Vec<Arc<ConfigProvider>> = vec![];
         let batch_file_path = self.prepare_batch();
         self.name = self.name.trim().intern();
+
+        if self.enabled {
+            self.prepare_remote_media_input()?;
+        }
 
         if self.url.starts_with(PROVIDER_SCHEME_PREFIX) {
             let provider_cfg = Self::resolve_provider_config(&self.url, provider_configs)?;
@@ -557,6 +722,7 @@ impl ConfigInput {
             persist: self.persist.clone(),
             enabled: self.enabled,
             options: self.options.clone(),
+            remote: self.remote.clone(),
             aliases: None,
             priority: alias.priority,
             max_connections: alias.max_connections,
@@ -644,6 +810,7 @@ impl From<&ConfigInputDto> for ConfigInput {
             persist: dto.persist.clone(),
             enabled: dto.enabled,
             options: Some(options),
+            remote: dto.remote.as_ref().map(RemoteMediaInputConfig::from),
             aliases: dto.aliases.as_ref().map(|list| list.iter().map(ConfigInputAlias::from).collect()),
             priority: dto.priority,
             max_connections: dto.max_connections,
@@ -754,6 +921,94 @@ mod tests {
     use shared::model::{ConfigProviderDto, ProviderUrlSelectionPolicy};
     use std::borrow::Cow;
     use std::sync::Arc;
+
+    fn remote_config_with_library() -> RemoteMediaInputConfig {
+        RemoteMediaInputConfig::from(&RemoteMediaInputConfigDto {
+            libraries: vec![RemoteLibrarySelectorDto::Name("Movies".to_string())],
+            ..RemoteMediaInputConfigDto::default()
+        })
+    }
+
+    #[test]
+    fn remote_media_runtime_mapping_preserves_safe_defaults() {
+        let dto = ConfigInputDto {
+            name: "emby_remote".into(),
+            input_type: InputType::Emby,
+            url: "https://media.example.invalid".to_string(),
+            remote: Some(RemoteMediaInputConfigDto {
+                token: Some("token".to_string()),
+                ..RemoteMediaInputConfigDto {
+                    libraries: vec![RemoteLibrarySelectorDto::Name("Movies".to_string())],
+                    ..RemoteMediaInputConfigDto::default()
+                }
+            }),
+            ..ConfigInputDto::default()
+        };
+
+        let input = ConfigInput::from(&dto);
+        let remote = input.remote.expect("remote config should map to runtime");
+
+        assert_eq!(remote.catalog.page_size, 100);
+        assert_eq!(remote.catalog.concurrency, 1);
+        assert!(remote.playback.direct_play_only);
+        assert!(!remote.playback.allow_transcode);
+        assert!(!remote.enrichment.ffprobe);
+        assert_eq!(remote.token.as_deref(), Some("token"));
+    }
+
+    #[test]
+    fn prepare_accepts_plex_remote_without_input_url() {
+        let mut input = ConfigInput {
+            name: "plex_remote".into(),
+            input_type: InputType::Plex,
+            remote: Some(RemoteMediaInputConfig {
+                account_token: Some("token".to_string()),
+                machine_id: Some("machine".to_string()),
+                ..remote_config_with_library()
+            }),
+            enabled: true,
+            ..Default::default()
+        };
+
+        input.prepare(&[]).expect("plex discovery config should prepare without input.url");
+    }
+
+    #[test]
+    fn prepare_rejects_remote_max_connections() {
+        let mut input = ConfigInput {
+            name: "emby_remote".into(),
+            input_type: InputType::Emby,
+            url: "https://media.example.invalid".to_string(),
+            remote: Some(RemoteMediaInputConfig {
+                token: Some("token".to_string()),
+                ..remote_config_with_library()
+            }),
+            max_connections: 1,
+            enabled: true,
+            ..Default::default()
+        };
+
+        let err = input.prepare(&[]).expect_err("remote max_connections should be rejected");
+        assert!(err.to_string().contains("remote.playback.max_streams"));
+    }
+
+    #[test]
+    fn prepare_rejects_remote_provider_url() {
+        let mut input = ConfigInput {
+            name: "emby_remote".into(),
+            input_type: InputType::Emby,
+            url: "provider://media-server".to_string(),
+            remote: Some(RemoteMediaInputConfig {
+                token: Some("token".to_string()),
+                ..remote_config_with_library()
+            }),
+            enabled: true,
+            ..Default::default()
+        };
+
+        let err = input.prepare(&[]).expect_err("remote provider URLs should be rejected");
+        assert!(err.to_string().contains("does not support batch:// or provider://"));
+    }
 
     #[test]
     fn test_resolve_url_normal() {

--- a/backend/src/model/config/input.rs
+++ b/backend/src/model/config/input.rs
@@ -567,12 +567,6 @@ impl ConfigInput {
                 self.name
             )));
         }
-        if remote.playback.max_streams == 0 {
-            return Err(TuliproxError::ConfigInput(format!(
-                "remote playback max_streams must be greater than zero (input: {})",
-                self.name
-            )));
-        }
 
         match self.input_type {
             InputType::Emby | InputType::Jellyfin => {
@@ -1022,7 +1016,7 @@ mod tests {
     }
 
     #[test]
-    fn prepare_rejects_remote_playback_max_streams_zero() {
+    fn prepare_accepts_remote_playback_max_streams_zero_as_unlimited() {
         let mut input = ConfigInput {
             name: "emby_remote".into(),
             input_type: InputType::Emby,
@@ -1036,8 +1030,8 @@ mod tests {
             ..Default::default()
         };
 
-        let err = input.prepare(&[]).expect_err("zero remote max_streams should be rejected");
-        assert!(err.to_string().contains("remote playback max_streams must be greater than zero"));
+        input.prepare(&[]).expect("zero remote max_streams means unlimited");
+        assert_eq!(input.remote.as_ref().expect("remote config").playback.max_streams, 0);
     }
 
     #[test]

--- a/backend/src/model/config/input.rs
+++ b/backend/src/model/config/input.rs
@@ -146,13 +146,23 @@ impl From<&RemoteMediaInputConfigDto> for RemoteMediaInputConfig {
 }
 
 impl RemoteMediaInputConfig {
-    pub fn has_any_emby_jellyfin_auth(&self) -> bool { self.token.is_some() || self.api_key.is_some() }
+    pub fn has_any_emby_jellyfin_auth(&self) -> bool {
+        is_non_blank_optional_string(&self.token) || is_non_blank_optional_string(&self.api_key)
+    }
 
-    pub fn has_any_plex_token(&self) -> bool { self.account_token.is_some() || self.token.is_some() }
+    pub fn has_any_plex_token(&self) -> bool {
+        is_non_blank_optional_string(&self.account_token) || is_non_blank_optional_string(&self.token)
+    }
 
     pub fn has_plex_server_selector(&self) -> bool {
-        self.server_id.is_some() || self.machine_id.is_some() || self.server_name.is_some()
+        is_non_blank_optional_string(&self.server_id)
+            || is_non_blank_optional_string(&self.machine_id)
+            || is_non_blank_optional_string(&self.server_name)
     }
+}
+
+fn is_non_blank_optional_string(value: &Option<String>) -> bool {
+    value.as_ref().is_some_and(|value| !value.trim().is_empty())
 }
 
 pub struct InputUserInfo {
@@ -554,6 +564,12 @@ impl ConfigInput {
         if remote.catalog.concurrency == 0 {
             return Err(TuliproxError::ConfigInput(format!(
                 "remote catalog concurrency must be greater than zero (input: {})",
+                self.name
+            )));
+        }
+        if remote.playback.max_streams == 0 {
+            return Err(TuliproxError::ConfigInput(format!(
+                "remote playback max_streams must be greater than zero (input: {})",
                 self.name
             )));
         }
@@ -971,6 +987,57 @@ mod tests {
         };
 
         input.prepare(&[]).expect("plex discovery config should prepare without input.url");
+    }
+
+    #[test]
+    fn prepare_rejects_blank_remote_credentials_and_selectors() {
+        let mut emby = ConfigInput {
+            name: "emby_remote".into(),
+            input_type: InputType::Emby,
+            url: "https://media.example.invalid".to_string(),
+            remote: Some(RemoteMediaInputConfig {
+                token: Some("   ".to_string()),
+                api_key: Some("".to_string()),
+                ..remote_config_with_library()
+            }),
+            enabled: true,
+            ..Default::default()
+        };
+        let err = emby.prepare(&[]).expect_err("blank token/api_key should be rejected");
+        assert!(err.to_string().contains("requires remote token/api_key"));
+
+        let mut plex = ConfigInput {
+            name: "plex_remote".into(),
+            input_type: InputType::Plex,
+            remote: Some(RemoteMediaInputConfig {
+                account_token: Some("   ".to_string()),
+                server_id: Some("   ".to_string()),
+                ..remote_config_with_library()
+            }),
+            enabled: true,
+            ..Default::default()
+        };
+        let err = plex.prepare(&[]).expect_err("blank plex token should be rejected");
+        assert!(err.to_string().contains("requires remote.account_token or remote.token"));
+    }
+
+    #[test]
+    fn prepare_rejects_remote_playback_max_streams_zero() {
+        let mut input = ConfigInput {
+            name: "emby_remote".into(),
+            input_type: InputType::Emby,
+            url: "https://media.example.invalid".to_string(),
+            remote: Some(RemoteMediaInputConfig {
+                token: Some("token".to_string()),
+                playback: RemotePlaybackConfigDto { max_streams: 0, ..RemotePlaybackConfigDto::default() },
+                ..remote_config_with_library()
+            }),
+            enabled: true,
+            ..Default::default()
+        };
+
+        let err = input.prepare(&[]).expect_err("zero remote max_streams should be rejected");
+        assert!(err.to_string().contains("remote playback max_streams must be greater than zero"));
     }
 
     #[test]

--- a/backend/src/modules.rs
+++ b/backend/src/modules.rs
@@ -11,6 +11,7 @@ macro_rules! include_modules {
         pub mod model;
         pub mod processing;
         pub mod ptt;
+        pub mod remote_media;
         pub mod repository;
         pub mod runtime_config_report;
         pub mod utils;

--- a/backend/src/processing/processor/playlist.rs
+++ b/backend/src/processing/processor/playlist.rs
@@ -507,6 +507,16 @@ async fn playlist_download_from_input(
                 let (p, e) = library::download_library_playlist(client, app_config, input).await;
                 (p, e, false, 0, 0)
             }
+            InputType::Emby | InputType::Jellyfin | InputType::Plex => (
+                vec![],
+                vec![TuliproxError::Download(format!(
+                    "remote media-server input '{}' is configured but catalog import is not implemented yet",
+                    input.name
+                ))],
+                false,
+                0,
+                0,
+            ),
         }
     };
 

--- a/backend/src/processing/processor/stream_probe.rs
+++ b/backend/src/processing/processor/stream_probe.rs
@@ -58,7 +58,7 @@ pub enum GenericProbeMetadataOutcome {
 }
 
 fn requires_provider_connection_for_generic_probe(input_type: InputType) -> bool {
-    !matches!(input_type, InputType::Library)
+    !(matches!(input_type, InputType::Library) || input_type.is_remote_media_server())
 }
 
 fn uses_seekable_remote_probe(item_type: PlaylistItemType, is_remote_probe: bool) -> bool {
@@ -183,13 +183,14 @@ async fn prepare_generic_stream_metadata(
                 XtreamCluster::Series
             } else {
                 // Generic probing currently supports live/video/series payload shapes.
-            return Ok(PreparedGenericProbeOutcome::Noop);
+                return Ok(PreparedGenericProbeOutcome::Noop);
             };
             (
                 xtream_get_file_path(&storage_path, cluster),
                 ProbeStorageKind::Xtream,
             )
         }
+        InputType::Emby | InputType::Jellyfin | InputType::Plex => return Ok(PreparedGenericProbeOutcome::Noop),
     };
 
     if !db_path.exists() {

--- a/backend/src/remote_media/catalog.rs
+++ b/backend/src/remote_media/catalog.rs
@@ -1,0 +1,303 @@
+use crate::remote_media::{
+    RemoteEpisode, RemoteLibrary, RemoteLibraryKind, RemoteMediaCatalogClient, RemoteMediaError, RemoteMediaErrorKind,
+    RemoteMovie, RemotePage, RemotePageRequest,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteCatalogCursor {
+    pub library_id: String,
+    pub kind: RemoteLibraryKind,
+    pub start: usize,
+    pub limit: usize,
+    pub total: Option<usize>,
+    pub fetched: usize,
+}
+
+impl RemoteCatalogCursor {
+    pub fn from_page<T>(library: &RemoteLibrary, page: &RemotePage<T>) -> Self {
+        Self {
+            library_id: library.reference.library_id.to_string(),
+            kind: library.kind,
+            start: page.request.start,
+            limit: page.request.limit,
+            total: page.total,
+            fetched: page.item_count(),
+        }
+    }
+
+    pub fn is_stalled_before_end(&self) -> bool {
+        self.fetched == 0 && self.total.is_some_and(|total| self.start < total)
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct RemoteCatalogRefreshPolicy {
+    pub page_size: usize,
+}
+
+impl Default for RemoteCatalogRefreshPolicy {
+    fn default() -> Self { Self { page_size: 100 } }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RemoteCatalogSnapshot {
+    pub libraries: Vec<RemoteLibrary>,
+    pub movies: Vec<RemoteMovie>,
+    pub episodes: Vec<RemoteEpisode>,
+    pub unsupported_libraries: Vec<RemoteLibrary>,
+}
+
+impl RemoteCatalogSnapshot {
+    pub fn item_count(&self) -> usize { self.movies.len() + self.episodes.len() }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct RemoteCatalogCache {
+    trusted: Option<RemoteCatalogSnapshot>,
+}
+
+impl RemoteCatalogCache {
+    pub fn trusted(&self) -> Option<&RemoteCatalogSnapshot> { self.trusted.as_ref() }
+
+    pub fn publish(&mut self, snapshot: RemoteCatalogSnapshot) -> &RemoteCatalogSnapshot {
+        self.trusted = Some(snapshot);
+        self.trusted.as_ref().expect("snapshot was just published")
+    }
+
+    pub async fn refresh_or_retain<C>(
+        &mut self,
+        client: &C,
+        policy: RemoteCatalogRefreshPolicy,
+    ) -> RemoteCatalogRefreshOutcome
+    where
+        C: RemoteMediaCatalogClient,
+    {
+        match refresh_remote_catalog_complete_before_publish(client, policy).await {
+            Ok(snapshot) => {
+                self.publish(snapshot);
+                RemoteCatalogRefreshOutcome::Published
+            }
+            Err(error) => RemoteCatalogRefreshOutcome::Retained { error, retained: self.trusted.is_some() },
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemoteCatalogRefreshOutcome {
+    Published,
+    Retained { error: RemoteMediaError, retained: bool },
+}
+
+pub async fn refresh_remote_catalog_complete_before_publish<C>(
+    client: &C,
+    policy: RemoteCatalogRefreshPolicy,
+) -> Result<RemoteCatalogSnapshot, RemoteMediaError>
+where
+    C: RemoteMediaCatalogClient,
+{
+    if policy.page_size == 0 {
+        return Err(RemoteMediaError::new(RemoteMediaErrorKind::RemoteCatalogIncomplete)
+            .detail("remote catalog page_size must be greater than zero"));
+    }
+
+    let _server = client.discover().await?;
+    let libraries = client.list_libraries().await?;
+    let mut snapshot = RemoteCatalogSnapshot { libraries: libraries.clone(), ..RemoteCatalogSnapshot::default() };
+
+    for library in libraries {
+        match library.kind {
+            RemoteLibraryKind::Movies => {
+                let mut page_request = RemotePageRequest::new(0, policy.page_size);
+                loop {
+                    let page = client.list_movies(&library.reference, page_request).await?;
+                    validate_page_progress(&library, &page)?;
+                    let next_request = page.next_request();
+                    snapshot.movies.extend(page.items);
+                    let Some(next) = next_request else { break };
+                    page_request = next;
+                }
+            }
+            RemoteLibraryKind::TvShows => {
+                let mut page_request = RemotePageRequest::new(0, policy.page_size);
+                loop {
+                    let page = client.list_episodes(&library.reference, page_request).await?;
+                    validate_page_progress(&library, &page)?;
+                    let next_request = page.next_request();
+                    snapshot.episodes.extend(page.items);
+                    let Some(next) = next_request else { break };
+                    page_request = next;
+                }
+            }
+            RemoteLibraryKind::Unsupported => snapshot.unsupported_libraries.push(library),
+        }
+    }
+
+    Ok(snapshot)
+}
+
+fn validate_page_progress<T>(library: &RemoteLibrary, page: &RemotePage<T>) -> Result<(), RemoteMediaError> {
+    let cursor = RemoteCatalogCursor::from_page(library, page);
+    if cursor.is_stalled_before_end() {
+        return Err(RemoteMediaError::new(RemoteMediaErrorKind::RemoteCatalogPageStalled).detail(format!(
+            "remote catalog page stalled for library kind {:?} at start {}",
+            cursor.kind, cursor.start
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::remote_media::{
+        RemoteImageRef, RemoteLibraryRef, RemoteMediaServerKind, RemoteProviderIdHint, RemoteResourceResponse,
+        RemoteServerStatus, RemoteStreamRef,
+    };
+    use bytes::Bytes;
+    use reqwest::{header::HeaderMap, StatusCode};
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Default)]
+    struct MockRemoteCatalogClient {
+        movie_pages: Mutex<Vec<Result<RemotePage<RemoteMovie>, RemoteMediaError>>>,
+        episode_pages: Mutex<Vec<Result<RemotePage<RemoteEpisode>, RemoteMediaError>>>,
+        libraries: Vec<RemoteLibrary>,
+    }
+
+    impl MockRemoteCatalogClient {
+        fn with_libraries(libraries: Vec<RemoteLibrary>) -> Self {
+            Self { libraries, ..Self::default() }
+        }
+    }
+
+    impl RemoteMediaCatalogClient for MockRemoteCatalogClient {
+        async fn discover(&self) -> Result<RemoteServerStatus, RemoteMediaError> {
+            Ok(RemoteServerStatus {
+                kind: RemoteMediaServerKind::Emby,
+                server_id: "server-redacted".into(),
+                display_name: None,
+                version: None,
+                owned: None,
+            })
+        }
+
+        async fn list_libraries(&self) -> Result<Vec<RemoteLibrary>, RemoteMediaError> { Ok(self.libraries.clone()) }
+
+        async fn list_movies(
+            &self,
+            _library: &RemoteLibraryRef,
+            _page: RemotePageRequest,
+        ) -> Result<RemotePage<RemoteMovie>, RemoteMediaError> {
+            self.movie_pages.lock().expect("lock").remove(0)
+        }
+
+        async fn list_episodes(
+            &self,
+            _library: &RemoteLibraryRef,
+            _page: RemotePageRequest,
+        ) -> Result<RemotePage<RemoteEpisode>, RemoteMediaError> {
+            self.episode_pages.lock().expect("lock").remove(0)
+        }
+
+        async fn open_stream(
+            &self,
+            _stream_ref: &RemoteStreamRef,
+            _range: Option<&str>,
+        ) -> Result<crate::remote_media::RemoteStreamResponse, RemoteMediaError> {
+            Ok(empty_response())
+        }
+
+        async fn open_image(
+            &self,
+            _image_ref: &RemoteImageRef,
+        ) -> Result<RemoteResourceResponse, RemoteMediaError> {
+            Ok(empty_response())
+        }
+    }
+
+    fn empty_response() -> RemoteResourceResponse {
+        RemoteResourceResponse { status: StatusCode::OK, headers: HeaderMap::new(), body: Bytes::new() }
+    }
+
+    fn movie_library() -> RemoteLibrary {
+        RemoteLibrary {
+            reference: RemoteLibraryRef {
+                input_name: "remote".into(),
+                server_id: "server".into(),
+                library_id: "movies".into(),
+            },
+            name: "Movies".into(),
+            kind: RemoteLibraryKind::Movies,
+        }
+    }
+
+    fn unsupported_library() -> RemoteLibrary {
+        RemoteLibrary { kind: RemoteLibraryKind::Unsupported, name: "Music".into(), ..movie_library() }
+    }
+
+    fn movie(id: &str) -> RemoteMovie {
+        RemoteMovie {
+            input_name: "remote".into(),
+            server_id: "server".into(),
+            library_id: "movies".into(),
+            item_id: Arc::<str>::from(id),
+            title: Arc::<str>::from("Movie Redacted"),
+            year: None,
+            source_version_hint: None,
+            provider_hints: Vec::<RemoteProviderIdHint>::new(),
+            stream_ref: None,
+            image_ref: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn incomplete_refresh_retains_previous_trusted_snapshot() {
+        let mut cache = RemoteCatalogCache::default();
+        cache.publish(RemoteCatalogSnapshot { movies: vec![movie("old")], ..RemoteCatalogSnapshot::default() });
+
+        let client = MockRemoteCatalogClient::with_libraries(vec![movie_library()]);
+        client.movie_pages.lock().expect("lock").extend([
+            Ok(RemotePage {
+                request: RemotePageRequest::new(0, 1),
+                total: Some(2),
+                items: vec![movie("new-1")],
+            }),
+            Err(RemoteMediaError::new(RemoteMediaErrorKind::RemoteServerUnavailable)),
+        ]);
+
+        let outcome = cache
+            .refresh_or_retain(&client, RemoteCatalogRefreshPolicy { page_size: 1 })
+            .await;
+
+        assert!(matches!(outcome, RemoteCatalogRefreshOutcome::Retained { retained: true, .. }));
+        assert_eq!(cache.trusted().expect("previous snapshot retained").movies[0].item_id.as_ref(), "old");
+    }
+
+    #[tokio::test]
+    async fn stalled_page_returns_stable_failure() {
+        let client = MockRemoteCatalogClient::with_libraries(vec![movie_library()]);
+        client.movie_pages.lock().expect("lock").push(Ok(RemotePage {
+            request: RemotePageRequest::new(0, 100),
+            total: Some(1),
+            items: vec![],
+        }));
+
+        let error = refresh_remote_catalog_complete_before_publish(&client, RemoteCatalogRefreshPolicy::default())
+            .await
+            .expect_err("stalled page should fail");
+
+        assert_eq!(error.kind, RemoteMediaErrorKind::RemoteCatalogPageStalled);
+    }
+
+    #[tokio::test]
+    async fn unsupported_library_kind_is_reported_and_not_coerced() {
+        let client = MockRemoteCatalogClient::with_libraries(vec![unsupported_library()]);
+
+        let snapshot = refresh_remote_catalog_complete_before_publish(&client, RemoteCatalogRefreshPolicy::default())
+            .await
+            .expect("unsupported library should be skipped safely");
+
+        assert_eq!(snapshot.item_count(), 0);
+        assert_eq!(snapshot.unsupported_libraries.len(), 1);
+    }
+}

--- a/backend/src/remote_media/catalog.rs
+++ b/backend/src/remote_media/catalog.rs
@@ -21,7 +21,7 @@ impl RemoteCatalogCursor {
             start: page.request.start,
             limit: page.request.limit,
             total: page.total,
-            fetched: page.item_count(),
+            fetched: page.upstream_item_count(),
         }
     }
 
@@ -257,11 +257,7 @@ mod tests {
 
         let client = MockRemoteCatalogClient::with_libraries(vec![movie_library()]);
         client.movie_pages.lock().expect("lock").extend([
-            Ok(RemotePage {
-                request: RemotePageRequest::new(0, 1),
-                total: Some(2),
-                items: vec![movie("new-1")],
-            }),
+            Ok(RemotePage::new(RemotePageRequest::new(0, 1), Some(2), vec![movie("new-1")])),
             Err(RemoteMediaError::new(RemoteMediaErrorKind::RemoteServerUnavailable)),
         ]);
 
@@ -276,11 +272,11 @@ mod tests {
     #[tokio::test]
     async fn stalled_page_returns_stable_failure() {
         let client = MockRemoteCatalogClient::with_libraries(vec![movie_library()]);
-        client.movie_pages.lock().expect("lock").push(Ok(RemotePage {
-            request: RemotePageRequest::new(0, 100),
-            total: Some(1),
-            items: vec![],
-        }));
+        client
+            .movie_pages
+            .lock()
+            .expect("lock")
+            .push(Ok(RemotePage::new(RemotePageRequest::new(0, 100), Some(1), vec![])));
 
         let error = refresh_remote_catalog_complete_before_publish(&client, RemoteCatalogRefreshPolicy::default())
             .await

--- a/backend/src/remote_media/client.rs
+++ b/backend/src/remote_media/client.rs
@@ -1,0 +1,94 @@
+use crate::remote_media::{
+    redaction::redact_remote_text, RemoteEpisode, RemoteImageRef, RemoteLibrary, RemoteLibraryRef, RemoteMediaError,
+    RemoteMovie, RemotePage, RemotePageRequest, RemoteResourceResponse, RemoteServerStatus, RemoteStreamRef,
+    RemoteStreamResponse,
+};
+use reqwest::{
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Method, RequestBuilder,
+};
+
+#[allow(async_fn_in_trait)]
+pub trait RemoteMediaCatalogClient: Send + Sync {
+    async fn discover(&self) -> Result<RemoteServerStatus, RemoteMediaError>;
+
+    async fn list_libraries(&self) -> Result<Vec<RemoteLibrary>, RemoteMediaError>;
+
+    async fn list_movies(
+        &self,
+        library: &RemoteLibraryRef,
+        page: RemotePageRequest,
+    ) -> Result<RemotePage<RemoteMovie>, RemoteMediaError>;
+
+    async fn list_episodes(
+        &self,
+        library: &RemoteLibraryRef,
+        page: RemotePageRequest,
+    ) -> Result<RemotePage<RemoteEpisode>, RemoteMediaError>;
+
+    async fn open_stream(
+        &self,
+        stream_ref: &RemoteStreamRef,
+        range: Option<&str>,
+    ) -> Result<RemoteStreamResponse, RemoteMediaError>;
+
+    async fn open_image(&self, image_ref: &RemoteImageRef) -> Result<RemoteResourceResponse, RemoteMediaError>;
+}
+
+#[derive(Clone)]
+pub struct RemoteHttpClient {
+    client: reqwest::Client,
+}
+
+impl RemoteHttpClient {
+    pub fn new(client: reqwest::Client) -> Self { Self { client } }
+
+    pub fn inner(&self) -> &reqwest::Client { &self.client }
+
+    pub fn request(&self, method: Method, url: &str) -> RemoteHttpRequestBuilder {
+        RemoteHttpRequestBuilder {
+            safe_url: redact_remote_text(url),
+            builder: self.client.request(method, url),
+        }
+    }
+}
+
+pub struct RemoteHttpRequestBuilder {
+    safe_url: String,
+    builder: RequestBuilder,
+}
+
+impl RemoteHttpRequestBuilder {
+    pub fn safe_url(&self) -> &str { &self.safe_url }
+
+    pub fn header(mut self, key: HeaderName, value: HeaderValue) -> Self {
+        self.builder = self.builder.header(key, value);
+        self
+    }
+
+    pub fn headers(mut self, headers: HeaderMap) -> Self {
+        self.builder = self.builder.headers(headers);
+        self
+    }
+
+    pub async fn send(self) -> Result<reqwest::Response, RemoteMediaError> {
+        self.builder
+            .send()
+            .await
+            .map_err(|err| RemoteMediaError::from_reqwest_error(&err).detail(format!("request {} failed", self.safe_url)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remote_http_request_builder_keeps_safe_url_redacted() {
+        let client = RemoteHttpClient::new(reqwest::Client::new());
+        let request = client.request(Method::GET, "https://media.example.invalid/video?api_key=secret");
+
+        assert!(!request.safe_url().contains("secret"));
+        assert!(request.safe_url().contains("api_key=<redacted>"));
+    }
+}

--- a/backend/src/remote_media/emby/dto.rs
+++ b/backend/src/remote_media/emby/dto.rs
@@ -1,0 +1,88 @@
+use serde::Deserialize;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "PascalCase")]
+pub struct EmbyPublicSystemInfoDto {
+    pub id: Option<String>,
+    pub server_name: Option<String>,
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "PascalCase", bound(deserialize = "T: Deserialize<'de>"))]
+pub struct EmbyItemsPageDto<T> {
+    #[serde(default)]
+    pub items: Vec<T>,
+    #[serde(default)]
+    pub total_record_count: usize,
+    #[serde(default)]
+    pub start_index: usize,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "PascalCase")]
+pub struct EmbyViewDto {
+    pub id: String,
+    pub name: Option<String>,
+    pub collection_type: Option<String>,
+    pub type_: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(rename_all = "PascalCase")]
+pub struct EmbyItemDto {
+    pub id: String,
+    pub name: Option<String>,
+    pub type_: Option<String>,
+    pub production_year: Option<u32>,
+    pub parent_id: Option<String>,
+    pub series_id: Option<String>,
+    pub series_name: Option<String>,
+    pub parent_index_number: Option<u32>,
+    pub index_number: Option<u32>,
+    #[serde(default)]
+    pub provider_ids: HashMap<String, String>,
+    #[serde(default)]
+    pub image_tags: HashMap<String, String>,
+    #[serde(default)]
+    pub media_sources: Vec<EmbyMediaSourceDto>,
+    // Parsed only so the boundary can explicitly ignore it by default.
+    pub path: Option<String>,
+    pub user_data: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(rename_all = "PascalCase")]
+pub struct EmbyMediaSourceDto {
+    pub id: Option<String>,
+    pub container: Option<String>,
+    pub path: Option<String>,
+    pub supports_direct_play: Option<bool>,
+    pub supports_direct_stream: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(rename_all = "PascalCase")]
+pub struct EmbyPlaybackInfoDto {
+    #[serde(default)]
+    pub media_sources: Vec<EmbyMediaSourceDto>,
+    pub play_session_id: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::remote_media::test_fixtures::EMBY_ITEMS_PAGE_JSON;
+
+    #[test]
+    fn parses_emby_item_page_and_keeps_edge_only_fields_at_boundary() {
+        let page: EmbyItemsPageDto<EmbyItemDto> = serde_json::from_str(EMBY_ITEMS_PAGE_JSON).expect("fixture parses");
+
+        assert_eq!(page.total_record_count, 1);
+        assert_eq!(page.items[0].id, "item-redacted-1");
+        assert_eq!(page.items[0].provider_ids.get("Tmdb").map(String::as_str), Some("12345"));
+        assert!(page.items[0].path.as_deref().is_some_and(|path| path.contains("/redacted/")));
+        assert!(page.items[0].user_data.is_some());
+    }
+}

--- a/backend/src/remote_media/emby/mod.rs
+++ b/backend/src/remote_media/emby/mod.rs
@@ -1,0 +1,1 @@
+pub mod dto;

--- a/backend/src/remote_media/errors.rs
+++ b/backend/src/remote_media/errors.rs
@@ -1,0 +1,135 @@
+use crate::remote_media::redaction::redact_remote_text;
+use reqwest::StatusCode;
+use std::{error::Error, fmt};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemoteMediaErrorKind {
+    RemoteAuthDenied,
+    RemoteServerUnavailable,
+    RemoteLibraryUnavailable,
+    RemoteLibraryTypeUnsupported,
+    RemoteCatalogDecodeFailed,
+    RemoteCatalogPageStalled,
+    RemoteCatalogIncomplete,
+    RemoteItemNotFound,
+    NoDirectPlayableRemoteSource,
+    RemoteStreamOpenFailed,
+    RemoteRateLimited,
+    ResourceDiscoveryFailed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteMediaError {
+    pub kind: RemoteMediaErrorKind,
+    pub provider: Option<&'static str>,
+    pub status: Option<StatusCode>,
+    detail: Option<String>,
+}
+
+impl RemoteMediaError {
+    pub fn new(kind: RemoteMediaErrorKind) -> Self {
+        Self {
+            kind,
+            provider: None,
+            status: None,
+            detail: None,
+        }
+    }
+
+    pub fn provider(mut self, provider: &'static str) -> Self {
+        self.provider = Some(provider);
+        self
+    }
+
+    pub fn status(mut self, status: StatusCode) -> Self {
+        self.status = Some(status);
+        self
+    }
+
+    pub fn detail(mut self, detail: impl AsRef<str>) -> Self {
+        let redacted = redact_remote_text(detail.as_ref());
+        if !redacted.trim().is_empty() {
+            self.detail = Some(redacted);
+        }
+        self
+    }
+
+    pub fn detail_text(&self) -> Option<&str> { self.detail.as_deref() }
+
+    pub fn from_http_status(status: StatusCode) -> Self {
+        let kind = if matches!(status, StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN) {
+            RemoteMediaErrorKind::RemoteAuthDenied
+        } else if status == StatusCode::TOO_MANY_REQUESTS {
+            RemoteMediaErrorKind::RemoteRateLimited
+        } else if status == StatusCode::NOT_FOUND {
+            RemoteMediaErrorKind::RemoteItemNotFound
+        } else {
+            RemoteMediaErrorKind::RemoteStreamOpenFailed
+        };
+        Self::new(kind).status(status)
+    }
+
+    pub fn from_reqwest_error(err: &reqwest::Error) -> Self {
+        let kind = if err.is_timeout() || err.is_connect() {
+            RemoteMediaErrorKind::RemoteServerUnavailable
+        } else if err.is_decode() {
+            RemoteMediaErrorKind::RemoteCatalogDecodeFailed
+        } else if let Some(status) = err.status() {
+            return Self::from_http_status(status).detail(err.to_string());
+        } else {
+            RemoteMediaErrorKind::RemoteStreamOpenFailed
+        };
+        Self::new(kind).detail(err.to_string())
+    }
+}
+
+impl fmt::Display for RemoteMediaError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.kind)?;
+        if let Some(provider) = self.provider {
+            write!(f, " provider={provider}")?;
+        }
+        if let Some(status) = self.status {
+            write!(f, " status={status}")?;
+        }
+        if let Some(detail) = self.detail.as_deref() {
+            write!(f, " detail={detail}")?;
+        }
+        Ok(())
+    }
+}
+
+impl Error for RemoteMediaError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn http_status_maps_to_stable_failure_kinds() {
+        assert_eq!(
+            RemoteMediaError::from_http_status(StatusCode::UNAUTHORIZED).kind,
+            RemoteMediaErrorKind::RemoteAuthDenied
+        );
+        assert_eq!(
+            RemoteMediaError::from_http_status(StatusCode::TOO_MANY_REQUESTS).kind,
+            RemoteMediaErrorKind::RemoteRateLimited
+        );
+        assert_eq!(
+            RemoteMediaError::from_http_status(StatusCode::NOT_FOUND).kind,
+            RemoteMediaErrorKind::RemoteItemNotFound
+        );
+    }
+
+    #[test]
+    fn detail_is_redacted_before_display() {
+        let err = RemoteMediaError::new(RemoteMediaErrorKind::RemoteStreamOpenFailed)
+            .provider("plex")
+            .detail("https://media.example.invalid/stream?X-Plex-Token=secret-token&api_key=secret-key");
+        let rendered = err.to_string();
+
+        assert!(!rendered.contains("secret-token"));
+        assert!(!rendered.contains("secret-key"));
+        assert!(rendered.contains("<redacted>"));
+    }
+}

--- a/backend/src/remote_media/jellyfin/dto.rs
+++ b/backend/src/remote_media/jellyfin/dto.rs
@@ -1,0 +1,26 @@
+//! Jellyfin uses Emby-compatible JSON shapes for the MVP endpoints Tuliprox needs.
+//!
+//! Keep aliases in this module so caller code still depends on a provider-specific
+//! seam and can diverge safely when Jellyfin fields differ.
+
+pub type JellyfinPublicSystemInfoDto = crate::remote_media::emby::dto::EmbyPublicSystemInfoDto;
+pub type JellyfinItemsPageDto<T> = crate::remote_media::emby::dto::EmbyItemsPageDto<T>;
+pub type JellyfinViewDto = crate::remote_media::emby::dto::EmbyViewDto;
+pub type JellyfinItemDto = crate::remote_media::emby::dto::EmbyItemDto;
+pub type JellyfinMediaSourceDto = crate::remote_media::emby::dto::EmbyMediaSourceDto;
+pub type JellyfinPlaybackInfoDto = crate::remote_media::emby::dto::EmbyPlaybackInfoDto;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::remote_media::test_fixtures::JELLYFIN_VIEWS_JSON;
+
+    #[test]
+    fn parses_jellyfin_views_through_provider_specific_aliases() {
+        let page: JellyfinItemsPageDto<JellyfinViewDto> = serde_json::from_str(JELLYFIN_VIEWS_JSON).expect("fixture parses");
+
+        assert_eq!(page.items.len(), 2);
+        assert_eq!(page.items[0].collection_type.as_deref(), Some("movies"));
+        assert_eq!(page.items[1].collection_type.as_deref(), Some("tvshows"));
+    }
+}

--- a/backend/src/remote_media/jellyfin/mod.rs
+++ b/backend/src/remote_media/jellyfin/mod.rs
@@ -1,0 +1,1 @@
+pub mod dto;

--- a/backend/src/remote_media/mod.rs
+++ b/backend/src/remote_media/mod.rs
@@ -1,0 +1,27 @@
+//! Remote media-server anti-corruption layer.
+//!
+//! This module keeps Emby/Jellyfin/Plex wire DTOs and transport concerns at the
+//! Source Acquisition boundary. Playlist Curation and Stream Brokerage should
+//! depend on the typed concepts exported here instead of provider-specific DTOs.
+
+pub mod catalog;
+pub mod client;
+pub mod emby;
+pub mod errors;
+pub mod jellyfin;
+pub mod playback;
+pub mod playlist_mapper;
+pub mod plex;
+pub mod redaction;
+pub mod types;
+
+#[cfg(test)]
+pub mod test_fixtures;
+
+pub use catalog::*;
+pub use client::*;
+pub use errors::*;
+pub use playback::*;
+pub use playlist_mapper::*;
+pub use redaction::*;
+pub use types::*;

--- a/backend/src/remote_media/playback.rs
+++ b/backend/src/remote_media/playback.rs
@@ -89,31 +89,31 @@ pub fn parse_remote_stream_ref(input_name: &Arc<str>, item_url: &str) -> Result<
             .detail("playlist item is not a remote media URL"));
     };
     let (path, query) = rest.split_once('?').unwrap_or((rest, ""));
-    let parts: Vec<&str> = path.split('/').collect();
+    let parts: Vec<String> = path.split('/').map(unescape_internal_url_component).collect();
     if parts.len() < 3 {
         return Err(RemoteMediaError::new(RemoteMediaErrorKind::RemoteStreamOpenFailed)
             .detail("remote media URL is missing required path parts"));
     }
 
-    match parts[0] {
+    match parts[0].as_str() {
         "emby" => Ok(RemoteStreamRef::Emby {
             input_name: input_name.clone(),
-            server_id: parts[1].into(),
-            item_id: parts[2].into(),
-            media_source_id: query_value(query, "media_source_id").map(|v| unescape_internal_url_component(&v).into()),
+            server_id: Arc::<str>::from(parts[1].as_str()),
+            item_id: Arc::<str>::from(parts[2].as_str()),
+            media_source_id: query_value(query, "media_source_id").map(Arc::<str>::from),
         }),
         "jellyfin" => Ok(RemoteStreamRef::Jellyfin {
             input_name: input_name.clone(),
-            server_id: parts[1].into(),
-            item_id: parts[2].into(),
-            media_source_id: query_value(query, "media_source_id").map(|v| unescape_internal_url_component(&v).into()),
+            server_id: Arc::<str>::from(parts[1].as_str()),
+            item_id: Arc::<str>::from(parts[2].as_str()),
+            media_source_id: query_value(query, "media_source_id").map(Arc::<str>::from),
         }),
         "plex" => Ok(RemoteStreamRef::Plex {
             input_name: input_name.clone(),
-            server_id: parts[1].into(),
-            rating_key: parts[2].into(),
+            server_id: Arc::<str>::from(parts[1].as_str()),
+            rating_key: Arc::<str>::from(parts[2].as_str()),
             part_key: query_value(query, "part_key")
-                .map(|v| unescape_internal_url_component(&v).into())
+                .map(Arc::<str>::from)
                 .ok_or_else(|| {
                     RemoteMediaError::new(RemoteMediaErrorKind::NoDirectPlayableRemoteSource)
                         .detail("plex remote URL is missing part_key")
@@ -125,25 +125,39 @@ pub fn parse_remote_stream_ref(input_name: &Arc<str>, item_url: &str) -> Result<
 }
 
 fn query_value(query: &str, key: &str) -> Option<String> {
-    query.split('&').find_map(|pair| {
-        let (name, value) = pair.split_once('=')?;
-        (name == key).then(|| value.to_string())
-    })
+    url::form_urlencoded::parse(query.as_bytes())
+        .find_map(|(name, value)| (name == key).then(|| value.into_owned()))
 }
 
 fn unescape_internal_url_component(value: &str) -> String {
-    let mut result = value.to_string();
-    for (encoded, decoded) in [
-        ("%2F", "/"),
-        ("%3F", "?"),
-        ("%26", "&"),
-        ("%3D", "="),
-        ("%23", "#"),
-        ("%25", "%"),
-    ] {
-        result = result.replace(encoded, decoded).replace(&encoded.to_ascii_lowercase(), decoded);
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let Some(byte) = decode_hex_byte(bytes[i + 1], bytes[i + 2]) {
+                decoded.push(byte);
+                i += 3;
+                continue;
+            }
+        }
+        decoded.push(bytes[i]);
+        i += 1;
     }
-    result
+    String::from_utf8_lossy(&decoded).into_owned()
+}
+
+fn decode_hex_byte(high: u8, low: u8) -> Option<u8> {
+    Some(hex_value(high)? << 4 | hex_value(low)?)
+}
+
+fn hex_value(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        b'A'..=b'F' => Some(value - b'A' + 10),
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -238,6 +252,21 @@ mod tests {
         let local = classify_playback_origin(InputType::Library, PlaylistItemType::LocalVideo, &input_name, "file:///tmp/a.mkv")
             .expect("local classifies");
         assert_eq!(local, PlaybackOrigin::LocalLibrary);
+
+        let encoded = parse_remote_stream_ref(
+            &input_name,
+            "remote://emby/server%2Fone/item%3Fone?media_source_id=media%2Fsource%3Fone",
+        )
+        .expect("encoded remote ref parses");
+        assert_eq!(
+            encoded,
+            RemoteStreamRef::Emby {
+                input_name: input_name.clone(),
+                server_id: "server/one".into(),
+                item_id: "item?one".into(),
+                media_source_id: Some("media/source?one".into()),
+            }
+        );
 
         let provider = classify_playback_origin(InputType::M3u, PlaylistItemType::Live, &input_name, "http://example.invalid/live")
             .expect("provider classifies");

--- a/backend/src/remote_media/playback.rs
+++ b/backend/src/remote_media/playback.rs
@@ -1,0 +1,266 @@
+use crate::remote_media::{
+    RemoteImageRef, RemoteMediaCatalogClient, RemoteMediaError, RemoteMediaErrorKind, RemoteResourceResponse, RemoteStreamRef,
+};
+use bytes::Bytes;
+use reqwest::{
+    header::{
+        HeaderMap, ACCEPT_RANGES, CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE, ETAG, LAST_MODIFIED,
+    },
+    StatusCode,
+};
+use shared::model::{InputType, PlaylistItemType};
+use std::sync::Arc;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlaybackOrigin {
+    Provider,
+    LocalLibrary,
+    RemoteMedia(RemoteStreamRef),
+}
+
+#[derive(Debug, Clone)]
+pub struct RemoteProxyResponse {
+    pub status: StatusCode,
+    pub headers: HeaderMap,
+    pub body: Bytes,
+}
+
+pub fn classify_playback_origin(
+    input_type: InputType,
+    item_type: PlaylistItemType,
+    input_name: &Arc<str>,
+    item_url: &str,
+) -> Result<PlaybackOrigin, RemoteMediaError> {
+    if input_type.is_remote_media_server() || item_url.starts_with("remote://") {
+        return parse_remote_stream_ref(input_name, item_url).map(PlaybackOrigin::RemoteMedia);
+    }
+
+    if matches!(item_type, PlaylistItemType::LocalVideo | PlaylistItemType::LocalSeries) {
+        return Ok(PlaybackOrigin::LocalLibrary);
+    }
+
+    Ok(PlaybackOrigin::Provider)
+}
+
+pub async fn remote_media_stream_response<C>(
+    client: &C,
+    stream_ref: &RemoteStreamRef,
+    range: Option<&str>,
+) -> Result<RemoteProxyResponse, RemoteMediaError>
+where
+    C: RemoteMediaCatalogClient,
+{
+    let response = client.open_stream(stream_ref, range).await?;
+    Ok(remote_resource_to_proxy_response(response))
+}
+
+pub async fn remote_media_image_response<C>(
+    client: &C,
+    image_ref: &RemoteImageRef,
+) -> Result<RemoteProxyResponse, RemoteMediaError>
+where
+    C: RemoteMediaCatalogClient,
+{
+    let response = client.open_image(image_ref).await?;
+    Ok(remote_resource_to_proxy_response(response))
+}
+
+fn remote_resource_to_proxy_response(response: RemoteResourceResponse) -> RemoteProxyResponse {
+    RemoteProxyResponse {
+        status: response.status,
+        headers: safe_remote_response_headers(&response.headers),
+        body: response.body,
+    }
+}
+
+pub fn safe_remote_response_headers(headers: &HeaderMap) -> HeaderMap {
+    let mut safe = HeaderMap::new();
+    for name in [CONTENT_TYPE, CONTENT_LENGTH, CONTENT_RANGE, ACCEPT_RANGES, ETAG, LAST_MODIFIED] {
+        if let Some(value) = headers.get(&name) {
+            safe.insert(name, value.clone());
+        }
+    }
+    safe
+}
+
+pub fn parse_remote_stream_ref(input_name: &Arc<str>, item_url: &str) -> Result<RemoteStreamRef, RemoteMediaError> {
+    let Some(rest) = item_url.strip_prefix("remote://") else {
+        return Err(RemoteMediaError::new(RemoteMediaErrorKind::RemoteStreamOpenFailed)
+            .detail("playlist item is not a remote media URL"));
+    };
+    let (path, query) = rest.split_once('?').unwrap_or((rest, ""));
+    let parts: Vec<&str> = path.split('/').collect();
+    if parts.len() < 3 {
+        return Err(RemoteMediaError::new(RemoteMediaErrorKind::RemoteStreamOpenFailed)
+            .detail("remote media URL is missing required path parts"));
+    }
+
+    match parts[0] {
+        "emby" => Ok(RemoteStreamRef::Emby {
+            input_name: input_name.clone(),
+            server_id: parts[1].into(),
+            item_id: parts[2].into(),
+            media_source_id: query_value(query, "media_source_id").map(|v| unescape_internal_url_component(&v).into()),
+        }),
+        "jellyfin" => Ok(RemoteStreamRef::Jellyfin {
+            input_name: input_name.clone(),
+            server_id: parts[1].into(),
+            item_id: parts[2].into(),
+            media_source_id: query_value(query, "media_source_id").map(|v| unescape_internal_url_component(&v).into()),
+        }),
+        "plex" => Ok(RemoteStreamRef::Plex {
+            input_name: input_name.clone(),
+            server_id: parts[1].into(),
+            rating_key: parts[2].into(),
+            part_key: query_value(query, "part_key")
+                .map(|v| unescape_internal_url_component(&v).into())
+                .ok_or_else(|| {
+                    RemoteMediaError::new(RemoteMediaErrorKind::NoDirectPlayableRemoteSource)
+                        .detail("plex remote URL is missing part_key")
+                })?,
+        }),
+        _ => Err(RemoteMediaError::new(RemoteMediaErrorKind::RemoteStreamOpenFailed)
+            .detail("unsupported remote media URL scheme")),
+    }
+}
+
+fn query_value(query: &str, key: &str) -> Option<String> {
+    query.split('&').find_map(|pair| {
+        let (name, value) = pair.split_once('=')?;
+        (name == key).then(|| value.to_string())
+    })
+}
+
+fn unescape_internal_url_component(value: &str) -> String {
+    let mut result = value.to_string();
+    for (encoded, decoded) in [
+        ("%2F", "/"),
+        ("%3F", "?"),
+        ("%26", "&"),
+        ("%3D", "="),
+        ("%23", "#"),
+        ("%25", "%"),
+    ] {
+        result = result.replace(encoded, decoded).replace(&encoded.to_ascii_lowercase(), decoded);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::remote_media::{
+        RemoteEpisode, RemoteLibrary, RemoteLibraryRef, RemoteMovie, RemotePage, RemotePageRequest,
+        RemoteServerStatus,
+    };
+    use reqwest::header::{HeaderValue, AUTHORIZATION};
+    use std::sync::{Mutex, Arc as StdArc};
+
+    #[derive(Default)]
+    struct MockPlaybackClient {
+        seen_range: Mutex<Option<String>>,
+        stream_error: Option<RemoteMediaError>,
+    }
+
+    impl RemoteMediaCatalogClient for MockPlaybackClient {
+        async fn discover(&self) -> Result<RemoteServerStatus, RemoteMediaError> { unreachable!() }
+        async fn list_libraries(&self) -> Result<Vec<RemoteLibrary>, RemoteMediaError> { unreachable!() }
+        async fn list_movies(
+            &self,
+            _library: &RemoteLibraryRef,
+            _page: RemotePageRequest,
+        ) -> Result<RemotePage<RemoteMovie>, RemoteMediaError> {
+            unreachable!()
+        }
+        async fn list_episodes(
+            &self,
+            _library: &RemoteLibraryRef,
+            _page: RemotePageRequest,
+        ) -> Result<RemotePage<RemoteEpisode>, RemoteMediaError> {
+            unreachable!()
+        }
+
+        async fn open_stream(
+            &self,
+            _stream_ref: &RemoteStreamRef,
+            range: Option<&str>,
+        ) -> Result<crate::remote_media::RemoteStreamResponse, RemoteMediaError> {
+            *self.seen_range.lock().expect("lock") = range.map(ToOwned::to_owned);
+            if let Some(error) = self.stream_error.clone() {
+                return Err(error);
+            }
+            let mut headers = HeaderMap::new();
+            headers.insert(CONTENT_TYPE, HeaderValue::from_static("video/mp4"));
+            headers.insert(CONTENT_RANGE, HeaderValue::from_static("bytes 0-1023/2048"));
+            headers.insert(CONTENT_LENGTH, HeaderValue::from_static("1024"));
+            headers.insert(ACCEPT_RANGES, HeaderValue::from_static("bytes"));
+            headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer should-not-leak"));
+            Ok(RemoteResourceResponse { status: StatusCode::PARTIAL_CONTENT, headers, body: Bytes::from_static(b"data") })
+        }
+
+        async fn open_image(&self, _image_ref: &RemoteImageRef) -> Result<RemoteResourceResponse, RemoteMediaError> {
+            Ok(RemoteResourceResponse { status: StatusCode::OK, headers: HeaderMap::new(), body: Bytes::new() })
+        }
+    }
+
+    #[tokio::test]
+    async fn remote_stream_response_forwards_range_and_filters_headers() {
+        let client = MockPlaybackClient::default();
+        let stream_ref = RemoteStreamRef::Plex {
+            input_name: "remote".into(),
+            server_id: "server".into(),
+            rating_key: "rating".into(),
+            part_key: "/library/parts/redacted/file.mkv".into(),
+        };
+
+        let response = remote_media_stream_response(&client, &stream_ref, Some("bytes=0-1023"))
+            .await
+            .expect("stream opens");
+
+        assert_eq!(client.seen_range.lock().expect("lock").as_deref(), Some("bytes=0-1023"));
+        assert_eq!(response.status, StatusCode::PARTIAL_CONTENT);
+        assert_eq!(response.headers.get(CONTENT_RANGE).and_then(|v| v.to_str().ok()), Some("bytes 0-1023/2048"));
+        assert!(response.headers.get(AUTHORIZATION).is_none());
+    }
+
+    #[test]
+    fn classifies_remote_local_and_provider_origins() {
+        let input_name = StdArc::<str>::from("remote");
+        let remote = classify_playback_origin(
+            InputType::Plex,
+            PlaylistItemType::Video,
+            &input_name,
+            "remote://plex/server/rating?part_key=%2Flibrary%2Fparts%2Fredacted%2Ffile.mkv",
+        )
+        .expect("remote parses");
+        assert!(matches!(remote, PlaybackOrigin::RemoteMedia(RemoteStreamRef::Plex { .. })));
+
+        let local = classify_playback_origin(InputType::Library, PlaylistItemType::LocalVideo, &input_name, "file:///tmp/a.mkv")
+            .expect("local classifies");
+        assert_eq!(local, PlaybackOrigin::LocalLibrary);
+
+        let provider = classify_playback_origin(InputType::M3u, PlaylistItemType::Live, &input_name, "http://example.invalid/live")
+            .expect("provider classifies");
+        assert_eq!(provider, PlaybackOrigin::Provider);
+    }
+
+    #[tokio::test]
+    async fn remote_auth_denied_stays_remote_error() {
+        let client = MockPlaybackClient {
+            stream_error: Some(RemoteMediaError::new(RemoteMediaErrorKind::RemoteAuthDenied)),
+            ..MockPlaybackClient::default()
+        };
+        let stream_ref = RemoteStreamRef::Emby {
+            input_name: "remote".into(),
+            server_id: "server".into(),
+            item_id: "item".into(),
+            media_source_id: None,
+        };
+
+        let error = remote_media_stream_response(&client, &stream_ref, None)
+            .await
+            .expect_err("auth denied should fail");
+
+        assert_eq!(error.kind, RemoteMediaErrorKind::RemoteAuthDenied);
+    }
+}

--- a/backend/src/remote_media/playlist_mapper.rs
+++ b/backend/src/remote_media/playlist_mapper.rs
@@ -6,7 +6,7 @@ use shared::{
     },
     utils::{generate_provider_playlist_uuid, Internable},
 };
-use std::sync::Arc;
+use std::{fmt::Write as _, sync::Arc};
 
 pub fn remote_catalog_snapshot_to_playlist(snapshot: &RemoteCatalogSnapshot) -> Vec<PlaylistGroup> {
     let mut groups = Vec::new();
@@ -38,7 +38,14 @@ fn remote_movie_to_playlist_item(movie: &RemoteMovie) -> PlaylistItem {
         .stream_ref
         .as_ref()
         .map(remote_stream_ref_to_internal_url)
-        .unwrap_or_else(|| format!("remote://{}/{}/{}", movie.server_id, movie.library_id, movie.item_id));
+        .unwrap_or_else(|| {
+            format!(
+                "remote://unavailable/{}/{}/{}",
+                escape_internal_url_component(&movie.server_id),
+                escape_internal_url_component(&movie.library_id),
+                escape_internal_url_component(&movie.item_id)
+            )
+        });
     let uuid = generate_provider_playlist_uuid(&movie.input_name, &stable_id, PlaylistItemType::Video);
 
     PlaylistItem {
@@ -80,7 +87,14 @@ fn remote_episode_to_playlist_item(episode: &RemoteEpisode) -> PlaylistItem {
         .stream_ref
         .as_ref()
         .map(remote_stream_ref_to_internal_url)
-        .unwrap_or_else(|| format!("remote://{}/{}/{}", episode.server_id, episode.library_id, episode.item_id));
+        .unwrap_or_else(|| {
+            format!(
+                "remote://unavailable/{}/{}/{}",
+                escape_internal_url_component(&episode.server_id),
+                escape_internal_url_component(&episode.library_id),
+                escape_internal_url_component(&episode.item_id)
+            )
+        });
     let uuid = generate_provider_playlist_uuid(&episode.input_name, &stable_id, PlaylistItemType::Series);
     let title = if episode.title.is_empty() {
         episode.series_title.clone().unwrap_or_else(|| "Remote Episode".intern())
@@ -126,7 +140,9 @@ pub fn remote_stream_ref_to_internal_url(stream_ref: &RemoteStreamRef) -> String
     match stream_ref {
         RemoteStreamRef::Emby { server_id, item_id, media_source_id, .. } => {
             format!(
-                "remote://emby/{server_id}/{item_id}{}",
+                "remote://emby/{}/{}{}",
+                escape_internal_url_component(server_id),
+                escape_internal_url_component(item_id),
                 media_source_id
                     .as_ref()
                     .map(|id| format!("?media_source_id={}", escape_internal_url_component(id)))
@@ -135,7 +151,9 @@ pub fn remote_stream_ref_to_internal_url(stream_ref: &RemoteStreamRef) -> String
         }
         RemoteStreamRef::Jellyfin { server_id, item_id, media_source_id, .. } => {
             format!(
-                "remote://jellyfin/{server_id}/{item_id}{}",
+                "remote://jellyfin/{}/{}{}",
+                escape_internal_url_component(server_id),
+                escape_internal_url_component(item_id),
                 media_source_id
                     .as_ref()
                     .map(|id| format!("?media_source_id={}", escape_internal_url_component(id)))
@@ -143,20 +161,24 @@ pub fn remote_stream_ref_to_internal_url(stream_ref: &RemoteStreamRef) -> String
             )
         }
         RemoteStreamRef::Plex { server_id, rating_key, part_key, .. } => format!(
-            "remote://plex/{server_id}/{rating_key}?part_key={}",
+            "remote://plex/{}/{}?part_key={}",
+            escape_internal_url_component(server_id),
+            escape_internal_url_component(rating_key),
             escape_internal_url_component(part_key)
         ),
     }
 }
 
 fn escape_internal_url_component(value: &str) -> String {
-    value
-        .replace('%', "%25")
-        .replace('/', "%2F")
-        .replace('?', "%3F")
-        .replace('&', "%26")
-        .replace('=', "%3D")
-        .replace('#', "%23")
+    let mut encoded = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~') {
+            encoded.push(byte as char);
+        } else {
+            let _ = write!(encoded, "%{byte:02X}");
+        }
+    }
+    encoded
 }
 
 #[cfg(test)]
@@ -167,17 +189,17 @@ mod tests {
     fn movie() -> RemoteMovie {
         RemoteMovie {
             input_name: "remote".into(),
-            server_id: "server".into(),
+            server_id: "server/one".into(),
             library_id: "movies".into(),
-            item_id: "item".into(),
+            item_id: "item?one plus+space".into(),
             title: "Movie".into(),
             year: Some(2024),
             source_version_hint: None,
             provider_hints: Vec::<RemoteProviderIdHint>::new(),
             stream_ref: Some(RemoteStreamRef::Emby {
                 input_name: "remote".into(),
-                server_id: "server".into(),
-                item_id: "item".into(),
+                server_id: "server/one".into(),
+                item_id: "item?one plus+space".into(),
                 media_source_id: Some("media/source".into()),
             }),
             image_ref: None,
@@ -219,7 +241,8 @@ mod tests {
         assert_eq!(groups[0].xtream_cluster, XtreamCluster::Video);
         assert_eq!(groups[0].channels[0].header.item_type, PlaylistItemType::Video);
         assert_eq!(groups[0].channels[0].header.virtual_id, 0);
-        assert!(groups[0].channels[0].header.id.starts_with("remote:server:movies:movie:item"));
+        assert!(groups[0].channels[0].header.id.starts_with("remote:server/one:movies:movie:item?one plus+space"));
+        assert!(groups[0].channels[0].header.url.contains("remote://emby/server%2Fone/item%3Fone%20plus%2Bspace"));
         assert_eq!(groups[1].channels[0].header.item_type, PlaylistItemType::Series);
         assert!(groups[1].channels[0].header.url.contains("part_key=%2Flibrary%2Fparts%2Fredacted%2Ffile.mkv"));
     }

--- a/backend/src/remote_media/playlist_mapper.rs
+++ b/backend/src/remote_media/playlist_mapper.rs
@@ -1,0 +1,226 @@
+use crate::remote_media::{RemoteCatalogSnapshot, RemoteEpisode, RemoteMovie, RemoteStreamRef};
+use shared::{
+    model::{
+        EpisodeStreamProperties, PlaylistGroup, PlaylistItem, PlaylistItemHeader, PlaylistItemType, StreamProperties,
+        VideoStreamProperties, XtreamCluster,
+    },
+    utils::{generate_provider_playlist_uuid, Internable},
+};
+use std::sync::Arc;
+
+pub fn remote_catalog_snapshot_to_playlist(snapshot: &RemoteCatalogSnapshot) -> Vec<PlaylistGroup> {
+    let mut groups = Vec::new();
+
+    if !snapshot.movies.is_empty() {
+        groups.push(PlaylistGroup {
+            id: 1,
+            title: "Remote Movies".intern(),
+            channels: snapshot.movies.iter().map(remote_movie_to_playlist_item).collect(),
+            xtream_cluster: XtreamCluster::Video,
+        });
+    }
+
+    if !snapshot.episodes.is_empty() {
+        groups.push(PlaylistGroup {
+            id: groups.len() as u32 + 1,
+            title: "Remote Series".intern(),
+            channels: snapshot.episodes.iter().map(remote_episode_to_playlist_item).collect(),
+            xtream_cluster: XtreamCluster::Series,
+        });
+    }
+
+    groups
+}
+
+fn remote_movie_to_playlist_item(movie: &RemoteMovie) -> PlaylistItem {
+    let stable_id = stable_remote_item_id(&movie.server_id, &movie.library_id, &movie.item_id, "movie");
+    let url = movie
+        .stream_ref
+        .as_ref()
+        .map(remote_stream_ref_to_internal_url)
+        .unwrap_or_else(|| format!("remote://{}/{}/{}", movie.server_id, movie.library_id, movie.item_id));
+    let uuid = generate_provider_playlist_uuid(&movie.input_name, &stable_id, PlaylistItemType::Video);
+
+    PlaylistItem {
+        header: PlaylistItemHeader {
+            uuid,
+            id: stable_id.intern(),
+            name: movie.title.clone(),
+            title: movie.title.clone(),
+            group: "Remote Movies".intern(),
+            url: url.intern(),
+            input_name: movie.input_name.clone(),
+            xtream_cluster: XtreamCluster::Video,
+            item_type: PlaylistItemType::Video,
+            additional_properties: Some(StreamProperties::Video(Box::new(VideoStreamProperties {
+                name: movie.title.clone(),
+                stream_id: 0,
+                stream_icon: "".intern(),
+                direct_source: "".intern(),
+                category_id: 0,
+                custom_sid: None,
+                added: movie.source_version_hint.clone().unwrap_or_else(|| "".intern()),
+                container_extension: "".intern(),
+                rating: None,
+                rating_5based: None,
+                stream_type: Some("movie".intern()),
+                trailer: None,
+                tmdb: None,
+                is_adult: 0,
+                details: None,
+            }))),
+            ..PlaylistItemHeader::default()
+        },
+    }
+}
+
+fn remote_episode_to_playlist_item(episode: &RemoteEpisode) -> PlaylistItem {
+    let stable_id = stable_remote_item_id(&episode.server_id, &episode.library_id, &episode.item_id, "episode");
+    let url = episode
+        .stream_ref
+        .as_ref()
+        .map(remote_stream_ref_to_internal_url)
+        .unwrap_or_else(|| format!("remote://{}/{}/{}", episode.server_id, episode.library_id, episode.item_id));
+    let uuid = generate_provider_playlist_uuid(&episode.input_name, &stable_id, PlaylistItemType::Series);
+    let title = if episode.title.is_empty() {
+        episode.series_title.clone().unwrap_or_else(|| "Remote Episode".intern())
+    } else {
+        episode.title.clone()
+    };
+
+    PlaylistItem {
+        header: PlaylistItemHeader {
+            uuid,
+            id: stable_id.intern(),
+            name: title.clone(),
+            title,
+            group: "Remote Series".intern(),
+            parent_code: episode.series_id.clone().unwrap_or_else(|| "".intern()),
+            url: url.intern(),
+            input_name: episode.input_name.clone(),
+            xtream_cluster: XtreamCluster::Series,
+            item_type: PlaylistItemType::Series,
+            additional_properties: Some(StreamProperties::Episode(Box::new(EpisodeStreamProperties {
+                episode_id: 0,
+                episode: episode.episode.unwrap_or_default(),
+                season: episode.season.unwrap_or_default(),
+                added: episode.source_version_hint.clone(),
+                release_date: None,
+                series_release_date: None,
+                tmdb: None,
+                movie_image: "".intern(),
+                container_extension: "".intern(),
+                video: None,
+                audio: None,
+            }))),
+            ..PlaylistItemHeader::default()
+        },
+    }
+}
+
+fn stable_remote_item_id(server_id: &Arc<str>, library_id: &Arc<str>, item_id: &Arc<str>, kind: &str) -> String {
+    format!("remote:{server_id}:{library_id}:{kind}:{item_id}")
+}
+
+pub fn remote_stream_ref_to_internal_url(stream_ref: &RemoteStreamRef) -> String {
+    match stream_ref {
+        RemoteStreamRef::Emby { server_id, item_id, media_source_id, .. } => {
+            format!(
+                "remote://emby/{server_id}/{item_id}{}",
+                media_source_id
+                    .as_ref()
+                    .map(|id| format!("?media_source_id={}", escape_internal_url_component(id)))
+                    .unwrap_or_default()
+            )
+        }
+        RemoteStreamRef::Jellyfin { server_id, item_id, media_source_id, .. } => {
+            format!(
+                "remote://jellyfin/{server_id}/{item_id}{}",
+                media_source_id
+                    .as_ref()
+                    .map(|id| format!("?media_source_id={}", escape_internal_url_component(id)))
+                    .unwrap_or_default()
+            )
+        }
+        RemoteStreamRef::Plex { server_id, rating_key, part_key, .. } => format!(
+            "remote://plex/{server_id}/{rating_key}?part_key={}",
+            escape_internal_url_component(part_key)
+        ),
+    }
+}
+
+fn escape_internal_url_component(value: &str) -> String {
+    value
+        .replace('%', "%25")
+        .replace('/', "%2F")
+        .replace('?', "%3F")
+        .replace('&', "%26")
+        .replace('=', "%3D")
+        .replace('#', "%23")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::remote_media::{RemoteCatalogSnapshot, RemoteProviderIdHint};
+
+    fn movie() -> RemoteMovie {
+        RemoteMovie {
+            input_name: "remote".into(),
+            server_id: "server".into(),
+            library_id: "movies".into(),
+            item_id: "item".into(),
+            title: "Movie".into(),
+            year: Some(2024),
+            source_version_hint: None,
+            provider_hints: Vec::<RemoteProviderIdHint>::new(),
+            stream_ref: Some(RemoteStreamRef::Emby {
+                input_name: "remote".into(),
+                server_id: "server".into(),
+                item_id: "item".into(),
+                media_source_id: Some("media/source".into()),
+            }),
+            image_ref: None,
+        }
+    }
+
+    fn episode() -> RemoteEpisode {
+        RemoteEpisode {
+            input_name: "remote".into(),
+            server_id: "server".into(),
+            library_id: "shows".into(),
+            item_id: "episode".into(),
+            series_id: Some("series".into()),
+            series_title: Some("Show".into()),
+            title: "Episode".into(),
+            season: Some(1),
+            episode: Some(2),
+            source_version_hint: None,
+            provider_hints: Vec::<RemoteProviderIdHint>::new(),
+            stream_ref: Some(RemoteStreamRef::Plex {
+                input_name: "remote".into(),
+                server_id: "server".into(),
+                rating_key: "rating".into(),
+                part_key: "/library/parts/redacted/file.mkv".into(),
+            }),
+            image_ref: None,
+        }
+    }
+
+    #[test]
+    fn maps_remote_movies_and_episodes_to_playlist_groups_without_virtual_ids() {
+        let groups = remote_catalog_snapshot_to_playlist(&RemoteCatalogSnapshot {
+            movies: vec![movie()],
+            episodes: vec![episode()],
+            ..RemoteCatalogSnapshot::default()
+        });
+
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[0].xtream_cluster, XtreamCluster::Video);
+        assert_eq!(groups[0].channels[0].header.item_type, PlaylistItemType::Video);
+        assert_eq!(groups[0].channels[0].header.virtual_id, 0);
+        assert!(groups[0].channels[0].header.id.starts_with("remote:server:movies:movie:item"));
+        assert_eq!(groups[1].channels[0].header.item_type, PlaylistItemType::Series);
+        assert!(groups[1].channels[0].header.url.contains("part_key=%2Flibrary%2Fparts%2Fredacted%2Ffile.mkv"));
+    }
+}

--- a/backend/src/remote_media/plex/dto.rs
+++ b/backend/src/remote_media/plex/dto.rs
@@ -1,0 +1,198 @@
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(rename = "MediaContainer")]
+pub struct PlexResourcesDto {
+    #[serde(rename = "Device", default)]
+    pub devices: Vec<PlexResourceDto>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct PlexResourceDto {
+    #[serde(rename = "@name")]
+    pub name: Option<String>,
+    #[serde(rename = "@product")]
+    pub product: Option<String>,
+    #[serde(rename = "@productVersion")]
+    pub product_version: Option<String>,
+    #[serde(rename = "@clientIdentifier")]
+    pub client_identifier: Option<String>,
+    #[serde(rename = "@machineIdentifier")]
+    pub machine_identifier: Option<String>,
+    #[serde(rename = "@owned", default)]
+    pub owned: Option<u8>,
+    #[serde(rename = "@accessToken")]
+    pub access_token: Option<String>,
+    #[serde(rename = "Connection", default)]
+    pub connections: Vec<PlexConnectionDto>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct PlexConnectionDto {
+    #[serde(rename = "@protocol")]
+    pub protocol: Option<String>,
+    #[serde(rename = "@uri")]
+    pub uri: Option<String>,
+    #[serde(rename = "@local", default)]
+    pub local: Option<u8>,
+    #[serde(rename = "@relay", default)]
+    pub relay: Option<u8>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(rename = "MediaContainer")]
+pub struct PlexSectionsDto {
+    #[serde(rename = "Directory", default)]
+    pub directories: Vec<PlexSectionDto>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct PlexSectionDto {
+    #[serde(rename = "@key")]
+    pub key: Option<String>,
+    #[serde(rename = "@title")]
+    pub title: Option<String>,
+    #[serde(rename = "@type")]
+    pub section_type: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(rename = "MediaContainer")]
+pub struct PlexMediaContainerDto {
+    #[serde(rename = "@size")]
+    pub size: Option<usize>,
+    #[serde(rename = "@totalSize")]
+    pub total_size: Option<usize>,
+    #[serde(rename = "Video", default)]
+    pub videos: Vec<PlexVideoDto>,
+    #[serde(rename = "Directory", default)]
+    pub directories: Vec<PlexDirectoryDto>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct PlexDirectoryDto {
+    #[serde(rename = "@ratingKey")]
+    pub rating_key: Option<String>,
+    #[serde(rename = "@key")]
+    pub key: Option<String>,
+    #[serde(rename = "@type")]
+    pub item_type: Option<String>,
+    #[serde(rename = "@title")]
+    pub title: Option<String>,
+    #[serde(rename = "@year")]
+    pub year: Option<u32>,
+    #[serde(rename = "Guid", default)]
+    pub guids: Vec<PlexGuidDto>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct PlexVideoDto {
+    #[serde(rename = "@ratingKey")]
+    pub rating_key: Option<String>,
+    #[serde(rename = "@key")]
+    pub key: Option<String>,
+    #[serde(rename = "@type")]
+    pub item_type: Option<String>,
+    #[serde(rename = "@title")]
+    pub title: Option<String>,
+    #[serde(rename = "@year")]
+    pub year: Option<u32>,
+    #[serde(rename = "@guid")]
+    pub guid: Option<String>,
+    #[serde(rename = "@thumb")]
+    pub thumb: Option<String>,
+    #[serde(rename = "@art")]
+    pub art: Option<String>,
+    #[serde(rename = "@parentRatingKey")]
+    pub parent_rating_key: Option<String>,
+    #[serde(rename = "@grandparentRatingKey")]
+    pub grandparent_rating_key: Option<String>,
+    #[serde(rename = "@grandparentTitle")]
+    pub grandparent_title: Option<String>,
+    #[serde(rename = "@parentIndex")]
+    pub parent_index: Option<u32>,
+    #[serde(rename = "@index")]
+    pub index: Option<u32>,
+    #[serde(rename = "@addedAt")]
+    pub added_at: Option<i64>,
+    #[serde(rename = "@updatedAt")]
+    pub updated_at: Option<i64>,
+    #[serde(rename = "Guid", default)]
+    pub guids: Vec<PlexGuidDto>,
+    #[serde(rename = "Media", default)]
+    pub media: Vec<PlexMediaDto>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct PlexGuidDto {
+    #[serde(rename = "@id")]
+    pub id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct PlexMediaDto {
+    #[serde(rename = "@id")]
+    pub id: Option<String>,
+    #[serde(rename = "@container")]
+    pub container: Option<String>,
+    #[serde(rename = "@duration")]
+    pub duration: Option<u64>,
+    #[serde(rename = "@bitrate")]
+    pub bitrate: Option<u32>,
+    #[serde(rename = "@width")]
+    pub width: Option<u32>,
+    #[serde(rename = "@height")]
+    pub height: Option<u32>,
+    #[serde(rename = "Part", default)]
+    pub parts: Vec<PlexPartDto>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct PlexPartDto {
+    #[serde(rename = "@id")]
+    pub id: Option<String>,
+    #[serde(rename = "@key")]
+    pub key: Option<String>,
+    #[serde(rename = "@size")]
+    pub size: Option<u64>,
+    #[serde(rename = "@file")]
+    pub file: Option<String>,
+    #[serde(rename = "@container")]
+    pub container: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::remote_media::test_fixtures::{PLEX_MOVIES_XML, PLEX_RESOURCES_XML, PLEX_SECTIONS_XML};
+
+    #[test]
+    fn parses_plex_resources_without_exposing_resource_token() {
+        let resources: PlexResourcesDto = quick_xml::de::from_str(PLEX_RESOURCES_XML).expect("fixture parses");
+
+        assert_eq!(resources.devices.len(), 1);
+        assert_eq!(resources.devices[0].connections.len(), 1);
+        assert_eq!(resources.devices[0].access_token.as_deref(), Some("resource-token-redacted"));
+    }
+
+    #[test]
+    fn parses_plex_sections_with_unsupported_kind_visible() {
+        let sections: PlexSectionsDto = quick_xml::de::from_str(PLEX_SECTIONS_XML).expect("fixture parses");
+
+        assert_eq!(sections.directories.len(), 3);
+        assert!(sections.directories.iter().any(|section| section.section_type.as_deref() == Some("artist")));
+    }
+
+    #[test]
+    fn parses_plex_movie_parts_and_optional_guids() {
+        let container: PlexMediaContainerDto = quick_xml::de::from_str(PLEX_MOVIES_XML).expect("fixture parses");
+        let movie = &container.videos[0];
+        let part = &movie.media[0].parts[0];
+
+        assert_eq!(container.total_size, Some(1));
+        assert_eq!(movie.rating_key.as_deref(), Some("rating-redacted-1"));
+        assert_eq!(part.key.as_deref(), Some("/library/parts/part-redacted/file.mkv"));
+        assert!(part.file.as_deref().is_some_and(|file| file.contains("/redacted/")));
+        assert_eq!(movie.guids.len(), 1);
+    }
+}

--- a/backend/src/remote_media/plex/mod.rs
+++ b/backend/src/remote_media/plex/mod.rs
@@ -1,0 +1,1 @@
+pub mod dto;

--- a/backend/src/remote_media/redaction.rs
+++ b/backend/src/remote_media/redaction.rs
@@ -1,0 +1,120 @@
+use reqwest::header::{HeaderMap, HeaderName};
+use shared::utils::sanitize_sensitive_info;
+
+const SENSITIVE_QUERY_KEYS: &[&str] = &[
+    "token",
+    "access_token",
+    "x-plex-token",
+    "x_emby_token",
+    "x-emby-token",
+    "api_key",
+    "apikey",
+    "password",
+    "passwd",
+    "authorization",
+    "auth",
+];
+
+const SENSITIVE_HEADER_NAMES: &[&str] = &[
+    "authorization",
+    "x-emby-token",
+    "x-mediabrowser-token",
+    "x-plex-token",
+    "cookie",
+    "set-cookie",
+];
+
+pub fn is_sensitive_remote_header(name: &HeaderName) -> bool {
+    let value = name.as_str().to_ascii_lowercase();
+    SENSITIVE_HEADER_NAMES.iter().any(|sensitive| value == *sensitive)
+}
+
+pub fn redact_remote_headers(headers: &HeaderMap) -> Vec<(String, String)> {
+    headers
+        .iter()
+        .map(|(name, value)| {
+            let rendered = if is_sensitive_remote_header(name) {
+                "<redacted>".to_string()
+            } else {
+                value
+                    .to_str()
+                    .map(redact_remote_text)
+                    .unwrap_or_else(|_| "<non-utf8>".to_string())
+            };
+            (name.as_str().to_string(), rendered)
+        })
+        .collect()
+}
+
+pub fn redact_remote_text(value: &str) -> String {
+    let sanitized = sanitize_sensitive_info(value);
+    redact_query_like_tokens(&sanitized)
+}
+
+fn redact_query_like_tokens(value: &str) -> String {
+    let mut result = String::with_capacity(value.len());
+    let bytes = value.as_bytes();
+    let mut i = 0;
+
+    while i < bytes.len() {
+        let matched = SENSITIVE_QUERY_KEYS.iter().find_map(|key| {
+            let remaining = &value[i..];
+            if remaining.len() < key.len() + 1 {
+                return None;
+            }
+            let candidate = &remaining[..key.len()];
+            let separator = remaining.as_bytes().get(key.len()).copied();
+            if candidate.eq_ignore_ascii_case(key) && matches!(separator, Some(b'=') | Some(b':')) {
+                Some((*key, separator.unwrap() as char))
+            } else {
+                None
+            }
+        });
+
+        if let Some((key, separator)) = matched {
+            result.push_str(key);
+            result.push(separator);
+            result.push_str("<redacted>");
+            i += key.len() + 1;
+            while i < bytes.len() && !matches!(bytes[i], b'&' | b' ' | b'\n' | b'\r' | b'\t' | b'\"' | b'\'') {
+                i += 1;
+            }
+        } else {
+            result.push(bytes[i] as char);
+            i += 1;
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::header::{HeaderValue, AUTHORIZATION};
+
+    #[test]
+    fn redacts_remote_query_tokens_case_insensitively() {
+        let redacted = redact_remote_text(
+            "https://media.example.invalid/video?X-Plex-Token=secret-token&api_key=secret-key&safe=value",
+        );
+
+        assert!(!redacted.contains("secret-token"));
+        assert!(!redacted.contains("secret-key"));
+        assert!(redacted.contains("X-Plex-Token=<redacted>") || redacted.contains("x-plex-token=<redacted>"));
+        assert!(redacted.contains("api_key=<redacted>"));
+        assert!(redacted.contains("safe=value"));
+    }
+
+    #[test]
+    fn redacts_sensitive_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer secret"));
+        headers.insert("content-type", HeaderValue::from_static("video/mp4"));
+
+        let rendered = redact_remote_headers(&headers);
+
+        assert!(rendered.iter().any(|(name, value)| name == "authorization" && value == "<redacted>"));
+        assert!(rendered.iter().any(|(name, value)| name == "content-type" && value == "video/mp4"));
+    }
+}

--- a/backend/src/remote_media/redaction.rs
+++ b/backend/src/remote_media/redaction.rs
@@ -53,39 +53,42 @@ pub fn redact_remote_text(value: &str) -> String {
 
 fn redact_query_like_tokens(value: &str) -> String {
     let mut result = String::with_capacity(value.len());
-    let bytes = value.as_bytes();
     let mut i = 0;
 
-    while i < bytes.len() {
-        let matched = SENSITIVE_QUERY_KEYS.iter().find_map(|key| {
-            let remaining = &value[i..];
-            if remaining.len() < key.len() + 1 {
-                return None;
-            }
-            let candidate = &remaining[..key.len()];
-            let separator = remaining.as_bytes().get(key.len()).copied();
-            if candidate.eq_ignore_ascii_case(key) && matches!(separator, Some(b'=') | Some(b':')) {
-                Some((*key, separator.unwrap() as char))
-            } else {
-                None
-            }
-        });
+    while i < value.len() {
+        let matched = SENSITIVE_QUERY_KEYS.iter().find_map(|key| matched_sensitive_key(value, i, *key));
 
         if let Some((key, separator)) = matched {
             result.push_str(key);
             result.push(separator);
             result.push_str("<redacted>");
-            i += key.len() + 1;
-            while i < bytes.len() && !matches!(bytes[i], b'&' | b' ' | b'\n' | b'\r' | b'\t' | b'\"' | b'\'') {
-                i += 1;
+            i += key.len() + separator.len_utf8();
+            while i < value.len() {
+                let Some(ch) = value[i..].chars().next() else { break };
+                if matches!(ch, '&' | ' ' | '\n' | '\r' | '\t' | '"' | '\'') {
+                    break;
+                }
+                i += ch.len_utf8();
             }
         } else {
-            result.push(bytes[i] as char);
-            i += 1;
+            let Some(ch) = value[i..].chars().next() else { break };
+            result.push(ch);
+            i += ch.len_utf8();
         }
     }
 
     result
+}
+
+fn matched_sensitive_key(value: &str, start: usize, key: &'static str) -> Option<(&'static str, char)> {
+    let remaining = value.get(start..)?;
+    let candidate = remaining.get(..key.len())?;
+    let separator = remaining.get(key.len()..)?.chars().next()?;
+    if candidate.eq_ignore_ascii_case(key) && matches!(separator, '=' | ':') {
+        Some((key, separator))
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]
@@ -104,6 +107,16 @@ mod tests {
         assert!(redacted.contains("X-Plex-Token=<redacted>") || redacted.contains("x-plex-token=<redacted>"));
         assert!(redacted.contains("api_key=<redacted>"));
         assert!(redacted.contains("safe=value"));
+    }
+
+    #[test]
+    fn redacts_query_tokens_without_corrupting_non_ascii_text() {
+        let redacted = redact_remote_text("https://media.example.invalid/épisode?token=sëcret&title=café");
+
+        assert!(!redacted.contains("sëcret"));
+        assert!(redacted.contains("épisode"));
+        assert!(redacted.contains("title=café"));
+        assert!(redacted.contains("token=<redacted>"));
     }
 
     #[test]

--- a/backend/src/remote_media/test_fixtures.rs
+++ b/backend/src/remote_media/test_fixtures.rs
@@ -1,0 +1,65 @@
+pub const EMBY_ITEMS_PAGE_JSON: &str = r#"
+{
+  "Items": [
+    {
+      "Id": "item-redacted-1",
+      "Name": "Movie Redacted",
+      "Type": "Movie",
+      "ProductionYear": 2024,
+      "ProviderIds": { "Tmdb": "12345" },
+      "ImageTags": { "Primary": "image-tag-redacted" },
+      "Path": "/redacted/upstream/path/movie.mkv",
+      "UserData": { "Played": true, "PlaybackPositionTicks": 123 },
+      "MediaSources": [
+        {
+          "Id": "media-source-redacted-1",
+          "Container": "mkv",
+          "Path": "/redacted/upstream/path/movie.mkv",
+          "SupportsDirectPlay": true,
+          "SupportsDirectStream": true
+        }
+      ]
+    }
+  ],
+  "TotalRecordCount": 1,
+  "StartIndex": 0
+}
+"#;
+
+pub const JELLYFIN_VIEWS_JSON: &str = r#"
+{
+  "Items": [
+    { "Id": "library-redacted-movies", "Name": "Movies", "CollectionType": "movies", "Type": "CollectionFolder" },
+    { "Id": "library-redacted-tv", "Name": "TV", "CollectionType": "tvshows", "Type": "CollectionFolder" }
+  ],
+  "TotalRecordCount": 2,
+  "StartIndex": 0
+}
+"#;
+
+pub const PLEX_RESOURCES_XML: &str = r#"
+<MediaContainer size="1">
+  <Device name="Server Redacted" product="Plex Media Server" productVersion="1.0.0" clientIdentifier="client-redacted" machineIdentifier="machine-redacted" owned="0" accessToken="resource-token-redacted">
+    <Connection protocol="https" uri="https://pms.example.invalid" local="0" relay="0" />
+  </Device>
+</MediaContainer>
+"#;
+
+pub const PLEX_SECTIONS_XML: &str = r#"
+<MediaContainer size="3">
+  <Directory key="1" title="Movies" type="movie" />
+  <Directory key="2" title="Shows" type="show" />
+  <Directory key="3" title="Music" type="artist" />
+</MediaContainer>
+"#;
+
+pub const PLEX_MOVIES_XML: &str = r#"
+<MediaContainer size="1" totalSize="1">
+  <Video ratingKey="rating-redacted-1" key="/library/metadata/rating-redacted-1" type="movie" title="Movie Redacted" year="2024" thumb="/library/metadata/rating-redacted-1/thumb" addedAt="1700000000" updatedAt="1700000001">
+    <Guid id="tmdb://12345" />
+    <Media id="media-redacted-1" container="mkv" duration="7200000" bitrate="8000" width="1920" height="1080">
+      <Part id="part-redacted" key="/library/parts/part-redacted/file.mkv" file="/redacted/upstream/path/movie.mkv" size="1024" container="mkv" />
+    </Media>
+  </Video>
+</MediaContainer>
+"#;

--- a/backend/src/remote_media/types.rs
+++ b/backend/src/remote_media/types.rs
@@ -1,0 +1,231 @@
+use bytes::Bytes;
+use reqwest::{header::HeaderMap, StatusCode};
+use shared::model::InputType;
+use std::sync::Arc;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum RemoteMediaServerKind {
+    Emby,
+    Jellyfin,
+    Plex,
+}
+
+impl RemoteMediaServerKind {
+    pub const fn as_input_type(self) -> InputType {
+        match self {
+            Self::Emby => InputType::Emby,
+            Self::Jellyfin => InputType::Jellyfin,
+            Self::Plex => InputType::Plex,
+        }
+    }
+}
+
+impl TryFrom<InputType> for RemoteMediaServerKind {
+    type Error = &'static str;
+
+    fn try_from(value: InputType) -> Result<Self, Self::Error> {
+        match value {
+            InputType::Emby => Ok(Self::Emby),
+            InputType::Jellyfin => Ok(Self::Jellyfin),
+            InputType::Plex => Ok(Self::Plex),
+            InputType::M3u | InputType::Xtream | InputType::M3uBatch | InputType::XtreamBatch | InputType::Library => {
+                Err("input type is not a remote media-server input")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteServerStatus {
+    pub kind: RemoteMediaServerKind,
+    pub server_id: Arc<str>,
+    pub display_name: Option<Arc<str>>,
+    pub version: Option<Arc<str>>,
+    pub owned: Option<bool>,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum RemoteLibraryKind {
+    Movies,
+    TvShows,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteLibraryRef {
+    pub input_name: Arc<str>,
+    pub server_id: Arc<str>,
+    pub library_id: Arc<str>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteLibrary {
+    pub reference: RemoteLibraryRef,
+    pub name: Arc<str>,
+    pub kind: RemoteLibraryKind,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct RemotePageRequest {
+    pub start: usize,
+    pub limit: usize,
+}
+
+impl RemotePageRequest {
+    pub const fn new(start: usize, limit: usize) -> Self { Self { start, limit } }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemotePage<T> {
+    pub request: RemotePageRequest,
+    pub total: Option<usize>,
+    pub items: Vec<T>,
+}
+
+impl<T> RemotePage<T> {
+    pub fn item_count(&self) -> usize { self.items.len() }
+
+    pub fn next_request(&self) -> Option<RemotePageRequest> {
+        let next_start = self.request.start.saturating_add(self.item_count());
+        if self.item_count() == 0 || self.total.is_some_and(|total| next_start >= total) {
+            None
+        } else {
+            Some(RemotePageRequest::new(next_start, self.request.limit))
+        }
+    }
+
+    pub fn cursor_advanced(&self) -> bool { self.item_count() > 0 }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteProviderIdHint {
+    pub namespace: Arc<str>,
+    pub value: Arc<str>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteMovie {
+    pub input_name: Arc<str>,
+    pub server_id: Arc<str>,
+    pub library_id: Arc<str>,
+    pub item_id: Arc<str>,
+    pub title: Arc<str>,
+    pub year: Option<u32>,
+    pub source_version_hint: Option<Arc<str>>,
+    pub provider_hints: Vec<RemoteProviderIdHint>,
+    pub stream_ref: Option<RemoteStreamRef>,
+    pub image_ref: Option<RemoteImageRef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteEpisode {
+    pub input_name: Arc<str>,
+    pub server_id: Arc<str>,
+    pub library_id: Arc<str>,
+    pub item_id: Arc<str>,
+    pub series_id: Option<Arc<str>>,
+    pub series_title: Option<Arc<str>>,
+    pub title: Arc<str>,
+    pub season: Option<u32>,
+    pub episode: Option<u32>,
+    pub source_version_hint: Option<Arc<str>>,
+    pub provider_hints: Vec<RemoteProviderIdHint>,
+    pub stream_ref: Option<RemoteStreamRef>,
+    pub image_ref: Option<RemoteImageRef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemoteStreamRef {
+    Emby {
+        input_name: Arc<str>,
+        server_id: Arc<str>,
+        item_id: Arc<str>,
+        media_source_id: Option<Arc<str>>,
+    },
+    Jellyfin {
+        input_name: Arc<str>,
+        server_id: Arc<str>,
+        item_id: Arc<str>,
+        media_source_id: Option<Arc<str>>,
+    },
+    Plex {
+        input_name: Arc<str>,
+        server_id: Arc<str>,
+        rating_key: Arc<str>,
+        part_key: Arc<str>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemoteImageRef {
+    Emby {
+        input_name: Arc<str>,
+        server_id: Arc<str>,
+        item_id: Arc<str>,
+        image_kind: Arc<str>,
+        tag: Option<Arc<str>>,
+    },
+    Jellyfin {
+        input_name: Arc<str>,
+        server_id: Arc<str>,
+        item_id: Arc<str>,
+        image_kind: Arc<str>,
+        tag: Option<Arc<str>>,
+    },
+    Plex {
+        input_name: Arc<str>,
+        server_id: Arc<str>,
+        rating_key: Arc<str>,
+        image_path: Arc<str>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemotePlaybackLease {
+    pub provider_kind: RemoteMediaServerKind,
+    pub lease_id: Arc<str>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RemoteResourceResponse {
+    pub status: StatusCode,
+    pub headers: HeaderMap,
+    pub body: Bytes,
+}
+
+pub type RemoteStreamResponse = RemoteResourceResponse;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remote_page_next_request_advances_until_total() {
+        let page = RemotePage {
+            request: RemotePageRequest::new(0, 2),
+            total: Some(3),
+            items: vec![1, 2],
+        };
+
+        assert_eq!(page.next_request(), Some(RemotePageRequest::new(2, 2)));
+
+        let last = RemotePage {
+            request: RemotePageRequest::new(2, 2),
+            total: Some(3),
+            items: vec![3],
+        };
+        assert_eq!(last.next_request(), None);
+    }
+
+    #[test]
+    fn remote_page_empty_page_does_not_advance() {
+        let page = RemotePage::<u8> {
+            request: RemotePageRequest::new(10, 100),
+            total: Some(50),
+            items: vec![],
+        };
+
+        assert!(!page.cursor_advanced());
+        assert_eq!(page.next_request(), None);
+    }
+}

--- a/backend/src/remote_media/types.rs
+++ b/backend/src/remote_media/types.rs
@@ -79,22 +79,39 @@ impl RemotePageRequest {
 pub struct RemotePage<T> {
     pub request: RemotePageRequest,
     pub total: Option<usize>,
+    pub upstream_item_count: usize,
     pub items: Vec<T>,
 }
 
 impl<T> RemotePage<T> {
+    pub fn new(request: RemotePageRequest, total: Option<usize>, items: Vec<T>) -> Self {
+        let upstream_item_count = items.len();
+        Self { request, total, upstream_item_count, items }
+    }
+
+    pub fn with_upstream_item_count(
+        request: RemotePageRequest,
+        total: Option<usize>,
+        upstream_item_count: usize,
+        items: Vec<T>,
+    ) -> Self {
+        Self { request, total, upstream_item_count, items }
+    }
+
     pub fn item_count(&self) -> usize { self.items.len() }
 
+    pub fn upstream_item_count(&self) -> usize { self.upstream_item_count }
+
     pub fn next_request(&self) -> Option<RemotePageRequest> {
-        let next_start = self.request.start.saturating_add(self.item_count());
-        if self.item_count() == 0 || self.total.is_some_and(|total| next_start >= total) {
+        let next_start = self.request.start.saturating_add(self.upstream_item_count());
+        if self.upstream_item_count() == 0 || self.total.is_some_and(|total| next_start >= total) {
             None
         } else {
             Some(RemotePageRequest::new(next_start, self.request.limit))
         }
     }
 
-    pub fn cursor_advanced(&self) -> bool { self.item_count() > 0 }
+    pub fn cursor_advanced(&self) -> bool { self.upstream_item_count() > 0 }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -201,31 +218,29 @@ mod tests {
 
     #[test]
     fn remote_page_next_request_advances_until_total() {
-        let page = RemotePage {
-            request: RemotePageRequest::new(0, 2),
-            total: Some(3),
-            items: vec![1, 2],
-        };
+        let page = RemotePage::new(RemotePageRequest::new(0, 2), Some(3), vec![1, 2]);
 
         assert_eq!(page.next_request(), Some(RemotePageRequest::new(2, 2)));
 
-        let last = RemotePage {
-            request: RemotePageRequest::new(2, 2),
-            total: Some(3),
-            items: vec![3],
-        };
+        let last = RemotePage::new(RemotePageRequest::new(2, 2), Some(3), vec![3]);
         assert_eq!(last.next_request(), None);
     }
 
     #[test]
     fn remote_page_empty_page_does_not_advance() {
-        let page = RemotePage::<u8> {
-            request: RemotePageRequest::new(10, 100),
-            total: Some(50),
-            items: vec![],
-        };
+        let page = RemotePage::<u8>::new(RemotePageRequest::new(10, 100), Some(50), vec![]);
 
         assert!(!page.cursor_advanced());
         assert_eq!(page.next_request(), None);
+    }
+
+    #[test]
+    fn remote_page_cursor_uses_upstream_count_when_items_are_filtered() {
+        let page = RemotePage::with_upstream_item_count(RemotePageRequest::new(0, 3), Some(5), 3, vec![1]);
+
+        assert_eq!(page.item_count(), 1);
+        assert_eq!(page.upstream_item_count(), 3);
+        assert!(page.cursor_advanced());
+        assert_eq!(page.next_request(), Some(RemotePageRequest::new(3, 3)));
     }
 }

--- a/backend/src/repository/alias_repository.rs
+++ b/backend/src/repository/alias_repository.rs
@@ -179,6 +179,7 @@ pub fn csv_read_inputs_from_reader(
         InputType::M3uBatch | InputType::M3u => InputType::M3uBatch,
         InputType::XtreamBatch | InputType::Xtream => InputType::XtreamBatch,
         InputType::Library => InputType::Library,
+        InputType::Emby | InputType::Jellyfin | InputType::Plex => batch_input_type,
     };
     let mut result = vec![];
     let mut default_columns = vec![];

--- a/backend/src/repository/playlist_repository.rs
+++ b/backend/src/repository/playlist_repository.rs
@@ -10,7 +10,10 @@ use crate::repository::{load_input_local_library_playlist, persist_input_library
 use crate::repository::{load_input_m3u_playlist, m3u_get_file_path_for_db, m3u_write_playlist, persist_input_m3u_playlist};
 use crate::repository::{load_input_xtream_playlist, persist_input_xtream_playlist, xtream_get_file_path, xtream_get_storage_path, xtream_write_playlist};
 use crate::repository::BPlusTree;
-use crate::repository::{LocalLibraryDiskPlaylistSource, M3uDiskPlaylistSource, MemoryPlaylistSource, PlaylistSource, XtreamDiskPlaylistSource};
+use crate::repository::{
+    LocalLibraryDiskPlaylistSource, M3uDiskPlaylistSource, MemoryPlaylistSource, PlaylistSource,
+    RemoteMediaDiskPlaylistSource, XtreamDiskPlaylistSource,
+};
 use crate::repository::{TargetIdMapping, VirtualIdRecord};
 use crate::utils;
 use log::{info, warn};
@@ -459,6 +462,14 @@ pub async fn persist_input_playlist(app_config: &Arc<AppConfig>, input: &ConfigI
             }
             (playlist, None)
         }
+        InputType::Emby | InputType::Jellyfin | InputType::Plex => {
+            let file_path = get_input_remote_media_playlist_file_path(&storage_path, &input.name);
+            let (playlist, result) = persist_input_remote_media_playlist(app_config, &file_path, playlist).await;
+            if let Err(err) = result {
+                return (playlist, Some(err));
+            }
+            (playlist, None)
+        }
     }
 }
 
@@ -502,6 +513,15 @@ pub async fn load_input_playlist(ctx: &PlaylistProcessingContext, input: &Config
                 Ok(Box::new(MemoryPlaylistSource::new(groups)))
             }
         }
+        InputType::Emby | InputType::Jellyfin | InputType::Plex => {
+            let file_path = get_input_remote_media_playlist_file_path(&storage_path, &input.name);
+            if disk_based_processing && file_path.exists() {
+                Ok(Box::new(RemoteMediaDiskPlaylistSource::new(app_config, &file_path).await))
+            } else {
+                let groups = load_input_remote_media_playlist(app_config, &file_path).await?;
+                Ok(Box::new(MemoryPlaylistSource::new(groups)))
+            }
+        }
     }
 }
 
@@ -519,12 +539,34 @@ pub fn get_input_local_library_playlist_file_path(storage_path: &Path, input_nam
     storage_path.join(format!("lib_{sanitized_input_name}.{FILE_SUFFIX_DB}"))
 }
 
+pub fn get_input_remote_media_playlist_file_path(storage_path: &Path, input_name: &Arc<str>) -> PathBuf {
+    let sanitized_input_name: String = input_name.chars()
+        .map(|c| if c.is_alphanumeric() { c } else { '_' })
+        .collect();
+    storage_path.join(format!("remote_{sanitized_input_name}.{FILE_SUFFIX_DB}"))
+}
+
+pub async fn persist_input_remote_media_playlist(
+    app_config: &Arc<AppConfig>,
+    file_path: &Path,
+    playlist: Vec<PlaylistGroup>,
+) -> (Vec<PlaylistGroup>, Result<(), TuliproxError>) {
+    persist_input_library_playlist(app_config, file_path, playlist).await
+}
+
+pub async fn load_input_remote_media_playlist(
+    app_config: &Arc<AppConfig>,
+    file_path: &Path,
+) -> Result<Vec<PlaylistGroup>, TuliproxError> {
+    load_input_local_library_playlist(app_config, file_path).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        assign_local_series_info_episode_key, rewrite_local_series_info_episode_virtual_id,
-        rewrite_series_episode_parent_virtual_ids, rewrite_series_info_episode_virtual_id, LocalEpisodeKey,
-        ProviderEpisodeKey,
+        assign_local_series_info_episode_key, get_input_remote_media_playlist_file_path,
+        rewrite_local_series_info_episode_virtual_id, rewrite_series_episode_parent_virtual_ids,
+        rewrite_series_info_episode_virtual_id, LocalEpisodeKey, ProviderEpisodeKey,
     };
     use crate::repository::{BPlusTreeQuery, TargetIdMapping, VirtualIdRecord};
     use shared::model::{
@@ -534,6 +576,14 @@ mod tests {
     use shared::utils::Internable;
     use std::{collections::HashMap, sync::Arc};
     use tempfile::tempdir;
+
+    #[test]
+    fn remote_media_playlist_file_path_uses_separate_prefix() {
+        let dir = tempdir().expect("tempdir");
+        let path = get_input_remote_media_playlist_file_path(dir.path(), &"Remote Input".intern());
+
+        assert!(path.ends_with("remote_Remote_Input.db"));
+    }
 
     fn make_local_series_info(series_uuid: &str, episodes: Vec<(u32, &str, &str)>) -> PlaylistItem {
         let episode_props = episodes

--- a/backend/src/repository/playlist_source.rs
+++ b/backend/src/repository/playlist_source.rs
@@ -436,6 +436,7 @@ macro_rules! impl_single_file_disk_source {
 impl_single_file_disk_source!(M3u, Arc<str>, M3uPlaylistItem);
 
 impl_single_file_disk_source!(LocalLibrary, UUIDType, XtreamPlaylistItem);
+impl_single_file_disk_source!(RemoteMedia, UUIDType, XtreamPlaylistItem);
 
 pub struct MemoryPlaylistSource {
     playlist: Arc<Vec<PlaylistGroup>>,

--- a/frontend/src/app/components/playlist/input/input_type_view.rs
+++ b/frontend/src/app/components/playlist/input/input_type_view.rs
@@ -17,6 +17,9 @@ pub fn InputTypeView(props: &InputTypeViewProps) -> Html {
         InputType::M3uBatch => "LABEL.M3U_BATCH",
         InputType::XtreamBatch => "LABEL.XTREAM_BATCH",
         InputType::Library => "LABEL.LIBRARY",
+        InputType::Emby => "LABEL.EMBY",
+        InputType::Jellyfin => "LABEL.JELLYFIN",
+        InputType::Plex => "LABEL.PLEX",
     };
 
     html! {

--- a/frontend/src/app/components/playlist/input/staged_input_view.rs
+++ b/frontend/src/app/components/playlist/input/staged_input_view.rs
@@ -23,6 +23,9 @@ pub fn StagedInputView(props: &StagedInputViewProps) -> Html {
                 InputType::M3uBatch => "LABEL.M3U_BATCH",
                 InputType::XtreamBatch => "LABEL.XTREAM_BATCH",
                 InputType::Library => "LABEL.LIBRARY",
+                InputType::Emby => "LABEL.EMBY",
+                InputType::Jellyfin => "LABEL.JELLYFIN",
+                InputType::Plex => "LABEL.PLEX",
             };
             html! {
                 <div class="tp__staged-input-view">

--- a/frontend/src/app/components/source_editor/editor_model.rs
+++ b/frontend/src/app/components/source_editor/editor_model.rs
@@ -68,6 +68,7 @@ impl From<InputType> for BlockType {
             InputType::M3uBatch | InputType::M3u => BlockType::InputM3u,
             InputType::XtreamBatch | InputType::Xtream => BlockType::InputXtream,
             InputType::Library => BlockType::InputLibrary,
+            InputType::Emby | InputType::Jellyfin | InputType::Plex => BlockType::InputXtream,
         }
     }
 }

--- a/shared/src/model/config/input.rs
+++ b/shared/src/model/config/input.rs
@@ -8,7 +8,8 @@ use crate::{
         arc_str_serde, arc_str_vec_serde, default_as_true, default_probe_delay_secs, default_probe_live_interval,
         default_resolve_background, default_resolve_delay_secs, default_xtream_live_stream_use_prefix,
         deserialize_timestamp, get_credentials_from_url_str, get_trimmed_string, is_blank_optional_string,
-        is_default_probe_delay_secs, is_default_probe_live_interval, is_default_resolve_delay_secs, is_false, is_true,
+        is_default_probe_delay_secs, is_default_probe_live_interval, is_default_resolve_delay_secs, is_false,
+        is_non_blank_optional_string, is_true,
         is_zero_i16, is_zero_u16, parse_duration_seconds, parse_provider_scheme_url_parts, sanitize_sensitive_info,
         serialize_option_vec_flow_map_items, trim_last_slash, Internable, BATCH_SCHEME_PREFIX, PROVIDER_SCHEME_PREFIX,
     },
@@ -345,10 +346,6 @@ pub const fn is_default_remote_catalog_concurrency(value: &u8) -> bool {
 }
 pub const fn is_default_remote_playback_max_streams(value: &u16) -> bool {
     *value == default_remote_playback_max_streams()
-}
-
-fn is_non_blank_optional_string(value: &Option<String>) -> bool {
-    value.as_ref().is_some_and(|value| !value.trim().is_empty())
 }
 
 #[derive(Debug, Copy, Clone, serde::Serialize, serde::Deserialize, Sequence, PartialEq, Eq, Default)]

--- a/shared/src/model/config/input.rs
+++ b/shared/src/model/config/input.rs
@@ -463,15 +463,6 @@ impl Default for RemotePlaybackConfigDto {
 
 impl RemotePlaybackConfigDto {
     pub fn is_default(&self) -> bool { self == &Self::default() }
-
-    pub fn prepare(&self, input_name: &Arc<str>) -> Result<(), TuliproxError> {
-        if self.max_streams == 0 {
-            return Err(TuliproxError::ConfigInput(format!(
-                "remote playback max_streams must be greater than zero (input: {input_name})"
-            )));
-        }
-        Ok(())
-    }
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default, PartialEq, Eq)]
@@ -625,7 +616,6 @@ impl RemoteMediaInputConfigDto {
         self.machine_id = get_trimmed_string(self.machine_id.as_deref());
         self.server_name = get_trimmed_string(self.server_name.as_deref());
         self.catalog.prepare(input_name)?;
-        self.playback.prepare(input_name)?;
 
         for library in &mut self.libraries {
             library.prepare();
@@ -1502,7 +1492,7 @@ mod tests {
     }
 
     #[test]
-    fn prepare_rejects_remote_playback_max_streams_zero() {
+    fn prepare_accepts_remote_playback_max_streams_zero_as_unlimited() {
         let mut dto = ConfigInputDto {
             name: "emby_remote".intern(),
             input_type: InputType::Emby,
@@ -1515,8 +1505,8 @@ mod tests {
             ..ConfigInputDto::default()
         };
 
-        let err = prepare_dto(&mut dto).expect_err("zero remote max_streams should be rejected");
-        assert!(err.to_string().contains("remote playback max_streams must be greater than zero"));
+        prepare_dto(&mut dto).expect("zero remote max_streams means unlimited");
+        assert_eq!(dto.remote.as_ref().expect("remote config").playback.max_streams, 0);
     }
 
     fn prepare_dto(dto: &mut ConfigInputDto) -> Result<u16, TuliproxError> {

--- a/shared/src/model/config/input.rs
+++ b/shared/src/model/config/input.rs
@@ -347,6 +347,10 @@ pub const fn is_default_remote_playback_max_streams(value: &u16) -> bool {
     *value == default_remote_playback_max_streams()
 }
 
+fn is_non_blank_optional_string(value: &Option<String>) -> bool {
+    value.as_ref().is_some_and(|value| !value.trim().is_empty())
+}
+
 #[derive(Debug, Copy, Clone, serde::Serialize, serde::Deserialize, Sequence, PartialEq, Eq, Default)]
 pub enum RemoteCatalogRefreshModeDto {
     #[serde(rename = "manual")]
@@ -459,6 +463,15 @@ impl Default for RemotePlaybackConfigDto {
 
 impl RemotePlaybackConfigDto {
     pub fn is_default(&self) -> bool { self == &Self::default() }
+
+    pub fn prepare(&self, input_name: &Arc<str>) -> Result<(), TuliproxError> {
+        if self.max_streams == 0 {
+            return Err(TuliproxError::ConfigInput(format!(
+                "remote playback max_streams must be greater than zero (input: {input_name})"
+            )));
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default, PartialEq, Eq)]
@@ -612,6 +625,7 @@ impl RemoteMediaInputConfigDto {
         self.machine_id = get_trimmed_string(self.machine_id.as_deref());
         self.server_name = get_trimmed_string(self.server_name.as_deref());
         self.catalog.prepare(input_name)?;
+        self.playback.prepare(input_name)?;
 
         for library in &mut self.libraries {
             library.prepare();
@@ -625,13 +639,17 @@ impl RemoteMediaInputConfigDto {
     }
 
     pub fn has_any_emby_jellyfin_auth(&self) -> bool {
-        self.token.is_some() || self.api_key.is_some()
+        is_non_blank_optional_string(&self.token) || is_non_blank_optional_string(&self.api_key)
     }
 
-    pub fn has_any_plex_token(&self) -> bool { self.account_token.is_some() || self.token.is_some() }
+    pub fn has_any_plex_token(&self) -> bool {
+        is_non_blank_optional_string(&self.account_token) || is_non_blank_optional_string(&self.token)
+    }
 
     pub fn has_plex_server_selector(&self) -> bool {
-        self.server_id.is_some() || self.machine_id.is_some() || self.server_name.is_some()
+        is_non_blank_optional_string(&self.server_id)
+            || is_non_blank_optional_string(&self.machine_id)
+            || is_non_blank_optional_string(&self.server_name)
     }
 }
 
@@ -1209,7 +1227,6 @@ impl ConfigInputDto {
     pub fn prepare_type(&mut self) -> Result<(), TuliproxError> {
         self.url = self.url.trim().to_string();
         self.normalize_input_type_from_batch_url();
-        self.prepare_remote_media_input()?;
         if self.url.starts_with(PROVIDER_SCHEME_PREFIX)
             && matches!(self.input_type, InputType::M3uBatch | InputType::XtreamBatch)
         {
@@ -1452,6 +1469,54 @@ mod tests {
             libraries: vec![RemoteLibrarySelectorDto::Name("Movies".to_string())],
             ..RemoteMediaInputConfigDto::default()
         }
+    }
+
+    #[test]
+    fn prepare_rejects_blank_remote_credentials_and_selectors() {
+        let mut emby = ConfigInputDto {
+            name: "emby_remote".intern(),
+            input_type: InputType::Emby,
+            url: "https://media.example.invalid".to_string(),
+            remote: Some(RemoteMediaInputConfigDto {
+                token: Some("   ".to_string()),
+                api_key: Some("".to_string()),
+                ..remote_config_with_library()
+            }),
+            ..ConfigInputDto::default()
+        };
+        let err = prepare_dto(&mut emby).expect_err("blank token/api_key should be rejected");
+        assert!(err.to_string().contains("requires remote token/api_key"));
+
+        let mut plex = ConfigInputDto {
+            name: "plex_remote".intern(),
+            input_type: InputType::Plex,
+            remote: Some(RemoteMediaInputConfigDto {
+                account_token: Some("   ".to_string()),
+                server_id: Some("   ".to_string()),
+                ..remote_config_with_library()
+            }),
+            ..ConfigInputDto::default()
+        };
+        let err = prepare_dto(&mut plex).expect_err("blank plex token should be rejected");
+        assert!(err.to_string().contains("requires remote.account_token or remote.token"));
+    }
+
+    #[test]
+    fn prepare_rejects_remote_playback_max_streams_zero() {
+        let mut dto = ConfigInputDto {
+            name: "emby_remote".intern(),
+            input_type: InputType::Emby,
+            url: "https://media.example.invalid".to_string(),
+            remote: Some(RemoteMediaInputConfigDto {
+                token: Some("token-value".to_string()),
+                playback: RemotePlaybackConfigDto { max_streams: 0, ..RemotePlaybackConfigDto::default() },
+                ..remote_config_with_library()
+            }),
+            ..ConfigInputDto::default()
+        };
+
+        let err = prepare_dto(&mut dto).expect_err("zero remote max_streams should be rejected");
+        assert!(err.to_string().contains("remote playback max_streams must be greater than zero"));
     }
 
     fn prepare_dto(dto: &mut ConfigInputDto) -> Result<u16, TuliproxError> {
@@ -1837,6 +1902,20 @@ mod tests {
         assert_eq!(dto.input_type, InputType::Xtream);
         dto.prepare(0, true, &HashSet::new(), None).expect("prepare should succeed for regular URL with aliases");
         assert_eq!(dto.input_type, InputType::Xtream);
+    }
+
+    #[test]
+    fn prepare_type_does_not_validate_remote_media_config() {
+        let mut dto = ConfigInputDto {
+            name: "emby_remote".intern(),
+            input_type: InputType::Emby,
+            url: "https://media.example.invalid".to_string(),
+            ..ConfigInputDto::default()
+        };
+
+        dto.prepare_type().expect("prepare_type only normalizes type/url");
+        let err = prepare_dto(&mut dto).expect_err("full prepare should validate missing remote block");
+        assert!(err.to_string().contains("remote configuration is mandatory"));
     }
 
     #[test]

--- a/shared/src/model/config/input.rs
+++ b/shared/src/model/config/input.rs
@@ -94,6 +94,12 @@ pub enum InputType {
     XtreamBatch,
     #[serde(rename = "library")]
     Library,
+    #[serde(rename = "emby")]
+    Emby,
+    #[serde(rename = "jellyfin")]
+    Jellyfin,
+    #[serde(rename = "plex")]
+    Plex,
 }
 
 impl InputType {
@@ -102,10 +108,14 @@ impl InputType {
     const M3U_BATCH: &'static str = "m3u_batch";
     const XTREAM_BATCH: &'static str = "xtream_batch";
     const LIBRARY: &'static str = "library";
+    const EMBY: &'static str = "emby";
+    const JELLYFIN: &'static str = "jellyfin";
+    const PLEX: &'static str = "plex";
     pub fn is_xtream(&self) -> bool { matches!(self, Self::Xtream | Self::XtreamBatch) }
     pub fn is_m3u(&self) -> bool { matches!(self, Self::M3u | Self::M3uBatch) }
 
     pub fn is_library(&self) -> bool { matches!(self, Self::Library) }
+    pub fn is_remote_media_server(&self) -> bool { matches!(self, Self::Emby | Self::Jellyfin | Self::Plex) }
 }
 
 impl Display for InputType {
@@ -119,6 +129,9 @@ impl Display for InputType {
                 Self::M3uBatch => Self::M3U_BATCH,
                 Self::XtreamBatch => Self::XTREAM_BATCH,
                 Self::Library => Self::LIBRARY,
+                Self::Emby => Self::EMBY,
+                Self::Jellyfin => Self::JELLYFIN,
+                Self::Plex => Self::PLEX,
             }
         )
     }
@@ -138,6 +151,12 @@ impl FromStr for InputType {
             Ok(Self::XtreamBatch)
         } else if s.eq(Self::LIBRARY) {
             Ok(Self::Library)
+        } else if s.eq(Self::EMBY) {
+            Ok(Self::Emby)
+        } else if s.eq(Self::JELLYFIN) {
+            Ok(Self::Jellyfin)
+        } else if s.eq(Self::PLEX) {
+            Ok(Self::Plex)
         } else {
             Err(TuliproxError::ConfigInput(format!("Unknown InputType: {}", s)))
         }
@@ -310,6 +329,309 @@ impl ConfigInputOptionsDto {
             self.t_probe_filter = Some(get_filter(raw_filter, templates)?);
         }
         Ok(())
+    }
+}
+
+pub const fn default_remote_catalog_page_size() -> u16 { 100 }
+pub const fn default_remote_catalog_request_delay_ms() -> u64 { 250 }
+pub const fn default_remote_catalog_concurrency() -> u8 { 1 }
+pub const fn default_remote_playback_max_streams() -> u16 { 1 }
+pub const fn is_default_remote_catalog_page_size(value: &u16) -> bool { *value == default_remote_catalog_page_size() }
+pub const fn is_default_remote_catalog_request_delay_ms(value: &u64) -> bool {
+    *value == default_remote_catalog_request_delay_ms()
+}
+pub const fn is_default_remote_catalog_concurrency(value: &u8) -> bool {
+    *value == default_remote_catalog_concurrency()
+}
+pub const fn is_default_remote_playback_max_streams(value: &u16) -> bool {
+    *value == default_remote_playback_max_streams()
+}
+
+#[derive(Debug, Copy, Clone, serde::Serialize, serde::Deserialize, Sequence, PartialEq, Eq, Default)]
+pub enum RemoteCatalogRefreshModeDto {
+    #[serde(rename = "manual")]
+    #[default]
+    Manual,
+    #[serde(rename = "scheduled")]
+    Scheduled,
+}
+
+pub fn is_default_remote_catalog_refresh_mode(value: &RemoteCatalogRefreshModeDto) -> bool {
+    *value == RemoteCatalogRefreshModeDto::default()
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RemoteCatalogConfigDto {
+    #[serde(default, skip_serializing_if = "is_default_remote_catalog_refresh_mode")]
+    pub refresh_mode: RemoteCatalogRefreshModeDto,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub refresh_on_startup: bool,
+    #[serde(default = "default_remote_catalog_page_size", skip_serializing_if = "is_default_remote_catalog_page_size")]
+    pub page_size: u16,
+    #[serde(
+        default = "default_remote_catalog_request_delay_ms",
+        skip_serializing_if = "is_default_remote_catalog_request_delay_ms"
+    )]
+    pub request_delay_ms: u64,
+    #[serde(default = "default_remote_catalog_concurrency", skip_serializing_if = "is_default_remote_catalog_concurrency")]
+    pub concurrency: u8,
+    #[serde(default = "default_as_true", skip_serializing_if = "is_true")]
+    pub include_media_sources: bool,
+    #[serde(default, alias = "include_file_paths", skip_serializing_if = "is_false")]
+    pub include_paths: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub include_user_state: bool,
+}
+
+impl Default for RemoteCatalogConfigDto {
+    fn default() -> Self {
+        Self {
+            refresh_mode: RemoteCatalogRefreshModeDto::default(),
+            refresh_on_startup: false,
+            page_size: default_remote_catalog_page_size(),
+            request_delay_ms: default_remote_catalog_request_delay_ms(),
+            concurrency: default_remote_catalog_concurrency(),
+            include_media_sources: default_as_true(),
+            include_paths: false,
+            include_user_state: false,
+        }
+    }
+}
+
+impl RemoteCatalogConfigDto {
+    pub fn is_default(&self) -> bool { self == &Self::default() }
+
+    pub fn prepare(&self, input_name: &Arc<str>) -> Result<(), TuliproxError> {
+        if self.page_size == 0 {
+            return Err(TuliproxError::ConfigInput(format!(
+                "remote catalog page_size must be greater than zero (input: {input_name})"
+            )));
+        }
+        if self.concurrency == 0 {
+            return Err(TuliproxError::ConfigInput(format!(
+                "remote catalog concurrency must be greater than zero (input: {input_name})"
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Copy, Clone, serde::Serialize, serde::Deserialize, Sequence, PartialEq, Eq, Default)]
+pub enum RemotePlaybackInfoPolicyDto {
+    #[serde(rename = "on_demand")]
+    #[default]
+    OnDemand,
+    #[serde(rename = "disabled")]
+    Disabled,
+}
+
+pub fn is_default_remote_playback_info_policy(value: &RemotePlaybackInfoPolicyDto) -> bool {
+    *value == RemotePlaybackInfoPolicyDto::default()
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RemotePlaybackConfigDto {
+    #[serde(default, skip_serializing_if = "is_default_remote_playback_info_policy")]
+    pub playback_info_policy: RemotePlaybackInfoPolicyDto,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub preflight_streams: bool,
+    #[serde(default = "default_as_true", skip_serializing_if = "is_true")]
+    pub direct_play_only: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub allow_transcode: bool,
+    #[serde(default = "default_remote_playback_max_streams", skip_serializing_if = "is_default_remote_playback_max_streams")]
+    pub max_streams: u16,
+}
+
+impl Default for RemotePlaybackConfigDto {
+    fn default() -> Self {
+        Self {
+            playback_info_policy: RemotePlaybackInfoPolicyDto::default(),
+            preflight_streams: false,
+            direct_play_only: default_as_true(),
+            allow_transcode: false,
+            max_streams: default_remote_playback_max_streams(),
+        }
+    }
+}
+
+impl RemotePlaybackConfigDto {
+    pub fn is_default(&self) -> bool { self == &Self::default() }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RemoteEnrichmentConfigDto {
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub ffprobe: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub tmdb_lookup: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub fetch_images: bool,
+}
+
+impl RemoteEnrichmentConfigDto {
+    pub fn is_default(&self) -> bool { self == &Self::default() }
+}
+
+#[derive(Debug, Copy, Clone, serde::Serialize, serde::Deserialize, Sequence, PartialEq, Eq, Default)]
+pub enum RemoteImagePolicyDto {
+    #[serde(rename = "proxy_on_demand")]
+    #[default]
+    ProxyOnDemand,
+    #[serde(rename = "disabled")]
+    Disabled,
+}
+
+pub fn is_default_remote_image_policy(value: &RemoteImagePolicyDto) -> bool {
+    *value == RemoteImagePolicyDto::default()
+}
+
+#[derive(Debug, Copy, Clone, serde::Serialize, serde::Deserialize, Sequence, PartialEq, Eq)]
+pub enum RemoteLibraryKindDto {
+    #[serde(rename = "movies")]
+    Movies,
+    #[serde(rename = "tvshows", alias = "shows", alias = "series")]
+    TvShows,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RemoteLibrarySelectorDetailsDto {
+    #[serde(default, skip_serializing_if = "is_blank_optional_string")]
+    pub id: Option<String>,
+    #[serde(default, skip_serializing_if = "is_blank_optional_string")]
+    pub key: Option<String>,
+    #[serde(default, skip_serializing_if = "is_blank_optional_string")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<RemoteLibraryKindDto>,
+}
+
+impl RemoteLibrarySelectorDetailsDto {
+    fn prepare(&mut self) {
+        self.id = get_trimmed_string(self.id.as_deref());
+        self.key = get_trimmed_string(self.key.as_deref());
+        self.name = get_trimmed_string(self.name.as_deref());
+    }
+
+    fn is_empty(&self) -> bool {
+        self.id.as_ref().is_none_or(|s| s.trim().is_empty())
+            && self.key.as_ref().is_none_or(|s| s.trim().is_empty())
+            && self.name.as_ref().is_none_or(|s| s.trim().is_empty())
+            && self.kind.is_none()
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum RemoteLibrarySelectorDto {
+    Name(String),
+    Detailed(RemoteLibrarySelectorDetailsDto),
+}
+
+impl RemoteLibrarySelectorDto {
+    fn prepare(&mut self) {
+        match self {
+            Self::Name(name) => *name = name.trim().to_string(),
+            Self::Detailed(details) => details.prepare(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        match self {
+            Self::Name(name) => name.trim().is_empty(),
+            Self::Detailed(details) => details.is_empty(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RemoteMediaInputConfigDto {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub libraries: Vec<RemoteLibrarySelectorDto>,
+    #[serde(default, skip_serializing_if = "RemoteCatalogConfigDto::is_default")]
+    pub catalog: RemoteCatalogConfigDto,
+    #[serde(default, skip_serializing_if = "RemotePlaybackConfigDto::is_default")]
+    pub playback: RemotePlaybackConfigDto,
+    #[serde(default, skip_serializing_if = "RemoteEnrichmentConfigDto::is_default")]
+    pub enrichment: RemoteEnrichmentConfigDto,
+    #[serde(default, skip_serializing_if = "is_default_remote_image_policy")]
+    pub image_policy: RemoteImagePolicyDto,
+    #[serde(default, skip_serializing_if = "is_blank_optional_string")]
+    pub token: Option<String>,
+    #[serde(default, skip_serializing_if = "is_blank_optional_string")]
+    pub api_key: Option<String>,
+    #[serde(default, skip_serializing_if = "is_blank_optional_string")]
+    pub user_id: Option<String>,
+    #[serde(default, skip_serializing_if = "is_blank_optional_string")]
+    pub account_token: Option<String>,
+    #[serde(default, skip_serializing_if = "is_blank_optional_string")]
+    pub server_id: Option<String>,
+    #[serde(default, skip_serializing_if = "is_blank_optional_string")]
+    pub machine_id: Option<String>,
+    #[serde(default, skip_serializing_if = "is_blank_optional_string")]
+    pub server_name: Option<String>,
+    #[serde(default = "default_as_true", skip_serializing_if = "is_true")]
+    pub prefer_https: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub allow_relay: bool,
+}
+
+impl Default for RemoteMediaInputConfigDto {
+    fn default() -> Self {
+        Self {
+            libraries: Vec::new(),
+            catalog: RemoteCatalogConfigDto::default(),
+            playback: RemotePlaybackConfigDto::default(),
+            enrichment: RemoteEnrichmentConfigDto::default(),
+            image_policy: RemoteImagePolicyDto::default(),
+            token: None,
+            api_key: None,
+            user_id: None,
+            account_token: None,
+            server_id: None,
+            machine_id: None,
+            server_name: None,
+            prefer_https: default_as_true(),
+            allow_relay: false,
+        }
+    }
+}
+
+impl RemoteMediaInputConfigDto {
+    pub fn prepare(&mut self, input_name: &Arc<str>) -> Result<(), TuliproxError> {
+        self.token = get_trimmed_string(self.token.as_deref());
+        self.api_key = get_trimmed_string(self.api_key.as_deref());
+        self.user_id = get_trimmed_string(self.user_id.as_deref());
+        self.account_token = get_trimmed_string(self.account_token.as_deref());
+        self.server_id = get_trimmed_string(self.server_id.as_deref());
+        self.machine_id = get_trimmed_string(self.machine_id.as_deref());
+        self.server_name = get_trimmed_string(self.server_name.as_deref());
+        self.catalog.prepare(input_name)?;
+
+        for library in &mut self.libraries {
+            library.prepare();
+        }
+        if self.libraries.iter().any(RemoteLibrarySelectorDto::is_empty) {
+            return Err(TuliproxError::ConfigInput(format!(
+                "remote library selectors must not be empty (input: {input_name})"
+            )));
+        }
+        Ok(())
+    }
+
+    pub fn has_any_emby_jellyfin_auth(&self) -> bool {
+        self.token.is_some() || self.api_key.is_some()
+    }
+
+    pub fn has_any_plex_token(&self) -> bool { self.account_token.is_some() || self.token.is_some() }
+
+    pub fn has_plex_server_selector(&self) -> bool {
+        self.server_id.is_some() || self.machine_id.is_some() || self.server_name.is_some()
     }
 }
 
@@ -495,6 +817,8 @@ pub struct ConfigInputDto {
     pub enabled: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub options: Option<ConfigInputOptionsDto>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote: Option<RemoteMediaInputConfigDto>,
     #[serde(default, skip_serializing_if = "is_blank_optional_string")]
     pub cache_duration: Option<String>,
     #[serde(skip)]
@@ -531,6 +855,7 @@ impl Default for ConfigInputDto {
             persist: None,
             enabled: default_as_true(),
             options: None,
+            remote: None,
             cache_duration: None,
             cache_duration_seconds: 0,
             aliases: None,
@@ -566,7 +891,109 @@ impl ConfigInputDto {
                 }
             }
             InputType::Library => InputType::Library,
+            InputType::Emby => InputType::Emby,
+            InputType::Jellyfin => InputType::Jellyfin,
+            InputType::Plex => InputType::Plex,
         };
+    }
+
+    fn prepare_remote_media_input(&mut self) -> Result<(), TuliproxError> {
+        if !self.input_type.is_remote_media_server() {
+            return Ok(());
+        }
+
+        if self.url.starts_with(BATCH_SCHEME_PREFIX) || self.url.starts_with(PROVIDER_SCHEME_PREFIX) {
+            return Err(TuliproxError::ConfigInput(format!(
+                "remote media-server input does not support batch:// or provider:// URLs (input: {})",
+                self.name
+            )));
+        }
+        if self.aliases.as_ref().is_some_and(|aliases| !aliases.is_empty()) {
+            return Err(TuliproxError::ConfigInput(format!(
+                "remote media-server input does not support aliases (input: {})",
+                self.name
+            )));
+        }
+        if self.staged.as_ref().is_some_and(|staged| staged.enabled) {
+            return Err(TuliproxError::ConfigInput(format!(
+                "remote media-server input does not support staged inputs (input: {})",
+                self.name
+            )));
+        }
+        if self.epg.is_some() {
+            return Err(TuliproxError::ConfigInput(format!(
+                "remote media-server input does not support EPG configuration (input: {})",
+                self.name
+            )));
+        }
+        if self.panel_api.is_some() {
+            return Err(TuliproxError::ConfigInput(format!(
+                "remote media-server input does not support panel_api configuration (input: {})",
+                self.name
+            )));
+        }
+        if self.provider.as_ref().is_some_and(|provider| !provider.is_empty()) {
+            return Err(TuliproxError::ConfigInput(format!(
+                "remote media-server input does not support provider failover definitions (input: {})",
+                self.name
+            )));
+        }
+        if self.max_connections > 0 {
+            return Err(TuliproxError::ConfigInput(format!(
+                "remote media-server input uses remote.playback.max_streams instead of max_connections (input: {})",
+                self.name
+            )));
+        }
+
+        let Some(remote) = self.remote.as_mut() else {
+            return Err(TuliproxError::ConfigInput(format!(
+                "remote configuration is mandatory for input type {} (input: {})",
+                self.input_type, self.name
+            )));
+        };
+        remote.prepare(&self.name)?;
+        if remote.libraries.is_empty() {
+            return Err(TuliproxError::ConfigInput(format!(
+                "remote media-server input requires at least one selected library (input: {})",
+                self.name
+            )));
+        }
+
+        match self.input_type {
+            InputType::Emby | InputType::Jellyfin => {
+                if self.url.trim().is_empty() {
+                    return Err(TuliproxError::ConfigInput(format!(
+                        "url is mandatory for input type {} (input: {})",
+                        self.input_type, self.name
+                    )));
+                }
+                let has_login = self.username.as_ref().is_some_and(|u| !u.trim().is_empty())
+                    && self.password.as_ref().is_some_and(|p| !p.trim().is_empty());
+                if !remote.has_any_emby_jellyfin_auth() && !has_login {
+                    return Err(TuliproxError::ConfigInput(format!(
+                        "remote input type {} requires remote token/api_key or username/password bootstrap credentials (input: {})",
+                        self.input_type, self.name
+                    )));
+                }
+            }
+            InputType::Plex => {
+                if !remote.has_any_plex_token() {
+                    return Err(TuliproxError::ConfigInput(format!(
+                        "remote input type plex requires remote.account_token or remote.token (input: {})",
+                        self.name
+                    )));
+                }
+                if !remote.has_plex_server_selector() {
+                    return Err(TuliproxError::ConfigInput(format!(
+                        "remote input type plex requires a server selector such as remote.machine_id, remote.server_id, or remote.server_name (input: {})",
+                        self.name
+                    )));
+                }
+            }
+            InputType::M3u | InputType::Xtream | InputType::M3uBatch | InputType::XtreamBatch | InputType::Library => {}
+        }
+
+        Ok(())
     }
 
     #[allow(clippy::cast_possible_truncation)]
@@ -590,6 +1017,7 @@ impl ConfigInputDto {
 
         self.url = self.url.trim().to_string();
         self.normalize_input_type_from_batch_url();
+        self.prepare_remote_media_input()?;
         if self.url.starts_with(PROVIDER_SCHEME_PREFIX)
             && matches!(self.input_type, InputType::M3uBatch | InputType::XtreamBatch)
         {
@@ -779,7 +1207,9 @@ impl ConfigInputDto {
     }
 
     pub fn prepare_type(&mut self) -> Result<(), TuliproxError> {
+        self.url = self.url.trim().to_string();
         self.normalize_input_type_from_batch_url();
+        self.prepare_remote_media_input()?;
         if self.url.starts_with(PROVIDER_SCHEME_PREFIX)
             && matches!(self.input_type, InputType::M3uBatch | InputType::XtreamBatch)
         {
@@ -1015,6 +1445,151 @@ mod tests {
 
     fn create_test_dto() -> ConfigInputDto {
         ConfigInputDto { name: "test_input".intern(), ..ConfigInputDto::default() }
+    }
+
+    fn remote_config_with_library() -> RemoteMediaInputConfigDto {
+        RemoteMediaInputConfigDto {
+            libraries: vec![RemoteLibrarySelectorDto::Name("Movies".to_string())],
+            ..RemoteMediaInputConfigDto::default()
+        }
+    }
+
+    fn prepare_dto(dto: &mut ConfigInputDto) -> Result<u16, TuliproxError> {
+        dto.prepare(0, false, &HashSet::new(), None)
+    }
+
+    #[test]
+    fn remote_media_defaults_are_conservative() {
+        let remote = RemoteMediaInputConfigDto::default();
+
+        assert_eq!(remote.catalog.page_size, 100);
+        assert_eq!(remote.catalog.request_delay_ms, 250);
+        assert_eq!(remote.catalog.concurrency, 1);
+        assert!(remote.catalog.include_media_sources);
+        assert!(!remote.catalog.include_paths);
+        assert!(!remote.catalog.include_user_state);
+        assert!(!remote.catalog.refresh_on_startup);
+        assert!(remote.playback.direct_play_only);
+        assert!(!remote.playback.allow_transcode);
+        assert!(!remote.playback.preflight_streams);
+        assert_eq!(remote.playback.max_streams, 1);
+        assert!(!remote.enrichment.ffprobe);
+        assert!(!remote.enrichment.tmdb_lookup);
+        assert!(!remote.enrichment.fetch_images);
+        assert_eq!(remote.image_policy, RemoteImagePolicyDto::ProxyOnDemand);
+        assert!(!remote.allow_relay);
+    }
+
+    #[test]
+    fn prepare_accepts_emby_remote_with_token_and_library() {
+        let mut dto = ConfigInputDto {
+            name: "emby_remote".intern(),
+            input_type: InputType::Emby,
+            url: " https://media.example.invalid/ ".to_string(),
+            remote: Some(RemoteMediaInputConfigDto {
+                token: Some(" token-value ".to_string()),
+                ..remote_config_with_library()
+            }),
+            ..ConfigInputDto::default()
+        };
+
+        prepare_dto(&mut dto).expect("emby remote config should prepare");
+
+        assert_eq!(dto.url, "https://media.example.invalid/");
+        assert!(dto.input_type.is_remote_media_server());
+        assert_eq!(dto.remote.as_ref().and_then(|remote| remote.token.as_deref()), Some("token-value"));
+    }
+
+    #[test]
+    fn prepare_rejects_remote_without_remote_block() {
+        let mut dto = ConfigInputDto {
+            name: "emby_remote".intern(),
+            input_type: InputType::Emby,
+            url: "https://media.example.invalid".to_string(),
+            ..ConfigInputDto::default()
+        };
+
+        let err = prepare_dto(&mut dto).expect_err("remote block should be mandatory");
+        assert!(err.to_string().contains("remote configuration is mandatory"));
+    }
+
+    #[test]
+    fn prepare_rejects_remote_provider_scheme_url() {
+        let mut dto = ConfigInputDto {
+            name: "emby_remote".intern(),
+            input_type: InputType::Emby,
+            url: "provider://media-server".to_string(),
+            remote: Some(RemoteMediaInputConfigDto {
+                token: Some("token-value".to_string()),
+                ..remote_config_with_library()
+            }),
+            ..ConfigInputDto::default()
+        };
+
+        let err = prepare_dto(&mut dto).expect_err("remote input must not use provider URLs");
+        assert!(err.to_string().contains("does not support batch:// or provider://"));
+    }
+
+    #[test]
+    fn prepare_rejects_remote_staged_input() {
+        let mut dto = ConfigInputDto {
+            name: "emby_remote".intern(),
+            input_type: InputType::Emby,
+            url: "https://media.example.invalid".to_string(),
+            remote: Some(RemoteMediaInputConfigDto {
+                token: Some("token-value".to_string()),
+                ..remote_config_with_library()
+            }),
+            staged: Some(StagedInputDto { enabled: true, name: "staged".intern(), ..StagedInputDto::default() }),
+            ..ConfigInputDto::default()
+        };
+
+        let err = prepare_dto(&mut dto).expect_err("remote input must reject staged config");
+        assert!(err.to_string().contains("does not support staged inputs"));
+    }
+
+    #[test]
+    fn prepare_rejects_plex_without_token_or_server_selector() {
+        let mut without_token = ConfigInputDto {
+            name: "plex_remote".intern(),
+            input_type: InputType::Plex,
+            remote: Some(RemoteMediaInputConfigDto {
+                machine_id: Some("machine".to_string()),
+                ..remote_config_with_library()
+            }),
+            ..ConfigInputDto::default()
+        };
+        let err = prepare_dto(&mut without_token).expect_err("plex token should be mandatory");
+        assert!(err.to_string().contains("requires remote.account_token or remote.token"));
+
+        let mut without_selector = ConfigInputDto {
+            name: "plex_remote".intern(),
+            input_type: InputType::Plex,
+            remote: Some(RemoteMediaInputConfigDto {
+                account_token: Some("token".to_string()),
+                ..remote_config_with_library()
+            }),
+            ..ConfigInputDto::default()
+        };
+        let err = prepare_dto(&mut without_selector).expect_err("plex server selector should be mandatory");
+        assert!(err.to_string().contains("requires a server selector"));
+    }
+
+    #[test]
+    fn prepare_accepts_plex_without_input_url_when_discovery_is_configured() {
+        let mut dto = ConfigInputDto {
+            name: "plex_remote".intern(),
+            input_type: InputType::Plex,
+            remote: Some(RemoteMediaInputConfigDto {
+                account_token: Some("token".to_string()),
+                machine_id: Some("machine".to_string()),
+                ..remote_config_with_library()
+            }),
+            ..ConfigInputDto::default()
+        };
+
+        prepare_dto(&mut dto).expect("plex discovery config should not require input.url");
+        assert_eq!(dto.input_type, InputType::Plex);
     }
 
     #[test]

--- a/shared/src/model/config/macros.rs
+++ b/shared/src/model/config/macros.rs
@@ -8,7 +8,7 @@ macro_rules! check_input_credentials {
 
         if !matches!($input_type, InputType::Library) {
             $this.url = $this.url.trim().to_string();
-            if $this.url.is_empty() {
+            if !matches!($input_type, InputType::Plex) && $this.url.is_empty() {
                 return Err($crate::error::TuliproxError::ConfigInput(format!("url for input is mandatory{}", __tp_input_name_suffix)));
             }
 
@@ -76,8 +76,9 @@ macro_rules! check_input_credentials {
                     }
                 }
             }
-            InputType::Library => {
-                // nothing to do
+            InputType::Library | InputType::Emby | InputType::Jellyfin | InputType::Plex => {
+                // Remote media-server credentials live in the dedicated remote block; detailed
+                // validation happens in ConfigInputDto/ConfigInput prepare methods.
             }
         }
     };
@@ -125,7 +126,7 @@ macro_rules! check_input_connections {
                     }
                 }
             }
-            InputType::Library => {}
+            InputType::Library | InputType::Emby | InputType::Jellyfin | InputType::Plex => {}
         }
     };
 }

--- a/shared/src/utils/default_utils.rs
+++ b/shared/src/utils/default_utils.rs
@@ -22,6 +22,10 @@ pub fn is_blank_optional_string(s: &Option<String>) -> bool {
     s.as_ref().is_none_or(|s| s.chars().all(|c| c.is_whitespace()))
 }
 
+pub fn is_non_blank_optional_string(s: &Option<String>) -> bool {
+    s.as_ref().is_some_and(|s| !s.chars().all(|c| c.is_whitespace()))
+}
+
 pub fn is_blank_optional_arc_str(s: &Option<Arc<str>>) -> bool {
     s.as_ref().is_none_or(|s| s.chars().all(|c| c.is_whitespace()))
 }

--- a/shared/src/utils/default_utils.rs
+++ b/shared/src/utils/default_utils.rs
@@ -22,9 +22,7 @@ pub fn is_blank_optional_string(s: &Option<String>) -> bool {
     s.as_ref().is_none_or(|s| s.chars().all(|c| c.is_whitespace()))
 }
 
-pub fn is_non_blank_optional_string(s: &Option<String>) -> bool {
-    s.as_ref().is_some_and(|s| !s.chars().all(|c| c.is_whitespace()))
-}
+pub fn is_non_blank_optional_string(s: &Option<String>) -> bool { !is_blank_optional_string(s) }
 
 pub fn is_blank_optional_arc_str(s: &Option<Arc<str>>) -> bool {
     s.as_ref().is_none_or(|s| s.chars().all(|c| c.is_whitespace()))


### PR DESCRIPTION
## Summary

Adds the first remote media input foundation for future Emby/Jellyfin/Plex catalog acquisition and proxied playback support.

This PR intentionally stops at the shared foundation layer. It does **not** wire a complete provider adapter into playlist processing or expose a new user-facing remote media workflow yet.

Included:

- Adds `InputType::{Emby,Jellyfin,Plex}` and conservative remote input config validation/defaults.
- Adds a `backend/src/remote_media/` anti-corruption seam with internal remote media types, stable error kinds, redaction helpers, and HTTP wrapper primitives.
- Adds DTO seams and redacted fixtures for Emby/Jellyfin/Plex API shapes.
- Adds complete-before-publish remote catalog refresh staging primitives.
- Adds a separate remote playlist cache path prefix (`remote_{input_name}.db`).
- Adds mapping from remote catalog snapshots into existing playlist group/item shapes without assigning target `virtual_id` in Source Acquisition.
- Adds remote playback proxy primitives with `Range` forwarding and safe response-header filtering.

Security/privacy defaults:

- Remote tokens, upstream URLs, playback leases, provider paths, and upstream stream URLs stay inside remote-media boundaries.
- Remote stream URLs use internal `remote://...` references only.
- Remote inputs reject provider failover/panel/alias/staged semantics.
- Defaults are conservative: direct-play-only, no transcode, no ffprobe/TMDB/image downloads during import, and no Plex relay by default.

## Non-goals

- No complete Emby/Jellyfin/Plex runtime adapter is activated in this PR.
- No remote media server credentials or real upstream details are included.
- No documentation/domain-context files are included in this PR.

## Validation

```bash
nix shell nixpkgs#cargo nixpkgs#rustc nixpkgs#gcc nixpkgs#gnumake nixpkgs#perl nixpkgs#pkg-config nixpkgs#openssl -c cargo test -p tuliprox remote_media
nix shell nixpkgs#cargo nixpkgs#rustc nixpkgs#gcc nixpkgs#gnumake nixpkgs#perl nixpkgs#pkg-config nixpkgs#openssl -c cargo check --workspace
git diff --cached --check
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Emby, Jellyfin, and Plex support: remote catalog browsing, library selection, paginated catalog refresh with caching, and remote playback proxying (streams/images).
  * On-disk playlist storage and loading for remote inputs.
  * UI labels updated to show Emby/Jellyfin/Plex where applicable.

* **Bug Fixes**
  * Improved validation and clearer errors for unsupported remote configurations and catalog import paths.
  * Provider-connection behavior for probing adjusted for remote servers.
  * Sensitive remote URLs/headers are redacted in logs and errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->