### PR TITLE
feat: expose series episode plot

### DIFF
--- a/shared/src/model/playlist_info_document.rs
+++ b/shared/src/model/playlist_info_document.rs
@@ -212,6 +212,8 @@ pub struct XtreamSeriesEpisodeInfoData {
     pub rating: f64,
     #[serde(rename = "id")]
     pub tmdb_id: u32,
+    #[serde(default, with = "arc_str_option_serde")]
+    pub plot: Option<Arc<str>>,
     #[serde(with = "arc_str_serde")]
     pub movie_image: Arc<str>,
     pub duration_secs: u32,
@@ -521,6 +523,7 @@ impl StreamProperties {
                     tmdb_id: ep.tmdb.unwrap_or_default(),
                     air_date: Arc::clone(&ep.release_date),
                     crew: ep.crew.as_ref().map(Arc::clone),
+                    plot: ep.plot.as_ref().map(Arc::clone),
                     rating: ep.rating.unwrap_or_default(),
                     movie_image: options
                         .get_resource_url(
@@ -598,5 +601,69 @@ impl Default for XtreamVideoInfoDoc {
                 direct_source: empty_str,
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{PlaylistItemTypeSet, SeriesStreamDetailProperties};
+
+    fn sample_options() -> XtreamMappingOptions {
+        XtreamMappingOptions {
+            flags: XtreamMappingFlags::RewriteResourceUrl.into(),
+            force_redirect: None,
+            reverse_item_types: PlaylistItemTypeSet::empty(),
+            resource_proxy_item_types: PlaylistItemTypeSet::empty(),
+            username: "user".to_string(),
+            password: "pass".to_string(),
+            base_url: "http://proxy.example".to_string(),
+            web_ui_request: false,
+            encrypt_secret: [0u8; 16],
+        }
+    }
+
+    #[test]
+    fn series_episode_info_document_includes_episode_plot() {
+        let properties = StreamProperties::Series(Box::new(SeriesStreamProperties {
+            name: "Example Show".into(),
+            series_id: 1,
+            details: Some(SeriesStreamDetailProperties {
+                year: None,
+                seasons: None,
+                episodes: Some(vec![SeriesStreamDetailEpisodeProperties {
+                    id: 101,
+                    episode_num: 1,
+                    season: 1,
+                    title: "Pilot".into(),
+                    container_extension: "mkv".into(),
+                    custom_sid: None,
+                    added: "1700000000".into(),
+                    direct_source: "".into(),
+                    tmdb: None,
+                    release_date: "2024-01-01".into(),
+                    series_release_date: None,
+                    plot: Some("Episode plot".into()),
+                    crew: None,
+                    duration_secs: 0,
+                    duration: "".into(),
+                    movie_image: "".into(),
+                    bitrate: 0,
+                    rating: None,
+                    video: None,
+                    audio: None,
+                }]),
+            }),
+            ..SeriesStreamProperties::default()
+        }));
+
+        let XtreamInfoDocument::Series(doc) =
+            properties.to_info_document(&sample_options(), PlaylistItemType::SeriesInfo, 42, 7)
+        else {
+            panic!("expected series info document");
+        };
+
+        let episode = doc.episodes.get("1").and_then(|episodes| episodes.first()).expect("episode missing");
+        assert_eq!(episode.info.plot.as_deref(), Some("Episode plot"));
     }
 }

--- a/shared/src/model/stream_properties.rs
+++ b/shared/src/model/stream_properties.rs
@@ -782,7 +782,7 @@ impl SeriesStreamProperties {
                             tmdb: info.info.tmdb,
                             release_date: e.info.as_ref().map(|i| i.air_date.clone()).unwrap_or_default(),
                             series_release_date: None,
-                            plot: None,
+                            plot: e.info.as_ref().and_then(|i| i.plot.clone()),
                             crew: e.info.as_ref().map(|i| i.crew.clone()),
                             duration_secs: e.info.as_ref().map(|i| i.duration_secs).unwrap_or_default(),
                             duration: e.info.as_ref().map(|i| i.duration.clone()).unwrap_or_default(),
@@ -883,7 +883,7 @@ impl SeriesStreamProperties {
                             tmdb,
                             release_date: e.info.air_date.clone(),
                             series_release_date: None,
-                            plot: None,
+                            plot: e.info.plot.clone(),
                             crew: e.info.crew.clone(),
                             duration_secs: e.info.duration_secs,
                             duration: e.info.duration.clone(),
@@ -1018,6 +1018,39 @@ mod tests {
         assert_eq!(props.trailer.as_deref(), Some("legacy-trailer"));
         assert_eq!(props.tmdb, Some(7788));
         assert_eq!(props.is_adult, 1);
+    }
+
+    #[test]
+    fn from_series_info_preserves_episode_plot() {
+        let info: XtreamSeriesInfo = serde_json::from_value(json!({
+            "info": {
+                "name": "Example Show"
+            },
+            "episodes": {
+                "1": [{
+                    "id": 101,
+                    "episode_num": 1,
+                    "season": 1,
+                    "title": "Pilot",
+                    "container_extension": "mkv",
+                    "info": {
+                        "air_date": "2024-01-01",
+                        "plot": "Episode plot",
+                        "movie_image": "https://img.example/still.jpg"
+                    }
+                }]
+            }
+        }))
+        .expect("sample XtreamSeriesInfo should deserialize");
+
+        let props = SeriesStreamProperties::from_info_without_existing(&info, 7);
+        let episode = props
+            .details
+            .and_then(|details| details.episodes)
+            .and_then(|episodes| episodes.first().cloned())
+            .expect("episode should be mapped");
+
+        assert_eq!(episode.plot.as_deref(), Some("Episode plot"));
     }
 
     #[test]

--- a/shared/src/model/xtream.rs
+++ b/shared/src/model/xtream.rs
@@ -193,6 +193,8 @@ pub struct XtreamSeriesInfoEpisodeInfo {
     pub air_date: Arc<str>,
     #[serde(default, with = "arc_str_serde")]
     pub crew: Arc<str>,
+    #[serde(default, with = "arc_str_option_serde")]
+    pub plot: Option<Arc<str>>,
     #[serde(default, deserialize_with = "deserialize_number_from_string_or_zero")]
     pub rating: f64,
     #[serde(default, deserialize_with = "deserialize_number_from_string")]


### PR DESCRIPTION
## Summary
- parse Xtream episode info `plot` into series episode properties
- include episode `plot` in Xtream `get_series_info` responses
- keep media-server episode plot propagation in #748

## Tests
- `cargo test -p shared -- --nocapture`
- `cargo clippy -p tuliprox --no-default-features -- -D warnings`
- `cargo +nightly fmt --all -- --check`
