### PR TITLE
feat: enable media-server TMDB VOD lookup

### DIFF
--- a/backend/src/api/endpoints/xtream_api.rs
+++ b/backend/src/api/endpoints/xtream_api.rs
@@ -950,7 +950,11 @@ pub async fn xtream_get_stream_info_response(
     };
 
     if let Ok(pli) = xtream_get_item_for_stream_id(virtual_id, app_state, target, Some(cluster)).await {
-        if pli.item_type.is_local() {
+        let is_media_server_item = app_state
+            .app_config
+            .get_input_by_name(&pli.input_name)
+            .is_some_and(|input| input.input_type.is_media_server());
+        if pli.item_type.is_local() || is_media_server_item {
             let Ok(xtream_output) = target.get_xtream_output().ok_or_else(|| {
                 TuliproxError::ApiXtream(format!("Unexpected: xtream output required for target {}", target.name))
             }) else {

--- a/backend/src/api/model/metadata_update_manager.rs
+++ b/backend/src/api/model/metadata_update_manager.rs
@@ -8,8 +8,9 @@ use crate::{
     },
     repository::{
         get_input_storage_path, get_target_id_mapping_file, persist_input_live_info_batch,
-        persist_input_series_info_batch, persist_input_vod_info_batch, write_playlist_batch_item_upsert,
-        xtream_get_file_path, BPlusTree, BPlusTreeQuery, BPlusTreeUpdate, TargetIdMapping,
+        persist_input_media_server_vod_info_batch, persist_input_series_info_batch, persist_input_vod_info_batch,
+        write_playlist_batch_item_upsert, xtream_get_file_path, BPlusTree, BPlusTreeQuery, BPlusTreeUpdate,
+        TargetIdMapping,
     },
     utils::{debug_if_enabled, FileReadGuard},
 };
@@ -2579,6 +2580,7 @@ impl InputWorker {
     }
 
     // Changed to static method
+    #[allow(clippy::too_many_lines)]
     async fn flush_batch_static(
         input_name: &str,
         app_state_weak: Option<&Weak<AppState>>,
@@ -2591,6 +2593,11 @@ impl InputWorker {
         let Some(app_state) = app_state_weak.and_then(Weak::upgrade) else { return };
         let app_config = &app_state.app_config;
         let cfg = app_config.config.load();
+        let input_name_arc = Arc::<str>::from(input_name);
+        let media_server_input = app_state
+            .app_config
+            .get_input_by_name(&input_name_arc)
+            .filter(|input| input.input_type.is_media_server());
         let vod_updates = batch_buffer.take_vod_updates();
         let series_updates = batch_buffer.take_series_updates();
         let live_updates = batch_buffer.take_live_updates();
@@ -2619,6 +2626,28 @@ impl InputWorker {
                         .await
                     {
                         error!("Failed to flush VOD batch for input {input_name}: {e}");
+                    }
+                }
+
+                if media_server_input.is_some() {
+                    let media_server_updates: Vec<(Arc<str>, VideoStreamProperties)> = vod_updates
+                        .iter()
+                        .filter_map(|(id, props)| match id {
+                            ProviderIdType::Text(provider_id) => Some((provider_id.clone(), props.clone())),
+                            ProviderIdType::Id(_) => None,
+                        })
+                        .collect();
+                    if !media_server_updates.is_empty() {
+                        if let Err(e) = persist_input_media_server_vod_info_batch(
+                            app_config,
+                            &storage_path,
+                            input_name,
+                            media_server_updates,
+                        )
+                        .await
+                        {
+                            error!("Failed to flush media-server VOD batch for input {input_name}: {e}");
+                        }
                     }
                 }
             }

--- a/backend/src/media_server/enrichment.rs
+++ b/backend/src/media_server/enrichment.rs
@@ -1,0 +1,52 @@
+use crate::{
+    model::{AppConfig, ConfigInput},
+    repository::{load_input_media_server_playlist_item_by_provider_id, persist_input_media_server_vod_info_batch},
+};
+use shared::{
+    error::TuliproxError,
+    model::{PlaylistItemType, StreamProperties, VideoStreamProperties, XtreamPlaylistItem},
+};
+use std::{io, path::Path, sync::Arc};
+
+pub async fn load_media_server_vod_item_and_properties(
+    app_config: &Arc<AppConfig>,
+    storage_path: &Path,
+    input: &ConfigInput,
+    provider_id: &str,
+) -> Result<Option<(XtreamPlaylistItem, VideoStreamProperties)>, TuliproxError> {
+    if !input.input_type.is_media_server() {
+        return Ok(None);
+    }
+
+    let Some(item) = load_input_media_server_playlist_item_by_provider_id(
+        app_config,
+        storage_path,
+        &input.name,
+        provider_id,
+        PlaylistItemType::Video,
+    )
+    .await?
+    else {
+        return Ok(None);
+    };
+
+    let properties = item.additional_properties.as_ref().and_then(|properties| match properties {
+        StreamProperties::Video(video) => Some(video.as_ref().clone()),
+        StreamProperties::Live(_) | StreamProperties::Series(_) | StreamProperties::Episode(_) => None,
+    });
+
+    Ok(properties.map(|properties| (item, properties)))
+}
+
+pub async fn persist_media_server_vod_info_batch_for_input(
+    app_config: &Arc<AppConfig>,
+    storage_path: &Path,
+    input: &ConfigInput,
+    updates: Vec<(Arc<str>, VideoStreamProperties)>,
+) -> Result<(), io::Error> {
+    if !input.input_type.is_media_server() || updates.is_empty() {
+        return Ok(());
+    }
+
+    persist_input_media_server_vod_info_batch(app_config, storage_path, &input.name, updates).await
+}

--- a/backend/src/media_server/mod.rs
+++ b/backend/src/media_server/mod.rs
@@ -7,6 +7,7 @@
 pub mod catalog;
 pub mod client;
 pub mod emby;
+pub mod enrichment;
 pub mod errors;
 pub mod jellyfin;
 pub mod playback;
@@ -20,6 +21,7 @@ pub mod test_fixtures;
 
 pub use catalog::*;
 pub use client::*;
+pub use enrichment::*;
 pub use errors::*;
 pub use playback::*;
 pub use playlist_mapper::*;

--- a/backend/src/model/config/input.rs
+++ b/backend/src/model/config/input.rs
@@ -474,6 +474,15 @@ impl ConfigInput {
     }
 
     #[inline]
+    pub fn media_server_tmdb_lookup_enabled(&self) -> bool {
+        self.input_type.is_media_server()
+            && self
+                .media_server
+                .as_ref()
+                .is_some_and(|media_server| media_server.enrichment.tmdb_lookup)
+    }
+
+    #[inline]
     pub fn has_any_flags(&self, flags: ConfigInputFlagsSet) -> bool {
         self.has_any_flags_or(flags, false)
     }
@@ -967,6 +976,22 @@ mod tests {
         assert_eq!(media_server.server_id.as_deref(), Some("server"));
         assert_eq!(media_server.machine_id.as_deref(), Some("machine"));
         assert_eq!(media_server.server_name.as_deref(), Some("server-name"));
+    }
+
+    #[test]
+    fn media_server_tmdb_lookup_is_separate_from_legacy_resolve_tmdb_flag() {
+        let input = ConfigInput {
+            name: "plex_media_server".into(),
+            input_type: InputType::Plex,
+            media_server: Some(MediaServerInputConfig {
+                enrichment: MediaServerEnrichmentConfigDto { tmdb_lookup: true, ..Default::default() },
+                ..media_server_config_with_library()
+            }),
+            ..Default::default()
+        };
+
+        assert!(input.media_server_tmdb_lookup_enabled());
+        assert!(!input.has_flag(ConfigInputFlags::ResolveTmdb));
     }
 
     #[test]

--- a/backend/src/processing/processor/mod.rs
+++ b/backend/src/processing/processor/mod.rs
@@ -48,6 +48,7 @@ macro_rules! create_resolve_options_function_for_xtream_target {
                     Some(_) => {
                         let input_options = fpl.input.options.as_ref();
                         let input_is_xtream = fpl.input.input_type.is_xtream();
+                        let media_server_tmdb_lookup = fpl.input.media_server_tmdb_lookup_enabled();
 
                         let (
                             resolve_tmdb_missing,
@@ -57,7 +58,7 @@ macro_rules! create_resolve_options_function_for_xtream_target {
                             resolve_background
                         ) = if let Some(options) = input_options {
                             (
-                                options.has_flag($crate::model::ConfigInputFlags::ResolveTmdb),
+                                options.has_flag($crate::model::ConfigInputFlags::ResolveTmdb) || media_server_tmdb_lookup,
                                 options.has_flag($crate::model::ConfigInputFlags::[<Resolve $cluster:camel>]),
                                 options.has_flag($crate::model::ConfigInputFlags::[<Probe $cluster:camel>]),
                                 options.resolve_delay,
@@ -65,7 +66,7 @@ macro_rules! create_resolve_options_function_for_xtream_target {
                             )
                         } else {
                             (
-                                false,
+                                media_server_tmdb_lookup,
                                 false,
                                 false,
                                 shared::utils::default_resolve_delay_secs(),

--- a/backend/src/processing/processor/xtream_vod.rs
+++ b/backend/src/processing/processor/xtream_vod.rs
@@ -1,6 +1,7 @@
 use crate::api::model::{ActiveProviderManager, ProviderHandle};
 use crate::api::model::{ProviderIdType, ResolveReason, ResolveReasonSet, UpdateTask};
 use crate::library::{MetadataResolver, MetadataStorage};
+use crate::media_server::{load_media_server_vod_item_and_properties, persist_media_server_vod_info_batch_for_input};
 use crate::model::FetchedPlaylist;
 use crate::model::InputSource;
 use crate::model::{AppConfig, ConfigTarget};
@@ -9,9 +10,8 @@ use crate::processing::input_cache::resolve_input_storage_path;
 use crate::processing::processor::playlist::PlaylistProcessingContext;
 use crate::processing::processor::{
     create_resolve_options_function_for_xtream_target, process_foreground_retry_once, select_cancel_token,
-    ProbeHandleGuard,
-    ResolveOptions, ResolveOptionsFlags, FOREGROUND_BATCH_SIZE as BATCH_SIZE, FOREGROUND_MIN_RETRY_DELAY_SECS,
-    FOREGROUND_RETRY_BATCH_MAX_SIZE as RETRY_BATCH_MAX_SIZE,
+    ProbeHandleGuard, ResolveOptions, ResolveOptionsFlags, FOREGROUND_BATCH_SIZE as BATCH_SIZE,
+    FOREGROUND_MIN_RETRY_DELAY_SECS, FOREGROUND_RETRY_BATCH_MAX_SIZE as RETRY_BATCH_MAX_SIZE,
 };
 use crate::ptt::ptt_parse_title;
 use crate::repository::persist_input_vod_info;
@@ -132,7 +132,8 @@ async fn playlist_resolve_vod_info(
         true
     };
 
-    let resolve_tmdb_enabled = fpl.input.has_flag(ConfigInputFlags::ResolveTmdb);
+    let resolve_tmdb_enabled = fpl.input.has_flag(ConfigInputFlags::ResolveTmdb)
+        || fpl.input.media_server_tmdb_lookup_enabled();
 
     if resolve_options.has_flag(ResolveOptionsFlags::Background) && ctx.metadata_manager.is_some() {
         queue_background_vod_info(ctx, fpl, filter, &resolve_options, do_probe, resolve_tmdb_enabled);
@@ -232,7 +233,6 @@ async fn process_immediate_vod_info(
                             db_query_holder = None;
                             _db_lock_holder = None;
 
-                            // Filter for u32 IDs for persistence
                             let updates: Vec<(u32, VideoStreamProperties)> = batch
                                 .iter()
                                 .filter_map(|(id, props)| {
@@ -243,11 +243,24 @@ async fn process_immediate_vod_info(
                                     }
                                 })
                                 .collect();
-
-                            if updates.is_empty() {
-                                batch.clear();
+                            let media_server_updates: Vec<(Arc<str>, VideoStreamProperties)> = if input.input_type.is_media_server() {
+                                batch
+                                    .iter()
+                                    .filter_map(|(id, props)| {
+                                        if let ProviderIdType::Text(provider_id) = id {
+                                            Some((provider_id.clone(), props.clone()))
+                                        } else {
+                                            None
+                                        }
+                                    })
+                                    .collect()
                             } else {
-                                match persist_input_vod_info_batch(
+                                Vec::new()
+                            };
+
+                            let mut persist_failed = false;
+                            if !updates.is_empty() {
+                                if let Err(err) = persist_input_vod_info_batch(
                                     &ctx.config,
                                     &storage_path,
                                     XtreamCluster::Video,
@@ -256,14 +269,31 @@ async fn process_immediate_vod_info(
                                 )
                                 .await
                                 {
-                                    Ok(()) => batch.clear(),
-                                    Err(err) => {
-                                        error!(
-                                            "persist_input_vod_info_batch failed for XtreamCluster::Video on input '{}'. batch.clear() skipped. Error: {err}",
-                                            input.name
-                                        );
-                                    }
+                                    persist_failed = true;
+                                    error!(
+                                        "persist_input_vod_info_batch failed for XtreamCluster::Video on input '{}'. batch.clear() skipped. Error: {err}",
+                                        input.name
+                                    );
                                 }
+                            }
+                            if !media_server_updates.is_empty() {
+                                if let Err(err) = persist_media_server_vod_info_batch_for_input(
+                                    &ctx.config,
+                                    &storage_path,
+                                    input,
+                                    media_server_updates,
+                                )
+                                .await
+                                {
+                                    persist_failed = true;
+                                    error!(
+                                        "persist_input_media_server_vod_info_batch failed on input '{}'. batch.clear() skipped. Error: {err}",
+                                        input.name
+                                    );
+                                }
+                            }
+                            if !persist_failed {
+                                batch.clear();
                             }
                         }
 
@@ -341,10 +371,17 @@ async fn process_immediate_vod_info(
         // Release lock before final persist
         _db_lock_holder = None;
 
-        let updates: Vec<(u32, VideoStreamProperties)> = batch
-            .into_iter()
-            .filter_map(|(id, props)| if let ProviderIdType::Id(vid) = id { Some((vid, props)) } else { None })
-            .collect();
+        let mut updates: Vec<(u32, VideoStreamProperties)> = Vec::new();
+        let mut media_server_updates: Vec<(Arc<str>, VideoStreamProperties)> = Vec::new();
+        for (id, props) in batch {
+            match id {
+                ProviderIdType::Id(vid) => updates.push((vid, props)),
+                ProviderIdType::Text(provider_id) if input.input_type.is_media_server() => {
+                    media_server_updates.push((provider_id, props));
+                }
+                ProviderIdType::Text(_) => {}
+            }
+        }
 
         if !updates.is_empty() {
             if let Err(err) =
@@ -352,6 +389,14 @@ async fn process_immediate_vod_info(
                     .await
             {
                 error!("Failed to persist final batch VOD info: {err}");
+            }
+        }
+        if !media_server_updates.is_empty() {
+            if let Err(err) =
+                persist_media_server_vod_info_batch_for_input(&ctx.config, &storage_path, input, media_server_updates)
+                    .await
+            {
+                error!("Failed to persist final media-server batch VOD info: {err}");
             }
         }
     }
@@ -625,6 +670,21 @@ pub async fn update_vod_metadata(
         }
     }
 
+    if props.is_none() && stream_id_opt.is_none() && input.input_type.is_media_server() {
+        if let ProviderIdType::Text(provider_id) = &id {
+            match load_media_server_vod_item_and_properties(app_config, &storage_path, input, provider_id).await {
+                Ok(Some((item, loaded_props))) => {
+                    existing_item = Some(item);
+                    props = Some(loaded_props);
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    debug!("Failed to query media-server VOD metadata from input cache: {err}");
+                }
+            }
+        }
+    }
+
     let mut fetched_new = false;
     let mut properties_updated = false;
     let mut probe_failure: Option<ProbeFailureKind> = None;
@@ -700,7 +760,7 @@ pub async fn update_vod_metadata(
         return Err(shared::error::TuliproxError::Config(format!("No VOD properties available after fallback creation for {display_id}")));
     };
 
-    let resolve_tmdb_enabled = input.has_flag(ConfigInputFlags::ResolveTmdb);
+    let resolve_tmdb_enabled = input.has_flag(ConfigInputFlags::ResolveTmdb) || input.media_server_tmdb_lookup_enabled();
 
     // 2. Resolve TMDB/Date if missing and explicitly enabled for this input
     let missing_tmdb = properties.tmdb.is_none();
@@ -991,6 +1051,17 @@ pub async fn update_vod_metadata(
                 )
                 .await
                 .map_err(|e| shared::error::TuliproxError::Config(format!("Persist error: {e}")))?;
+            } else if input.input_type.is_media_server() {
+                if let ProviderIdType::Text(provider_id) = &id {
+                    persist_media_server_vod_info_batch_for_input(
+                        app_config,
+                        &storage_path,
+                        input,
+                        vec![(provider_id.clone(), properties.clone())],
+                    )
+                    .await
+                    .map_err(|e| shared::error::TuliproxError::Config(format!("Persist error: {e}")))?;
+                }
             }
 
             debug_if_enabled!("Successfully updated VOD metadata for '{}' (ID: {})", display_title, display_id);

--- a/backend/src/repository/playlist_repository.rs
+++ b/backend/src/repository/playlist_repository.rs
@@ -9,7 +9,7 @@ use crate::repository::{ensure_target_storage_path, get_input_storage_path, get_
 use crate::repository::{load_input_local_library_playlist, persist_input_library_playlist};
 use crate::repository::{load_input_m3u_playlist, m3u_get_file_path_for_db, m3u_write_playlist, persist_input_m3u_playlist};
 use crate::repository::{load_input_xtream_playlist, persist_input_xtream_playlist, xtream_get_file_path, xtream_get_storage_path, xtream_write_playlist};
-use crate::repository::BPlusTree;
+use crate::repository::{BPlusTree, BPlusTreeQuery, BPlusTreeUpdate};
 use crate::repository::{
     LocalLibraryDiskPlaylistSource, M3uDiskPlaylistSource, MemoryPlaylistSource, PlaylistSource,
     MediaServerDiskPlaylistSource, XtreamDiskPlaylistSource,
@@ -19,8 +19,11 @@ use crate::utils;
 use log::{info, warn};
 use shared::error::{ TuliproxError};
 use shared::model::xtream_const::XTREAM_CLUSTER;
-use shared::model::{InputType, M3uPlaylistItem, PlaylistEntry, PlaylistGroup, PlaylistItem, PlaylistItemHeader, PlaylistItemType, StreamProperties, VirtualId, XtreamCluster, XtreamPlaylistItem};
-use shared::utils::{is_dash_url, is_hls_url, Internable};
+use shared::model::{
+    InputType, M3uPlaylistItem, PlaylistEntry, PlaylistGroup, PlaylistItem, PlaylistItemHeader, PlaylistItemType,
+    StreamProperties, UUIDType, VideoStreamProperties, VirtualId, XtreamCluster, XtreamPlaylistItem,
+};
+use shared::utils::{generate_provider_playlist_uuid, is_dash_url, is_hls_url, Internable};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -559,6 +562,117 @@ pub async fn load_input_media_server_playlist(
     file_path: &Path,
 ) -> Result<Vec<PlaylistGroup>, TuliproxError> {
     load_input_local_library_playlist(app_config, file_path).await
+}
+
+pub async fn load_input_media_server_playlist_item_by_provider_id(
+    app_config: &Arc<AppConfig>,
+    storage_path: &Path,
+    input_name: &str,
+    provider_id: &str,
+    item_type: PlaylistItemType,
+) -> Result<Option<XtreamPlaylistItem>, TuliproxError> {
+    let input_name_arc = Arc::<str>::from(input_name);
+    let file_path = get_input_media_server_playlist_file_path(storage_path, &input_name_arc);
+    if !file_path.exists() {
+        return Ok(None);
+    }
+
+    let uuid = generate_provider_playlist_uuid(input_name, provider_id, item_type);
+    let file_lock = app_config.file_locks.read_lock(&file_path).await;
+    let file_path_display = file_path.display().to_string();
+    let file_path_display_for_query = file_path_display.clone();
+    let item = tokio::task::spawn_blocking(move || -> Result<Option<XtreamPlaylistItem>, TuliproxError> {
+        let _guard = file_lock;
+        let mut query = BPlusTreeQuery::<UUIDType, XtreamPlaylistItem>::try_new(&file_path).map_err(|err| {
+            TuliproxError::RepositoryLibrary(format!(
+                "failed to open media-server input playlist: {file_path_display_for_query} - {err}"
+            ))
+        })?;
+        query.query(&uuid).map_err(|err| {
+            TuliproxError::RepositoryLibrary(format!(
+                "failed to query media-server input playlist: {file_path_display_for_query} - {err}"
+            ))
+        })
+    })
+    .await
+    .map_err(|err| {
+        TuliproxError::RepositoryLibrary(format!(
+            "failed to join media-server input playlist query: {file_path_display} - {err}"
+        ))
+    })??;
+
+    Ok(item)
+}
+
+pub async fn persist_input_media_server_vod_info_batch(
+    app_config: &Arc<AppConfig>,
+    storage_path: &Path,
+    input_name: &str,
+    updates: Vec<(Arc<str>, VideoStreamProperties)>,
+) -> Result<(), std::io::Error> {
+    if updates.is_empty() {
+        return Ok(());
+    }
+
+    let input_name_arc = Arc::<str>::from(input_name);
+    let file_path = get_input_media_server_playlist_file_path(storage_path, &input_name_arc);
+    if !file_path.exists() {
+        return Ok(());
+    }
+
+    let file_lock = app_config.file_locks.write_lock(&file_path).await;
+    let file_path_clone = file_path.clone();
+    let input_name_owned = input_name.to_string();
+    tokio::task::spawn_blocking(move || -> Result<(), std::io::Error> {
+        let _guard = file_lock;
+        let mut tree: BPlusTreeUpdate<UUIDType, XtreamPlaylistItem> =
+            BPlusTreeUpdate::try_new_with_backoff(&file_path_clone).map_err(|err| {
+                std::io::Error::other(format!(
+                    "failed to open media-server BPlusTree for input {input_name_owned}: {err}"
+                ))
+            })?;
+
+        let mut deduped_updates: HashMap<Arc<str>, VideoStreamProperties> = HashMap::with_capacity(updates.len());
+        for (provider_id, props) in updates {
+            deduped_updates.insert(provider_id, props);
+        }
+
+        let mut updated_items = Vec::with_capacity(deduped_updates.len());
+        for (provider_id, props) in deduped_updates {
+            let uuid = generate_provider_playlist_uuid(&input_name_owned, &provider_id, PlaylistItemType::Video);
+            match tree.query(&uuid) {
+                Ok(Some(mut item)) => {
+                    item.additional_properties = Some(StreamProperties::Video(Box::new(props)));
+                    updated_items.push((uuid, item));
+                }
+                Ok(None) => {
+                    log::debug!("Could not find media-server VOD input entry for metadata update");
+                }
+                Err(err) => {
+                    log::debug!("Failed to query media-server VOD input entry for metadata update: {err}");
+                }
+            }
+        }
+
+        if !updated_items.is_empty() {
+            let refs: Vec<(&UUIDType, &XtreamPlaylistItem)> = updated_items.iter().map(|(id, item)| (id, item)).collect();
+            tree.update_batch(&refs).map_err(|err| {
+                std::io::Error::other(format!(
+                    "failed to write media-server metadata batch for input {input_name_owned}: {err}"
+                ))
+            })?;
+        }
+
+        Ok(())
+    })
+    .await
+    .map_err(|err| {
+        std::io::Error::other(format!(
+            "failed to join media-server metadata batch persist for {input_name}: {err}"
+        ))
+    })??;
+
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Draft follow-up for media-server TMDB lookup. This branch is based directly on `develop` so the PR diff stays focused and does not include #744.

#744 contains the concrete Plex adapter and the no-network provider-hint projection (`tmdb://...` -> stream metadata). This PR adds the smaller runtime lookup path that becomes active when a media-server input actually produces VOD items and `media_server.enrichment.tmdb_lookup` is enabled:

- keep `media_server.enrichment.tmdb_lookup` separate from legacy `options.resolve_tmdb`, but let the VOD metadata pipeline treat it as TMDB lookup opt-in
- load/persist media-server VOD metadata by stable media-server input cache identity during foreground/background metadata updates
- use the existing TMDB resolver to fill missing VOD `tmdb` / release date metadata, preferring any exact media-server TMDB hint already present on the item
- let Xtream `get_vod_info` serialize media-server VOD metadata from `VideoStreamProperties`

## Draft note

This is intentionally **draft**. Against current `develop` the runtime path is effectively inert/no-op until a concrete media-server adapter such as #744 imports media-server VOD catalog items. Keeping it based on `develop` avoids a large stacked diff while preserving a smaller review surface.

Rich TMDB metadata mapping such as poster/fanart/plot/cast/runtime is intentionally left out of this PR.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo +stable check --workspace`
- `cargo +stable test -p tuliprox media_server`
- `cargo +stable test -p tuliprox xtream`
- `cargo +stable clippy --workspace -- -D warnings`
- `git diff --check`
