### PR TITLE
Fixed redirect url provider:// scheme resolve

### DIFF
--- a/backend/src/api/api_utils.rs
+++ b/backend/src/api/api_utils.rs
@@ -1326,11 +1326,11 @@ pub fn get_stream_alternative_url(stream_url: &str, input: &ConfigInput, alias_i
     modified.replacen(&input_user_info.password, &alt_input_user_info.password, 1)
 }
 
-fn resolve_redirect_location(input: &ConfigInput, stream_url: &str) -> Result<String, TuliproxError> {
-    Ok(match input.resolve_url(stream_url)? {
-        Cow::Borrowed(url) => url.to_string(),
-        Cow::Owned(url) => url,
-    })
+pub(crate) fn resolve_redirect_location<'a>(
+    input: Option<&ConfigInput>,
+    stream_url: &'a str,
+) -> Result<Cow<'a, str>, TuliproxError> {
+    input.map_or(Ok(Cow::Borrowed(stream_url)), |input| input.resolve_url(stream_url))
 }
 
 async fn get_redirect_alternative_url(
@@ -1787,8 +1787,15 @@ where
             let redirect_url =
                 if is_dash_request { replace_url_extension(&redirect_url, DASH_EXT).into() } else { redirect_url };
             let redirect_url = get_redirect_alternative_url(app_state, &redirect_url, params.input).await;
-            debug_if_enabled!("Redirecting stream request to {}", sanitize_sensitive_info(&redirect_url));
-            return Some(redirect(&redirect_url).into_response());
+            let redirect_url = match resolve_redirect_location(Some(params.input), &redirect_url) {
+                Ok(url) => url,
+                Err(err) => {
+                    error!("Failed to resolve redirect url: {}", sanitize_sensitive_info(err.to_string().as_str()));
+                    return Some(StatusCode::BAD_REQUEST.into_response());
+                }
+            };
+            debug_if_enabled!("Redirecting stream request to {}", sanitize_sensitive_info(redirect_url.as_ref()));
+            return Some(redirect(redirect_url.as_ref()).into_response());
         }
     } else if params.target_type == TargetType::Xtream {
         let Some(provider_id) = params.provider_id else {
@@ -1816,7 +1823,7 @@ where
                     None => url.to_string(),
                 },
             };
-            let stream_url = match resolve_redirect_location(params.input, &stream_url) {
+            let stream_url = match resolve_redirect_location(Some(params.input), &stream_url) {
                 Ok(url) => url,
                 Err(err) => {
                     error!("Failed to resolve redirect url: {}", sanitize_sensitive_info(err.to_string().as_str()));
@@ -1840,9 +1847,9 @@ where
 
             debug_if_enabled!(
                 "Redirecting stream request to {}",
-                sanitize_sensitive_info(resolve_request_url_for_logging(params.input, &stream_url).as_ref())
+                sanitize_sensitive_info(resolve_request_url_for_logging(params.input, stream_url.as_ref()).as_ref())
             );
-            return Some(redirect(&stream_url).into_response());
+            return Some(redirect(stream_url.as_ref()).into_response());
         }
     }
 
@@ -3473,7 +3480,7 @@ mod tests {
         };
 
         let resolved =
-            resolve_redirect_location(&input, "provider://develop/live/provider-user/provider-pass/33486.m3u8")
+            resolve_redirect_location(Some(&input), "provider://develop/live/provider-user/provider-pass/33486.m3u8")
                 .expect("provider url should resolve");
 
         assert_eq!(resolved, "https://provider.example/live/provider-user/provider-pass/33486.m3u8");

--- a/backend/src/api/endpoints/m3u_api.rs
+++ b/backend/src/api/endpoints/m3u_api.rs
@@ -433,8 +433,18 @@ async fn m3u_api_resource(
         None => axum::http::StatusCode::NOT_FOUND.into_response(),
         Some(url) => {
             if user.proxy.is_redirect(m3u_item.item_type) || target.is_force_redirect(m3u_item.item_type) {
-                debug!("Redirecting stream request to {}", sanitize_sensitive_info(&url));
-                redirect(&url).into_response()
+                let input = app_state.app_config.get_input_by_name(&m3u_item.input_name);
+                let redirect_url = crate::api::api_utils::resolve_redirect_location(input.as_deref(), &url);
+                match redirect_url {
+                    Ok(redirect_url) => {
+                        debug!("Redirecting stream request to {}", sanitize_sensitive_info(redirect_url.as_ref()));
+                        redirect(redirect_url.as_ref()).into_response()
+                    }
+                    Err(err) => {
+                        error!("Failed to resolve redirect url: {}", sanitize_sensitive_info(err.to_string().as_str()));
+                        axum::http::StatusCode::BAD_REQUEST.into_response()
+                    }
+                }
             } else {
                 resource_response(&app_state, &url, &req_headers, None).await.into_response()
             }

--- a/backend/src/api/endpoints/xtream_api.rs
+++ b/backend/src/api/endpoints/xtream_api.rs
@@ -758,8 +758,18 @@ async fn xtream_player_api_resource(
         None => axum::http::StatusCode::NOT_FOUND.into_response(),
         Some(url) => {
             if user.proxy.is_redirect(pli.item_type) || target.is_force_redirect(pli.item_type) {
-                trace_if_enabled!("Redirecting resource request to {}", sanitize_sensitive_info(&url));
-                redirect(&url).into_response()
+                let input = app_state.app_config.get_input_by_name(&pli.input_name);
+                let redirect_url = api_utils::resolve_redirect_location(input.as_deref(), &url);
+                match redirect_url {
+                    Ok(redirect_url) => {
+                        trace_if_enabled!("Redirecting resource request to {}", sanitize_sensitive_info(redirect_url.as_ref()));
+                        redirect(redirect_url.as_ref()).into_response()
+                    }
+                    Err(err) => {
+                        error!("Failed to resolve redirect url: {}", sanitize_sensitive_info(err.to_string().as_str()));
+                        axum::http::StatusCode::BAD_REQUEST.into_response()
+                    }
+                }
             } else {
                 trace_if_enabled!("Resource request to {}", sanitize_sensitive_info(&url));
                 resource_response(app_state, &url, req_headers, None).await.into_response()
@@ -981,7 +991,13 @@ pub async fn xtream_get_stream_info_response(
                 if let Some(info_url) = xtream::get_xtream_player_api_info_url(&input, cluster, pli.provider_id) {
                     // Redirect is only possible for live streams, vod and series info needs to be modified
                     if user.proxy == ProxyType::Redirect && cluster == XtreamCluster::Live {
-                        return redirect(&info_url).into_response();
+                        return match api_utils::resolve_redirect_location(Some(&input), &info_url) {
+                            Ok(redirect_url) => redirect(redirect_url.as_ref()).into_response(),
+                            Err(err) => {
+                                error!("Failed to resolve redirect url: {}", sanitize_sensitive_info(err.to_string().as_str()));
+                                axum::http::StatusCode::BAD_REQUEST.into_response()
+                            }
+                        };
                     } else if let Ok(content) = xtream::get_xtream_stream_info(
                         &app_state.http_client.load(),
                         app_state,
@@ -1066,7 +1082,13 @@ async fn xtream_get_short_epg(
                             info_url = format!("{info_url}&limit={limit}");
                         }
                         if user.proxy.is_redirect(pli.item_type) || target.is_force_redirect(pli.item_type) {
-                            return redirect(&info_url).into_response();
+                            return match api_utils::resolve_redirect_location(Some(&input), &info_url) {
+                                Ok(redirect_url) => redirect(redirect_url.as_ref()).into_response(),
+                                Err(err) => {
+                                    error!("Failed to resolve redirect url: {}", sanitize_sensitive_info(err.to_string().as_str()));
+                                    axum::http::StatusCode::BAD_REQUEST.into_response()
+                                }
+                            };
                         }
 
                         let input_source = InputSource::from(&*input).with_url(info_url);

--- a/backend/src/model/config/input.rs
+++ b/backend/src/model/config/input.rs
@@ -1138,6 +1138,25 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_url_provider_stream_path_requires_provider_name() {
+        let provider = ConfigProvider::from(&ConfigProviderDto {
+            name: "myprovider".into(),
+            urls: vec!["http://provider.com".into()],
+            provider_url_selection_policy: ProviderUrlSelectionPolicy::ResumeLastWorking,
+            dns: None,
+        });
+        let input = ConfigInput {
+            name: "test_input".into(),
+            provider_configs: Some(vec![Arc::new(provider)]),
+            ..Default::default()
+        };
+
+        let err = input.resolve_url("provider://live/user/pass/813294.ts").unwrap_err();
+
+        assert!(err.to_string().contains("Provider config for 'live' not found"));
+    }
+
+    #[test]
     fn test_resolve_provider_scheme_url_starts_from_first_url_for_new_resolution() {
         let provider = Arc::new(ConfigProvider::from(&ConfigProviderDto {
             name: "myprovider".into(),

--- a/backend/src/repository/m3u_playlist_iterator.rs
+++ b/backend/src/repository/m3u_playlist_iterator.rs
@@ -10,8 +10,11 @@ use log::error;
 use shared::create_bitset;
 use shared::error::TuliproxError;
 use shared::model::{ConfigTargetOptions, M3uPlaylistItem, PlaylistItemType, ProxyType, TargetType, XtreamCluster};
-use shared::utils::{extract_extension_from_url, Internable};
+use shared::utils::{extract_extension_from_url, sanitize_sensitive_info, Internable, PROVIDER_SCHEME_PREFIX};
+use std::borrow::Cow;
+use std::collections::HashMap;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 use tokio::sync::mpsc;
 use tokio::task;
@@ -79,11 +82,48 @@ fn build_rewritten_url(
     }
 }
 
+fn resolve_effective_source_url<'a>(
+    m3u_pli: &'a M3uPlaylistItem,
+    input_by_name: &HashMap<Arc<str>, Arc<crate::model::ConfigInput>>,
+) -> Cow<'a, str> {
+    if !m3u_pli.url.starts_with(PROVIDER_SCHEME_PREFIX) {
+        return Cow::Borrowed(m3u_pli.url.as_ref());
+    }
+
+    input_by_name.get(&m3u_pli.input_name).map_or_else(
+        || {
+            error!(
+                "Input '{}' not found while resolving provider URL '{}'",
+                m3u_pli.input_name,
+                sanitize_sensitive_info(&m3u_pli.url)
+            );
+            Cow::Borrowed(m3u_pli.url.as_ref())
+        },
+        |input| match input.resolve_url(&m3u_pli.url) {
+            Ok(resolved) => match resolved {
+                Cow::Borrowed(url) => Cow::Borrowed(url),
+                Cow::Owned(url) => Cow::Owned(url),
+            },
+            Err(err) => {
+                error!(
+                    "Failed to resolve provider URL '{}' for input '{}': {}",
+                    sanitize_sensitive_info(&m3u_pli.url),
+                    m3u_pli.input_name,
+                    sanitize_sensitive_info(err.to_string().as_str())
+                );
+                Cow::Borrowed(m3u_pli.url.as_ref())
+            }
+        },
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
 fn apply_rewrite(
     mut m3u_pli: M3uPlaylistItem,
     base_url: &str,
     username: &str,
     password: &str,
+    input_by_name: &HashMap<Arc<str>, Arc<crate::model::ConfigInput>>,
     target_options: Option<&ConfigTargetOptions>,
     flags: M3uPlaylistIteratorFlagsSet,
     proxy_type: ProxyType,
@@ -93,12 +133,14 @@ fn apply_rewrite(
     let should_rewrite_urls =
         if is_redirect { flags.contains(M3uPlaylistIteratorFlags::MaskRedirectUrl) } else { true };
 
+    let effective_source_url = resolve_effective_source_url(&m3u_pli, input_by_name);
+
     if should_rewrite_urls {
         let stream_url = build_rewritten_url(
             base_url,
             username,
             password,
-            m3u_pli.url.as_ref(),
+            effective_source_url.as_ref(),
             &m3u_pli,
             flags.contains(M3uPlaylistIteratorFlags::IncludeTypeInUrl),
             storage_const::M3U_STREAM_PATH,
@@ -122,14 +164,18 @@ fn apply_rewrite(
         m3u_pli.t_stream_url = stream_url.intern();
         m3u_pli.t_resource_url = resource_url;
     } else {
-        // Keep original URL (clone required because target field is distinct)
-        m3u_pli.t_stream_url = m3u_pli.url.clone();
+        m3u_pli.t_stream_url = match effective_source_url {
+            Cow::Borrowed(_) => Arc::clone(&m3u_pli.url),
+            Cow::Owned(url) => url.intern(),
+        };
         m3u_pli.t_resource_url = None;
     }
 
     m3u_pli
 }
 
+
+#[allow(clippy::too_many_lines)]
 impl M3uPlaylistIterator {
     pub async fn new(
         cfg: &AppConfig,
@@ -166,6 +212,13 @@ impl M3uPlaylistIterator {
         let proxy_type = user.proxy;
         let output_clusters = user.output_clusters;
         let target_options = target.options.clone();
+        let input_by_name: HashMap<Arc<str>, Arc<crate::model::ConfigInput>> = cfg
+            .sources
+            .load()
+            .inputs
+            .iter()
+            .map(|input| (Arc::clone(&input.name), Arc::clone(input)))
+            .collect();
 
         let m3u_path = m3u_path.clone();
         let index_path = get_file_path_for_db_index(&m3u_path);
@@ -207,8 +260,16 @@ impl M3uPlaylistIterator {
                     }
                 }
 
-                let item =
-                    apply_rewrite(item, &base_url, &username, &password, target_options.as_ref(), flags, proxy_type);
+                let item = apply_rewrite(
+                    item,
+                    &base_url,
+                    &username,
+                    &password,
+                    &input_by_name,
+                    target_options.as_ref(),
+                    flags,
+                    proxy_type,
+                );
 
                 if let Some(prev) = pending.replace(item) {
                     if tx.blocking_send((prev, true)).is_err() {
@@ -282,5 +343,115 @@ impl Stream for M3uPlaylistM3uTextIterator {
             Poll::Ready(None) => Poll::Ready(None),
             Poll::Pending => Poll::Pending,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{apply_rewrite, M3uPlaylistIteratorFlags, M3uPlaylistIteratorFlagsSet};
+    use crate::model::{ConfigInput, ConfigProvider, ProviderDnsCache};
+    use shared::{
+        model::{M3uPlaylistItem, PlaylistItemType, ProviderUrlSelectionPolicy, ProxyType},
+        utils::Internable,
+    };
+    use std::{
+        collections::HashMap,
+        sync::{atomic::AtomicUsize, Arc},
+    };
+
+    fn provider_input() -> Arc<ConfigInput> {
+        Arc::new(ConfigInput {
+            name: "example1".intern(),
+            provider_configs: Some(vec![Arc::new(ConfigProvider {
+                name: "example".intern(),
+                urls: vec!["http://example.com".intern()],
+                provider_url_selection_policy: ProviderUrlSelectionPolicy::ResumeLastWorking,
+                current_url_index: AtomicUsize::new(0),
+                dns: None,
+                dns_cache: Arc::new(ProviderDnsCache::default()),
+            })]),
+            ..ConfigInput::default()
+        })
+    }
+
+    fn m3u_item(url: &str) -> M3uPlaylistItem {
+        M3uPlaylistItem {
+            virtual_id: 813_294,
+            provider_id: "813294".intern(),
+            name: "France 4K".intern(),
+            chno: 0,
+            logo: "".intern(),
+            logo_small: "".intern(),
+            group: "FR| FRANCE 4K".intern(),
+            title: "France 4K".intern(),
+            parent_code: "".intern(),
+            audio_track: "".intern(),
+            time_shift: "".intern(),
+            rec: "".intern(),
+            url: url.intern(),
+            epg_channel_id: None,
+            input_name: "example1".intern(),
+            item_type: PlaylistItemType::Live,
+            t_stream_url: "".intern(),
+            t_resource_url: None,
+            source_ordinal: 0,
+            additional_properties: None,
+        }
+    }
+
+    #[test]
+    fn redirect_without_mask_resolves_provider_scheme_url() {
+        let input = provider_input();
+        let input_by_name = HashMap::from([(Arc::clone(&input.name), input)]);
+        let rewritten = apply_rewrite(
+            m3u_item("provider://example/live/user/pass/813294.ts"),
+            "https://example.com",
+            "user",
+            "pass",
+            &input_by_name,
+            None,
+            M3uPlaylistIteratorFlagsSet::new(),
+            ProxyType::Redirect,
+        );
+
+        assert_eq!(rewritten.t_stream_url.as_ref(), "http://example.com/live/user/pass/813294.ts");
+    }
+
+    #[test]
+    fn redirect_without_mask_keeps_regular_url() {
+        let input_by_name = HashMap::new();
+        let rewritten = apply_rewrite(
+            m3u_item("http://example.com/live/user/pass/813294.ts"),
+            "https://example.com",
+            "user",
+            "pass",
+            &input_by_name,
+            None,
+            M3uPlaylistIteratorFlagsSet::new(),
+            ProxyType::Redirect,
+        );
+
+        assert_eq!(rewritten.t_stream_url.as_ref(), "http://example.com/live/user/pass/813294.ts");
+    }
+
+    #[test]
+    fn masked_redirect_uses_resolved_provider_source_for_rewritten_url() {
+        let input = provider_input();
+        let input_by_name = HashMap::from([(Arc::clone(&input.name), input)]);
+        let mut flags = M3uPlaylistIteratorFlagsSet::new();
+        flags.set(M3uPlaylistIteratorFlags::MaskRedirectUrl);
+
+        let rewritten = apply_rewrite(
+            m3u_item("provider://example/live/user/pass/813294.ts"),
+            "https://example.com",
+            "user",
+            "pass",
+            &input_by_name,
+            None,
+            flags,
+            ProxyType::Redirect,
+        );
+
+        assert_eq!(rewritten.t_stream_url.as_ref(), "https://example.com/m3u-stream/user/pass/813294.ts");
     }
 }

--- a/backend/src/repository/m3u_playlist_iterator.rs
+++ b/backend/src/repository/m3u_playlist_iterator.rs
@@ -435,6 +435,23 @@ mod tests {
     }
 
     #[test]
+    fn redirect_without_mask_preserves_provider_scheme_url_when_input_is_missing() {
+        let input_by_name = HashMap::new();
+        let rewritten = apply_rewrite(
+            m3u_item("provider://example/live/user/pass/813294.ts"),
+            "https://example.com",
+            "user",
+            "pass",
+            &input_by_name,
+            None,
+            M3uPlaylistIteratorFlagsSet::new(),
+            ProxyType::Redirect,
+        );
+
+        assert_eq!(rewritten.t_stream_url.as_ref(), "provider://example/live/user/pass/813294.ts");
+    }
+
+    #[test]
     fn masked_redirect_uses_resolved_provider_source_for_rewritten_url() {
         let input = provider_input();
         let input_by_name = HashMap::from([(Arc::clone(&input.name), input)]);


### PR DESCRIPTION
Fixed redirect url provider:// scheme resolve

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redirect error handling: failed redirect location resolutions now return proper error responses (HTTP 400) instead of potentially invalid redirects.
  
* **New Features**
  * Enhanced provider-scheme URL resolution across M3U and Xtream API endpoints for more robust URL handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->