### PR TITLE
Fix: Session handling

### DIFF
--- a/backend/src/api/api_utils.rs
+++ b/backend/src/api/api_utils.rs
@@ -47,8 +47,8 @@ use shared::{
     },
     utils::{
         bin_serialize, extract_extension_from_url, human_readable_kbps, is_sanitize_sensitive_info_enabled,
-        replace_url_extension, sanitize_sensitive_info, current_time_secs, trim_slash, Internable, CONTENT_TYPE_CBOR,
-        CONTENT_TYPE_JSON, DASH_EXT, HLS_EXT,
+        replace_url_extension, sanitize_sensitive_info, current_time_secs, trim_slash, get_credentials_from_url, Internable,
+        CONTENT_TYPE_CBOR, CONTENT_TYPE_JSON, DASH_EXT, HLS_EXT,
     },
 };
 use smallvec::SmallVec;
@@ -1309,21 +1309,14 @@ async fn activate_session_before_stream_open(
 }
 
 pub fn get_stream_alternative_url(stream_url: &str, input: &ConfigInput, alias_input: &Arc<ProviderConfig>) -> String {
-    let matched_input = input.get_matched_config_by_url(stream_url);
-    let source_base_url: Cow<'_, str> = if let Some((base_url, _, _)) = matched_input {
-        Cow::Borrowed(base_url)
-    } else if let Some(input_user_info) = input.get_user_info() {
-        Cow::Owned(input_user_info.base_url)
-    } else {
+    let Some((source_base_url, source_username, source_password)) = input.get_matched_config_by_url(stream_url) else {
         return stream_url.to_string();
     };
-    let source_username = matched_input.map_or(input.username.as_deref(), |(_, username, _)| username.map(String::as_str));
-    let source_password = matched_input.map_or(input.password.as_deref(), |(_, _, password)| password.map(String::as_str));
     let Some(alt_input_user_info) = alias_input.get_user_info() else {
         return stream_url.to_string();
     };
 
-    let mut modified = stream_url.replacen(source_base_url.as_ref(), &alt_input_user_info.base_url, 1);
+    let mut modified = stream_url.replacen(source_base_url, &alt_input_user_info.base_url, 1);
     if let Some(old_username) = source_username {
         let new_username = alt_input_user_info.username.as_str();
         modified = modified.replacen(old_username, new_username, 1);
@@ -1336,7 +1329,49 @@ pub fn get_stream_alternative_url(stream_url: &str, input: &ConfigInput, alias_i
 }
 
 fn stream_url_matches_provider(stream_url: &str, provider_cfg: &ProviderConfig) -> bool {
-    provider_cfg.get_user_info().is_some_and(|user_info| stream_url.starts_with(&user_info.base_url))
+    provider_cfg
+        .get_user_info()
+        .is_some_and(|user_info| stream_url_base_matches(stream_url, &user_info.base_url) && stream_url_account_matches(stream_url, &user_info))
+}
+
+fn stream_url_base_matches(stream_url: &str, base_url: &str) -> bool {
+    stream_url.strip_prefix(base_url).is_some_and(|remaining| {
+        remaining.is_empty() || remaining.starts_with(['/', '?', '#'])
+    })
+}
+
+fn stream_url_account_matches(stream_url: &str, user_info: &crate::model::InputUserInfo) -> bool {
+    let Ok(url) = Url::parse(stream_url) else {
+        return false;
+    };
+
+    let (url_username, url_password) = get_credentials_from_url(&url);
+    if let (Some(url_username), Some(url_password)) = (url_username.as_deref(), url_password.as_deref()) {
+        return url_username == user_info.username && url_password == user_info.password;
+    }
+
+    let mut has_query_username = false;
+    let mut has_query_password = false;
+    for (key, value) in url.query_pairs() {
+        if key.eq_ignore_ascii_case("username") {
+            has_query_username = value == user_info.username;
+        } else if key.eq_ignore_ascii_case("password") {
+            has_query_password = value == user_info.password;
+        }
+    }
+    if has_query_username || has_query_password {
+        return has_query_username && has_query_password;
+    }
+
+    let mut segments = url.path_segments().into_iter().flatten();
+    let first = segments.next();
+    let (username, password) = match first {
+        Some("live" | "movie" | "series") => (segments.next(), segments.next()),
+        Some(username) => (Some(username), segments.next()),
+        None => return false,
+    };
+
+    username == Some(user_info.username.as_str()) && password == Some(user_info.password.as_str())
 }
 
 pub(crate) fn resolve_redirect_location<'a>(
@@ -1378,7 +1413,7 @@ async fn get_redirect_alternative_url(
 ///
 /// - If no connections are available (`Exhausted`), it returns a custom stream indicating exhaustion.
 /// - If a connection is available or in a grace period, it constructs a streaming URL accordingly:
-///   - If the provider was forced or matches the input, the original URL is reused.
+///   - If the URL already targets the selected provider account, the original URL is reused.
 ///   - Otherwise, an alternative URL is generated based on the provider and input.
 ///
 /// The function returns:
@@ -1395,7 +1430,6 @@ async fn resolve_streaming_strategy(
     options: StreamingAcquireOptions<'_>,
 ) -> StreamingStrategy {
     // allocate a provider connection
-    let mut forced_provider_allocated = false;
     let provider_connection_handle = match options.force_provider {
         Some(provider) => {
             // First try to stay on the exact pinned provider account without over-allocating.
@@ -1411,7 +1445,6 @@ async fn resolve_streaming_strategy(
                 )
                 .await
             {
-                forced_provider_allocated = true;
                 Some(handle)
             } else if options.allow_forced_provider_fallback {
                 debug_if_enabled!(
@@ -1465,9 +1498,9 @@ async fn resolve_streaming_strategy(
                 ProviderStreamState::Custom(stream)
             }
             ProviderAllocation::Available(ref provider_cfg) | ProviderAllocation::GracePeriod(ref provider_cfg) => {
-                // Keep the URL only when provider affinity requires it or the URL already targets the selected
-                // provider. Hot reload can leave old alias URLs in persisted playlists until the next processing run.
-                let keep_original_url = forced_provider_allocated || stream_url_matches_provider(stream_url, provider_cfg);
+                // Keep the URL only when it already targets the selected provider. Hot reload can leave old alias URLs
+                // in persisted playlists until the next processing run.
+                let keep_original_url = stream_url_matches_provider(stream_url, provider_cfg);
                 let (selected_provider_name, url) = if keep_original_url {
                     (provider_cfg.name.clone(), stream_url.to_string())
                 } else {
@@ -3625,7 +3658,8 @@ mod tests {
     use crate::{
         api::model::{
             ActiveProviderManager, ActiveUserManager, AppState, CancelTokens, ConnectionManager, EventManager,
-            MetadataUpdateManager, PlaylistStorageState, SharedStreamManager,
+            MetadataUpdateManager, PlaylistStorageState, ProviderConfig as RuntimeProviderConfig,
+            ProviderConfigConnection, SharedStreamManager,
         },
         auth::Fingerprint,
         model::{
@@ -3647,7 +3681,23 @@ mod tests {
         utils::{default_catchup_session_ttl_secs, default_hls_session_ttl_secs, Internable},
     };
     use std::{borrow::Cow, collections::HashMap, net::SocketAddr, sync::Arc};
-    use tokio::sync::mpsc;
+    use tokio::sync::{mpsc, RwLock};
+
+    fn test_runtime_provider(url: &str, username: &str, password: &str) -> Arc<RuntimeProviderConfig> {
+        let input = ConfigInput {
+            name: "provider".intern(),
+            url: url.to_string(),
+            username: Some(username.to_string()),
+            password: Some(password.to_string()),
+            input_type: InputType::Xtream,
+            ..ConfigInput::default()
+        };
+        Arc::new(RuntimeProviderConfig::new(
+            &input,
+            Arc::new(RwLock::new(ProviderConfigConnection::default())),
+            Arc::new(|_, _| {}),
+        ))
+    }
 
     #[tokio::test]
     async fn test_is_seek_request() {
@@ -3692,6 +3742,38 @@ mod tests {
                 .expect("provider url should resolve");
 
         assert_eq!(resolved, "https://provider.example/live/provider-user/provider-pass/33486.m3u8");
+    }
+
+    #[test]
+    fn stream_alternative_url_keeps_unmatched_urls_unchanged() {
+        let input = ConfigInput {
+            name: "source".intern(),
+            url: "http://source.example".to_string(),
+            username: Some("source-user".to_string()),
+            password: Some("source-pass".to_string()),
+            input_type: InputType::Xtream,
+            ..ConfigInput::default()
+        };
+        let alias = test_runtime_provider("http://alias.example", "alias-user", "alias-pass");
+        let stream_url = "http://other.example/live/source-user/source-pass/123.ts";
+
+        let rewritten = get_stream_alternative_url(stream_url, &input, &alias);
+
+        assert_eq!(rewritten, stream_url);
+    }
+
+    #[test]
+    fn stream_url_matches_provider_requires_base_url_and_account_identity() {
+        let provider = test_runtime_provider("http://same.example", "selected-user", "selected-pass");
+
+        assert!(stream_url_matches_provider(
+            "http://same.example/live/selected-user/selected-pass/123.ts",
+            &provider
+        ));
+        assert!(!stream_url_matches_provider(
+            "http://same.example/live/other-user/other-pass/123.ts",
+            &provider
+        ));
     }
 
     #[test]

--- a/backend/src/api/api_utils.rs
+++ b/backend/src/api/api_utils.rs
@@ -1127,35 +1127,18 @@ async fn activate_session_before_stream_open(
     let effective_request_class = if let Some(request_class) = request_class {
         if request_class == PlaybackRequestClass::FollowUp {
             // Re-read session under the guard to ensure the counted lease is still held.
-            // Only reclassify if the session was in a counted state that has since been
-            // released. Pending sessions were never counted (admission pending provider
-            // acquisition) — keep FollowUp so no spurious placeholder is created.
+            // If it is no longer counted, classify it from the current lifecycle so
+            // stale FollowUp requests cannot bypass admission.
             let current_session = app_state
                 .active_users
                 .get_and_update_user_session(&user.username, session_token)
                 .await;
-            match current_session.as_ref().map(|s| &s.lifecycle) {
-                // Session is gone (expired/removed) or was never in a counted state — reclassify
-                // so admission runs and creates a fresh placeholder.
-                None => classify_playback_request(PlaybackRequestFacts {
-                    item_type,
-                    existing_session: None,
-                    prepare_only: false,
-                    terminate: false,
-                }),
-                // Had a counted lease but lost it — need to reclassify to Activate.
-                Some(crate::api::model::PlaybackLifecycle::Active | crate::api::model::PlaybackLifecycle::GraceActive) => {
-                    classify_playback_request(PlaybackRequestFacts {
-                        item_type,
-                        existing_session: current_session.as_ref(),
-                        prepare_only: false,
-                        terminate: false,
-                    })
-                }
-                // Pending was never counted (waiting for provider slot); Prepared/Preserved hold
-                // no counted slot — caller-specified FollowUp is still valid, no reclassification.
-                _ => request_class,
-            }
+            classify_playback_request(PlaybackRequestFacts {
+                item_type,
+                existing_session: current_session.as_ref(),
+                prepare_only: false,
+                terminate: false,
+            })
         } else {
             request_class
         }
@@ -1326,16 +1309,34 @@ async fn activate_session_before_stream_open(
 }
 
 pub fn get_stream_alternative_url(stream_url: &str, input: &ConfigInput, alias_input: &Arc<ProviderConfig>) -> String {
-    let Some(input_user_info) = input.get_user_info() else {
+    let matched_input = input.get_matched_config_by_url(stream_url);
+    let source_base_url: Cow<'_, str> = if let Some((base_url, _, _)) = matched_input {
+        Cow::Borrowed(base_url)
+    } else if let Some(input_user_info) = input.get_user_info() {
+        Cow::Owned(input_user_info.base_url)
+    } else {
         return stream_url.to_string();
     };
+    let source_username = matched_input.map_or(input.username.as_deref(), |(_, username, _)| username.map(String::as_str));
+    let source_password = matched_input.map_or(input.password.as_deref(), |(_, _, password)| password.map(String::as_str));
     let Some(alt_input_user_info) = alias_input.get_user_info() else {
         return stream_url.to_string();
     };
 
-    let modified = stream_url.replacen(&input_user_info.base_url, &alt_input_user_info.base_url, 1);
-    let modified = modified.replacen(&input_user_info.username, &alt_input_user_info.username, 1);
-    modified.replacen(&input_user_info.password, &alt_input_user_info.password, 1)
+    let mut modified = stream_url.replacen(source_base_url.as_ref(), &alt_input_user_info.base_url, 1);
+    if let Some(old_username) = source_username {
+        let new_username = alt_input_user_info.username.as_str();
+        modified = modified.replacen(old_username, new_username, 1);
+    }
+    if let Some(old_password) = source_password {
+        let new_password = alt_input_user_info.password.as_str();
+        modified = modified.replacen(old_password, new_password, 1);
+    }
+    modified
+}
+
+fn stream_url_matches_provider(stream_url: &str, provider_cfg: &ProviderConfig) -> bool {
+    provider_cfg.get_user_info().is_some_and(|user_info| stream_url.starts_with(&user_info.base_url))
 }
 
 pub(crate) fn resolve_redirect_location<'a>(
@@ -1464,10 +1465,11 @@ async fn resolve_streaming_strategy(
                 ProviderStreamState::Custom(stream)
             }
             ProviderAllocation::Available(ref provider_cfg) | ProviderAllocation::GracePeriod(ref provider_cfg) => {
-                // force_stream_provider means we keep the url and the provider.
-                // If force_stream_provider or the input is the same as the config we don't need to get new url
-                let (selected_provider_name, url) = if forced_provider_allocated || provider_cfg.id == input.id {
-                    (input.name.clone(), stream_url.to_string())
+                // Keep the URL only when provider affinity requires it or the URL already targets the selected
+                // provider. Hot reload can leave old alias URLs in persisted playlists until the next processing run.
+                let keep_original_url = forced_provider_allocated || stream_url_matches_provider(stream_url, provider_cfg);
+                let (selected_provider_name, url) = if keep_original_url {
+                    (provider_cfg.name.clone(), stream_url.to_string())
                 } else {
                     (provider_cfg.name.clone(), get_stream_alternative_url(stream_url, input, provider_cfg))
                 };
@@ -2083,6 +2085,7 @@ pub async fn force_provider_stream_response(
         }
         app_state.active_users.update_session_addr(&ctx.user.username, &user_session.token, &fingerprint.addr).await;
         stream_channel.shared = share_stream;
+        let socket_bound = user_session.socket_bound;
         let stream = create_active_client_stream(crate::api::model::ActiveClientStreamParams {
             stream_details,
             app_state,
@@ -2091,6 +2094,7 @@ pub async fn force_provider_stream_response(
             connection_kind: user_session.connection_kind.unwrap_or(crate::api::model::ConnectionKind::Normal),
             fingerprint,
             stream_channel,
+            socket_bound,
             session_token: Some(&user_session.token),
             req_headers: ctx.req_headers,
             meter_uid: metering.meter_uid,
@@ -2168,6 +2172,8 @@ pub(crate) async fn stream_response(
 
     let virtual_id = stream_channel.virtual_id;
     let item_type = stream_channel.item_type;
+    let playback_extension = extract_extension_from_url(stream_url);
+    let socket_bound = is_socket_bound_playback_session(item_type, playback_extension.as_deref());
     let mut connection_permission = connection_permission;
     let mut connection_kind = connection_kind;
     let activation = activate_session_before_stream_open(
@@ -2183,7 +2189,7 @@ pub(crate) async fn stream_response(
             stream_url,
             connection_permission,
             connection_kind,
-            socket_bound: item_type.uses_socket_bound_session(),
+            socket_bound,
         },
         )
         .await;
@@ -2376,6 +2382,7 @@ pub(crate) async fn stream_response(
             connection_kind,
             fingerprint,
             stream_channel,
+            socket_bound,
             session_token: Some(session_token),
             req_headers,
             meter_uid: metering.meter_uid,
@@ -2485,7 +2492,7 @@ pub(crate) async fn stream_response(
                             addr: &fingerprint.addr,
                             connection_permission,
                             connection_kind: Some(connection_kind),
-                            socket_bound: item_type.uses_socket_bound_session(),
+                            socket_bound,
                         })
                         .await;
                     let reservation_ttl_secs = get_session_reservation_ttl_secs(app_state, item_type);
@@ -2654,6 +2661,8 @@ async fn try_shared_stream_response_if_any(
             let mut stream_details = StreamDetails::from_stream(stream, grace_period_options);
 
             stream_details.provider_name = provider;
+            let socket_bound =
+                is_socket_bound_playback_session(stream_channel.item_type, extract_extension_from_url(stream_url).as_deref());
             if let Some(provider_name) = stream_details.provider_name.as_deref() {
                 let _ = app_state
                     .active_users
@@ -2666,7 +2675,7 @@ async fn try_shared_stream_response_if_any(
                         addr: &fingerprint.addr,
                         connection_permission: connect_permission,
                         connection_kind: Some(connection_kind),
-                        socket_bound: stream_channel.item_type.uses_socket_bound_session(),
+                        socket_bound,
                     })
                     .await;
             }
@@ -2686,6 +2695,7 @@ async fn try_shared_stream_response_if_any(
                 connection_kind,
                 fingerprint,
                 stream_channel,
+                socket_bound,
                 session_token: Some(session_token),
                 req_headers,
                 meter_uid: metering.meter_uid,
@@ -2855,6 +2865,7 @@ pub(crate) async fn local_stream_response(
     } else {
         stream
     };
+    let socket_bound = is_socket_bound_playback_session(pli.item_type, extract_extension_from_url(&pli.url).as_deref());
     let mut connection_kind = connection_kind;
     if let Some(session_token) = playback_session_token {
         let activation = activate_session_before_stream_open(
@@ -2870,7 +2881,7 @@ pub(crate) async fn local_stream_response(
                 stream_url: &pli.url,
                 connection_permission,
                 connection_kind,
-                socket_bound: pli.item_type.uses_socket_bound_session(),
+                socket_bound,
             },
         )
             .await;
@@ -2925,7 +2936,7 @@ pub(crate) async fn local_stream_response(
                 addr: &fingerprint.addr,
                 connection_permission,
                 connection_kind: Some(resolved_connection_kind),
-                socket_bound: pli.item_type.uses_socket_bound_session(),
+                socket_bound,
             })
             .await;
     }
@@ -2937,6 +2948,7 @@ pub(crate) async fn local_stream_response(
         connection_kind: resolved_connection_kind,
         fingerprint,
         stream_channel: pli.clone(),
+        socket_bound,
         session_token: playback_session_token,
         req_headers,
         meter_uid: 0,
@@ -3394,6 +3406,10 @@ pub(crate) fn create_playback_session_fingerprint(
     item_type: PlaylistItemType,
     extension: Option<&str>,
 ) -> String {
+    // This scopes the session identity, not the session address-tracking policy.
+    // Adaptive playlist starts need a per-initial-socket token so two players behind
+    // the same IP/UA can watch the same HLS/DASH stream independently. The created
+    // UserSession itself can still be non-socket-bound.
     let socket_bound =
         is_socket_bound_playback_session(item_type, extension) || is_session_based_playback(item_type, extension);
     create_session_fingerprint(fingerprint, username, virtual_id, socket_bound)
@@ -3877,6 +3893,44 @@ mod tests {
         app_state.active_provider.release_connection(&busy_addr).await;
         app_state.active_provider.release_connection(&strict_addr).await;
         app_state.active_provider.release_connection(&fallback_addr).await;
+    }
+
+    #[tokio::test]
+    async fn resolve_streaming_strategy_rewrites_stale_alias_url_to_selected_main_provider() {
+        let app_state = create_test_dual_provider_app_state();
+        let input_name = "provider_1".intern();
+        let input = app_state
+            .app_config
+            .sources
+            .load()
+            .get_input_by_name(&input_name)
+            .cloned()
+            .unwrap_or_else(|| unreachable!());
+        let addr: SocketAddr = "127.0.0.1:55304".parse().unwrap_or_else(|_| unreachable!());
+
+        let strategy = resolve_streaming_strategy(
+            &app_state,
+            "http://provider-2.example/live/user2/pass2/100.ts",
+            &create_test_fingerprint(addr),
+            &input,
+            StreamingAcquireOptions {
+                force_provider: None,
+                allow_forced_provider_fallback: false,
+                allow_provider_grace: false,
+                user_priority: 0,
+                connection_kind: crate::api::model::ConnectionKind::Normal,
+                session_owner: Some("live-session"),
+            },
+        )
+        .await;
+
+        let ProviderStreamState::Available(Some(provider), url) = strategy.provider_stream_state else {
+            panic!("request should allocate the main provider")
+        };
+        assert_eq!(provider.as_ref(), "provider_1");
+        assert_eq!(url.as_ref(), "http://provider-1.example/live/user1/pass1/100.ts");
+
+        app_state.active_provider.release_connection(&addr).await;
     }
 
     #[test]
@@ -4452,7 +4506,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn activate_session_before_stream_open_uses_precomputed_follow_up_request_class() {
+    async fn activate_session_before_stream_open_revalidates_precomputed_follow_up_request_class() {
         let app_state = create_test_app_state_with_stream_config(crate::model::StreamConfig {
             retry: true,
             metrics_enabled: true,
@@ -4514,8 +4568,8 @@ mod tests {
         assert_eq!(activation.admission.kind, Some(crate::api::model::ConnectionKind::Normal));
         assert_eq!(activation.grace_mode, None);
         assert!(
-            activation.placeholder_transition_version.is_none(),
-            "precomputed follow-up activation must not create a placeholder session"
+            activation.placeholder_transition_version.is_some(),
+            "precomputed FollowUp must be revalidated against the current uncounted lifecycle"
         );
     }
 
@@ -7391,7 +7445,7 @@ mod tests {
         let Some(second_addr) = "127.0.0.1:55178".parse().ok() else {
             return;
         };
-        let first = create_test_fingerprint(first_addr);
+        let first = Fingerprint::new("10.0.0.6|player".to_string(), "10.0.0.6".to_string(), first_addr);
         let second = Fingerprint::new(first.key.clone(), first.client_ip.clone(), second_addr);
 
         let first_token = create_playback_session_fingerprint(&first, "user1", 7002, PlaylistItemType::Live, Some(HLS_EXT));
@@ -7400,6 +7454,22 @@ mod tests {
         assert_ne!(first_token, second_token);
         assert!(first_token.contains(&first.addr.to_string()));
         assert!(second_token.contains(&second.addr.to_string()));
+    }
+
+    #[test]
+    fn playback_session_fingerprint_keeps_ts_socket_bound_but_vod_logical() {
+        let first_addr: SocketAddr = "127.0.0.1:55179".parse().unwrap_or_else(|_| unreachable!());
+        let second_addr: SocketAddr = "127.0.0.1:55180".parse().unwrap_or_else(|_| unreachable!());
+        let first = Fingerprint::new("10.0.0.7|player".to_string(), "10.0.0.7".to_string(), first_addr);
+        let second = Fingerprint::new(first.key.clone(), first.client_ip.clone(), second_addr);
+
+        let first_ts = create_playback_session_fingerprint(&first, "user1", 7003, PlaylistItemType::Live, None);
+        let second_ts = create_playback_session_fingerprint(&second, "user1", 7003, PlaylistItemType::Live, None);
+        let first_vod = create_playback_session_fingerprint(&first, "user1", 7003, PlaylistItemType::Video, None);
+        let second_vod = create_playback_session_fingerprint(&second, "user1", 7003, PlaylistItemType::Video, None);
+
+        assert_ne!(first_ts, second_ts, "plain TS live remains socket-bound");
+        assert_eq!(first_vod, second_vod, "VOD remains logical across reopen/seek sockets");
     }
 
     #[tokio::test]

--- a/backend/src/api/api_utils.rs
+++ b/backend/src/api/api_utils.rs
@@ -4,9 +4,10 @@ use crate::{
         model::{
             create_active_client_stream, create_channel_unavailable_stream, create_custom_video_stream_response,
             create_provider_connections_exhausted_stream, create_provider_stream, get_stream_response_with_headers,
-            tee_stream, AppState, BoxedProviderStream, CustomVideoStreamType, ProviderAllocation, ProviderConfig,
-            ProviderStreamFactoryOptions, ProviderStreamInfo, ProviderStreamState, SharedStreamManager, StreamDetails, StreamError,
-            StreamingStrategy, ThrottledStream, UserApiRequest, UserSession, PendingProviderReason,
+            tee_stream, AppState, BoxedProviderStream, CustomVideoStreamType, PendingProviderReason, ProviderAllocation,
+            ProviderConfig, ProviderHandle, ProviderStreamFactoryOptions, ProviderStreamInfo, ProviderStreamState,
+            SharedStreamManager, StreamDetails, StreamError, StreamingStrategy, ThrottledStream, UserApiRequest,
+            UserSession,
         },
     },
     auth::Fingerprint,
@@ -19,7 +20,7 @@ use crate::{
         plex::client::PlexCatalogClient,
         MediaServerError, MediaServerErrorKind, MediaServerHttpClient, MediaServerImageRef,
     },
-    model::{ConfigInput, ConfigTarget, ProxyUserCredentials},
+    model::{AppConfig, ConfigInput, ConfigTarget, ProxyUserCredentials},
     utils::{
         async_file_reader, async_file_writer, create_new_file_for_write, debug_if_enabled, get_file_extension, request,
         request::{content_type_from_ext, parse_range, send_with_retry_and_provider},
@@ -1308,24 +1309,114 @@ async fn activate_session_before_stream_open(
     }
 }
 
-pub fn get_stream_alternative_url(stream_url: &str, input: &ConfigInput, alias_input: &Arc<ProviderConfig>) -> String {
-    let Some((source_base_url, source_username, source_password)) = input.get_matched_config_by_url(stream_url) else {
-        return stream_url.to_string();
-    };
-    let Some(alt_input_user_info) = alias_input.get_user_info() else {
-        return stream_url.to_string();
+pub fn get_stream_alternative_url(stream_url: &str, input: &ConfigInput, alias_input: &Arc<ProviderConfig>) -> Option<String> {
+    let (source_base_url, source_username, source_password) = input.get_matched_config_by_url(stream_url)?;
+    let alt_input_user_info = alias_input.get_user_info()?;
+
+    let modified = stream_url.replacen(source_base_url, &alt_input_user_info.base_url, 1);
+    let mut url = Url::parse(&modified).ok()?;
+
+    if let (Some(old_username), Some(old_password)) = (source_username, source_password) {
+        let auth_updated = rewrite_url_auth_fields(
+            &mut url,
+            old_username,
+            old_password,
+            &alt_input_user_info.username,
+            &alt_input_user_info.password,
+        );
+        if !auth_updated {
+            return None;
+        }
+    }
+
+    Some(url.to_string())
+}
+
+fn rewrite_url_auth_fields(
+    url: &mut Url,
+    old_username: &str,
+    old_password: &str,
+    new_username: &str,
+    new_password: &str,
+) -> bool {
+    if rewrite_query_auth_fields(url, new_username, new_password) {
+        return true;
+    }
+
+    if url.username() == old_username && url.password() == Some(old_password) {
+        return url.set_username(new_username).is_ok() && url.set_password(Some(new_password)).is_ok();
+    }
+
+    rewrite_path_auth_fields(url, old_username, old_password, new_username, new_password)
+}
+
+fn rewrite_query_auth_fields(url: &mut Url, new_username: &str, new_password: &str) -> bool {
+    let mut has_username = false;
+    let mut has_password = false;
+    let pairs: Vec<(String, String)> = url
+        .query_pairs()
+        .map(|(key, value)| {
+            if key.eq_ignore_ascii_case("username") {
+                has_username = true;
+                (key.into_owned(), new_username.to_string())
+            } else if key.eq_ignore_ascii_case("password") {
+                has_password = true;
+                (key.into_owned(), new_password.to_string())
+            } else {
+                (key.into_owned(), value.into_owned())
+            }
+        })
+        .collect();
+
+    if !(has_username && has_password) {
+        return false;
+    }
+
+    url.query_pairs_mut().clear().extend_pairs(pairs.iter().map(|(key, value)| (key.as_str(), value.as_str())));
+    true
+}
+
+fn rewrite_path_auth_fields(
+    url: &mut Url,
+    old_username: &str,
+    old_password: &str,
+    new_username: &str,
+    new_password: &str,
+) -> bool {
+    let Some(mut segments) = url
+        .path_segments()
+        .map(|segments| segments.map(ToOwned::to_owned).collect::<Vec<_>>())
+    else {
+        return false;
     };
 
-    let mut modified = stream_url.replacen(source_base_url, &alt_input_user_info.base_url, 1);
-    if let Some(old_username) = source_username {
-        let new_username = alt_input_user_info.username.as_str();
-        modified = modified.replacen(old_username, new_username, 1);
-    }
-    if let Some(old_password) = source_password {
-        let new_password = alt_input_user_info.password.as_str();
-        modified = modified.replacen(old_password, new_password, 1);
-    }
-    modified
+    let credential_index = if segments.len() >= 3
+        && matches!(segments.first().map(String::as_str), Some("live" | "movie" | "series"))
+        && segments.get(1).is_some_and(|segment| segment == old_username)
+        && segments.get(2).is_some_and(|segment| segment == old_password)
+    {
+        Some(1)
+    } else if segments.len() >= 2
+        && segments.first().is_some_and(|segment| segment == old_username)
+        && segments.get(1).is_some_and(|segment| segment == old_password)
+    {
+        Some(0)
+    } else {
+        None
+    };
+
+    let Some(credential_index) = credential_index else {
+        return false;
+    };
+
+    segments[credential_index] = new_username.to_string();
+    segments[credential_index + 1] = new_password.to_string();
+
+    let Ok(mut path_segments) = url.path_segments_mut() else {
+        return false;
+    };
+    path_segments.clear().extend(segments.iter().map(String::as_str));
+    true
 }
 
 fn stream_url_matches_provider(stream_url: &str, provider_cfg: &ProviderConfig) -> bool {
@@ -1372,6 +1463,90 @@ fn stream_url_account_matches(stream_url: &str, user_info: &crate::model::InputU
     };
 
     username == Some(user_info.username.as_str()) && password == Some(user_info.password.as_str())
+}
+
+fn select_provider_stream_url(
+    stream_url: &str,
+    input: &ConfigInput,
+    provider_cfg: &Arc<ProviderConfig>,
+) -> Option<(Arc<str>, String)> {
+    if stream_url_matches_provider(stream_url, provider_cfg) {
+        Some((provider_cfg.name.clone(), stream_url.to_string()))
+    } else {
+        get_stream_alternative_url(stream_url, input, provider_cfg).map(|url| (provider_cfg.name.clone(), url))
+    }
+}
+
+fn create_unmapped_provider_stream(app_config: &AppConfig) -> ProviderStreamState {
+    ProviderStreamState::Custom(create_channel_unavailable_stream(
+        app_config,
+        &[],
+        StatusCode::SERVICE_UNAVAILABLE,
+    ))
+}
+
+async fn acquire_stream_provider_handle(
+    app_state: &Arc<AppState>,
+    input: &ConfigInput,
+    fingerprint: &Fingerprint,
+    options: StreamingAcquireOptions<'_>,
+) -> Option<ProviderHandle> {
+    match options.force_provider {
+        Some(provider) => {
+            // First try to stay on the exact pinned provider account without over-allocating.
+            if let Some(handle) = app_state
+                .active_provider
+                .acquire_exact_connection_with_grace_for_session(
+                    provider,
+                    &fingerprint.addr,
+                    options.allow_provider_grace,
+                    options.user_priority,
+                    options.connection_kind,
+                    options.session_owner,
+                )
+                .await
+            {
+                Some(handle)
+            } else if options.allow_forced_provider_fallback {
+                debug_if_enabled!(
+                    "Pinned provider {} unavailable for {}; falling back to lineup allocation",
+                    sanitize_sensitive_info(provider),
+                    sanitize_sensitive_info(&fingerprint.addr.to_string())
+                );
+                app_state
+                    .active_provider
+                    .acquire_connection_with_grace_for_session(
+                        &input.name,
+                        &fingerprint.addr,
+                        options.allow_provider_grace,
+                        options.user_priority,
+                        options.connection_kind,
+                        options.session_owner,
+                    )
+                    .await
+            } else {
+                debug_if_enabled!(
+                    "Pinned provider {} unavailable for {}; strict provider affinity prevents fallback",
+                    sanitize_sensitive_info(provider),
+                    sanitize_sensitive_info(&fingerprint.addr.to_string())
+                );
+                None
+            }
+        }
+        None => {
+            app_state
+                .active_provider
+                .acquire_connection_with_grace_for_session(
+                    &input.name,
+                    &fingerprint.addr,
+                    options.allow_provider_grace,
+                    options.user_priority,
+                    options.connection_kind,
+                    options.session_owner,
+                )
+                .await
+        }
+    }
 }
 
 pub(crate) fn resolve_redirect_location<'a>(
@@ -1430,67 +1605,12 @@ async fn resolve_streaming_strategy(
     options: StreamingAcquireOptions<'_>,
 ) -> StreamingStrategy {
     // allocate a provider connection
-    let provider_connection_handle = match options.force_provider {
-        Some(provider) => {
-            // First try to stay on the exact pinned provider account without over-allocating.
-            if let Some(handle) = app_state
-                .active_provider
-                .acquire_exact_connection_with_grace_for_session(
-                    provider,
-                    &fingerprint.addr,
-                    options.allow_provider_grace,
-                    options.user_priority,
-                    options.connection_kind,
-                    options.session_owner,
-                )
-                .await
-            {
-                Some(handle)
-            } else if options.allow_forced_provider_fallback {
-                debug_if_enabled!(
-                    "Pinned provider {} unavailable for {}; falling back to lineup allocation",
-                    sanitize_sensitive_info(provider),
-                    sanitize_sensitive_info(&fingerprint.addr.to_string())
-                );
-                app_state
-                    .active_provider
-                    .acquire_connection_with_grace_for_session(
-                        &input.name,
-                        &fingerprint.addr,
-                        options.allow_provider_grace,
-                        options.user_priority,
-                        options.connection_kind,
-                        options.session_owner,
-                    )
-                    .await
-            } else {
-                debug_if_enabled!(
-                    "Pinned provider {} unavailable for {}; strict provider affinity prevents fallback",
-                    sanitize_sensitive_info(provider),
-                    sanitize_sensitive_info(&fingerprint.addr.to_string())
-                );
-                None
-            }
-        }
-        None => {
-            app_state
-                .active_provider
-                .acquire_connection_with_grace_for_session(
-                    &input.name,
-                    &fingerprint.addr,
-                    options.allow_provider_grace,
-                    options.user_priority,
-                    options.connection_kind,
-                    options.session_owner,
-                )
-                .await
-        }
-    };
+    let mut provider_connection_handle = acquire_stream_provider_handle(app_state, input, fingerprint, options).await;
 
     // panel_api provisioning/loading is handled later in the stream creation flow
 
-    let stream_response_params = if let Some(allocation) = provider_connection_handle.as_ref().map(|ph| &ph.allocation)
-    {
+    let mut release_failed_mapping = false;
+    let stream_response_params = if let Some(allocation) = provider_connection_handle.as_ref().map(|ph| &ph.allocation) {
         match allocation {
             ProviderAllocation::Exhausted => {
                 debug!("Provider {} is exhausted. No connections allowed.", input.name);
@@ -1498,30 +1618,35 @@ async fn resolve_streaming_strategy(
                 ProviderStreamState::Custom(stream)
             }
             ProviderAllocation::Available(ref provider_cfg) | ProviderAllocation::GracePeriod(ref provider_cfg) => {
-                // Keep the URL only when it already targets the selected provider. Hot reload can leave old alias URLs
-                // in persisted playlists until the next processing run.
-                let keep_original_url = stream_url_matches_provider(stream_url, provider_cfg);
-                let (selected_provider_name, url) = if keep_original_url {
-                    (provider_cfg.name.clone(), stream_url.to_string())
-                } else {
-                    (provider_cfg.name.clone(), get_stream_alternative_url(stream_url, input, provider_cfg))
-                };
+                // Keep the URL only when it already targets the selected provider account. Hot reload can leave old
+                // alias URLs in persisted playlists until the next processing run.
+                if let Some((selected_provider_name, url)) = select_provider_stream_url(stream_url, input, provider_cfg) {
+                    debug_if_enabled!(
+                        "provider session: input={} provider_cfg={} user={} allocation={} stream_url={}",
+                        sanitize_sensitive_info(&input.name),
+                        sanitize_sensitive_info(&provider_cfg.name),
+                        sanitize_sensitive_info(
+                            provider_cfg.get_user_info().as_ref().map_or_else(|| "?", |u| u.username.as_str())
+                        ),
+                        allocation.short_key(),
+                        sanitize_sensitive_info(resolve_request_url_for_logging(input, &url).as_ref())
+                    );
 
-                debug_if_enabled!(
-                    "provider session: input={} provider_cfg={} user={} allocation={} stream_url={}",
-                    sanitize_sensitive_info(&input.name),
-                    sanitize_sensitive_info(&provider_cfg.name),
-                    sanitize_sensitive_info(
-                        provider_cfg.get_user_info().as_ref().map_or_else(|| "?", |u| u.username.as_str())
-                    ),
-                    allocation.short_key(),
-                    sanitize_sensitive_info(resolve_request_url_for_logging(input, &url).as_ref())
-                );
-
-                if matches!(allocation, ProviderAllocation::Available(_)) {
-                    ProviderStreamState::Available(Some(selected_provider_name.intern()), url.intern())
+                    if matches!(allocation, ProviderAllocation::Available(_)) {
+                        ProviderStreamState::Available(Some(selected_provider_name.intern()), url.intern())
+                    } else {
+                        ProviderStreamState::GracePeriod(Some(selected_provider_name.intern()), url.intern())
+                    }
                 } else {
-                    ProviderStreamState::GracePeriod(Some(selected_provider_name.intern()), url.intern())
+                    debug_if_enabled!(
+                        "provider session rejected: input={} provider_cfg={} allocation={} stream_url={} reason=unmapped_provider_url",
+                        sanitize_sensitive_info(&input.name),
+                        sanitize_sensitive_info(&provider_cfg.name),
+                        allocation.short_key(),
+                        sanitize_sensitive_info(resolve_request_url_for_logging(input, stream_url).as_ref())
+                    );
+                    release_failed_mapping = true;
+                    create_unmapped_provider_stream(&app_state.app_config)
                 }
             }
         }
@@ -1530,6 +1655,12 @@ async fn resolve_streaming_strategy(
         let stream = create_provider_connections_exhausted_stream(&app_state.app_config, &[]);
         ProviderStreamState::Custom(stream)
     };
+
+    if release_failed_mapping {
+        if let Some(handle) = provider_connection_handle.take() {
+            app_state.connection_manager.release_provider_handle(Some(handle)).await;
+        }
+    }
 
     StreamingStrategy {
         provider_handle: provider_connection_handle,
@@ -1877,7 +2008,10 @@ where
                     return Some(StatusCode::BAD_REQUEST.into_response());
                 }
                 Some(url) => match app_state.active_provider.get_next_provider(&params.input.name).await {
-                    Some(provider_cfg) => get_stream_alternative_url(&url, params.input, &provider_cfg),
+                    Some(provider_cfg) => match get_stream_alternative_url(&url, params.input, &provider_cfg) {
+                        Some(stream_url) => stream_url,
+                        None => return Some(StatusCode::BAD_REQUEST.into_response()),
+                    },
                     None => url.to_string(),
                 },
             };
@@ -3759,7 +3893,29 @@ mod tests {
 
         let rewritten = get_stream_alternative_url(stream_url, &input, &alias);
 
-        assert_eq!(rewritten, stream_url);
+        assert_eq!(rewritten, None);
+    }
+
+    #[test]
+    fn stream_alternative_url_rewrites_only_query_auth_fields() {
+        let input = ConfigInput {
+            name: "source".intern(),
+            url: "http://source.example".to_string(),
+            username: Some("source-user".to_string()),
+            password: Some("source-pass".to_string()),
+            input_type: InputType::Xtream,
+            ..ConfigInput::default()
+        };
+        let alias = test_runtime_provider("http://alias.example", "alias-user", "alias-pass");
+        let stream_url =
+            "http://source.example/player?token=source-user&username=source-user&password=source-pass";
+
+        let rewritten = get_stream_alternative_url(stream_url, &input, &alias);
+
+        assert_eq!(
+            rewritten,
+            Some("http://alias.example/player?token=source-user&username=alias-user&password=alias-pass".to_string())
+        );
     }
 
     #[test]
@@ -3915,7 +4071,7 @@ mod tests {
         let busy_addr: SocketAddr = "127.0.0.1:55301".parse().unwrap_or_else(|_| unreachable!());
         let strict_addr: SocketAddr = "127.0.0.1:55302".parse().unwrap_or_else(|_| unreachable!());
         let fallback_addr: SocketAddr = "127.0.0.1:55303".parse().unwrap_or_else(|_| unreachable!());
-        let stream_url = "http://provider-1.example/movie/1.mkv";
+        let stream_url = "http://provider-1.example/movie/user1/pass1/1.mkv";
 
         let busy = app_state
             .active_provider
@@ -4011,6 +4167,41 @@ mod tests {
         };
         assert_eq!(provider.as_ref(), "provider_1");
         assert_eq!(url.as_ref(), "http://provider-1.example/live/user1/pass1/100.ts");
+
+        app_state.active_provider.release_connection(&addr).await;
+    }
+
+    #[tokio::test]
+    async fn resolve_streaming_strategy_rejects_unmapped_provider_url() {
+        let app_state = create_test_dual_provider_app_state();
+        let input_name = "provider_1".intern();
+        let input = app_state
+            .app_config
+            .sources
+            .load()
+            .get_input_by_name(&input_name)
+            .cloned()
+            .unwrap_or_else(|| unreachable!());
+        let addr: SocketAddr = "127.0.0.1:55305".parse().unwrap_or_else(|_| unreachable!());
+
+        let strategy = resolve_streaming_strategy(
+            &app_state,
+            "http://unmapped.example/live/user1/pass1/100.ts",
+            &create_test_fingerprint(addr),
+            &input,
+            StreamingAcquireOptions {
+                force_provider: None,
+                allow_forced_provider_fallback: false,
+                allow_provider_grace: false,
+                user_priority: 0,
+                connection_kind: crate::api::model::ConnectionKind::Normal,
+                session_owner: Some("live-session"),
+            },
+        )
+        .await;
+
+        assert!(strategy.provider_handle.is_none());
+        assert!(matches!(strategy.provider_stream_state, ProviderStreamState::Custom(_)));
 
         app_state.active_provider.release_connection(&addr).await;
     }

--- a/backend/src/api/endpoints/hls_api.rs
+++ b/backend/src/api/endpoints/hls_api.rs
@@ -178,7 +178,10 @@ pub(in crate::api) async fn handle_hls_stream_request(
         match provider_handle.as_ref().map(|handle| &handle.allocation) {
             Some(ProviderAllocation::Exhausted) => (url, None, provider_handle),
             Some(ProviderAllocation::Available(cfg) | ProviderAllocation::GracePeriod(cfg)) => {
-                let stream_url = get_stream_alternative_url(&url, input, cfg);
+                let Some(stream_url) = get_stream_alternative_url(&url, input, cfg) else {
+                    app_state.connection_manager.release_provider_handle(provider_handle).await;
+                    return axum::http::StatusCode::SERVICE_UNAVAILABLE.into_response();
+                };
                 let session_token = app_state
                     .active_users
                     .create_user_session(crate::api::model::CreateUserSessionParams {
@@ -218,7 +221,13 @@ pub(in crate::api) async fn handle_hls_stream_request(
         {
             Some(provider_handle) => match provider_handle.allocation.get_provider_config() {
                 Some(provider_cfg) => {
-                    let stream_url = get_stream_alternative_url(&url, input, &provider_cfg);
+                    let Some(stream_url) = get_stream_alternative_url(&url, input, &provider_cfg) else {
+                        app_state
+                            .connection_manager
+                            .release_provider_handle(Some(provider_handle))
+                            .await;
+                        return axum::http::StatusCode::SERVICE_UNAVAILABLE.into_response();
+                    };
                     debug_if_enabled!(
                             "API endpoint [HLS] create_session_fingerprint user={} virtual_id={virtual_id} provider={} stream_url={}",
                             sanitize_sensitive_info(&user.username),

--- a/backend/src/api/endpoints/m3u_api.rs
+++ b/backend/src/api/endpoints/m3u_api.rs
@@ -172,7 +172,7 @@ async fn m3u_api_stream(
     }
 
     if pli.item_type.is_local() {
-        let playback_session_token = create_session_fingerprint(fingerprint, &user.username, virtual_id, true);
+        let playback_session_token = create_session_fingerprint(fingerprint, &user.username, virtual_id, false);
         let user_session = app_state
             .active_users
             .get_and_update_user_session(&user.username, &playback_session_token)
@@ -185,9 +185,7 @@ async fn m3u_api_stream(
             user_session.as_ref(),
             playback_session_token.as_str(),
             false,
-            crate::api::api_utils::EvictionReentryGuard::SocketPlayback {
-                virtual_id: pli.virtual_id,
-            },
+            crate::api::api_utils::EvictionReentryGuard::Session(playback_session_token.as_str()),
             false,
             false,
         )

--- a/backend/src/api/endpoints/xtream_api.rs
+++ b/backend/src/api/endpoints/xtream_api.rs
@@ -309,7 +309,7 @@ async fn xtream_player_api_stream(
     }
 
     if pli.item_type.is_local() {
-        let playback_session_token = create_session_fingerprint(fingerprint, &user.username, virtual_id, true);
+        let playback_session_token = create_session_fingerprint(fingerprint, &user.username, virtual_id, false);
         let user_session = app_state
             .active_users
             .get_and_update_user_session(&user.username, &playback_session_token)
@@ -322,9 +322,7 @@ async fn xtream_player_api_stream(
             user_session.as_ref(),
             playback_session_token.as_str(),
             false,
-            crate::api::api_utils::EvictionReentryGuard::SocketPlayback {
-                virtual_id: pli.virtual_id,
-            },
+            crate::api::api_utils::EvictionReentryGuard::Session(playback_session_token.as_str()),
             false,
             false,
         )
@@ -639,7 +637,7 @@ async fn xtream_player_api_stream_with_token(
         let user = create_api_proxy_user(app_state);
 
         if pli.item_type.is_local() {
-            let playback_session_token = create_session_fingerprint(fingerprint, "webui", virtual_id, true);
+            let playback_session_token = create_session_fingerprint(fingerprint, "webui", virtual_id, false);
             return local_stream_response(
                 fingerprint,
                 app_state,

--- a/backend/src/api/model/active_user_manager.rs
+++ b/backend/src/api/model/active_user_manager.rs
@@ -389,6 +389,14 @@ fn is_stable_session_stream(stream: &StreamInfo) -> bool {
         )
 }
 
+fn uses_session_reentry_guard(stream: &StreamInfo) -> bool {
+    stream.channel.item_type.requires_provider_affinity()
+        || matches!(
+            extract_extension_from_url(stream.channel.url.as_ref()).as_deref(),
+            Some(ext) if ext == HLS_EXT || ext == DASH_EXT
+        )
+}
+
 #[derive(Clone, Copy, Debug)]
 struct RecentWinnerProtection {
     protected_addr: SocketAddr,
@@ -2857,10 +2865,11 @@ impl ActiveUserManager {
         let mut socket_guard_keys = Vec::new();
 
         for stream in connection_data.streams.iter().filter(|stream| stream.addr == *addr) {
-            if is_stable_session_stream(stream) {
-                if let Some(session_token) = stream.session_token.clone() {
-                    session_tokens.push(session_token);
-                }
+            if uses_session_reentry_guard(stream) && stream.session_token.is_some() {
+                let Some(session_token) = stream.session_token.clone() else {
+                    continue;
+                };
+                session_tokens.push(session_token);
             } else {
                 socket_guard_keys.push(create_socket_reentry_guard_key(
                     &username,
@@ -4986,6 +4995,120 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn recently_evicted_vod_uses_session_reentry_guard() {
+        let config = Config::default();
+        let geoip = Arc::new(ArcSwapOption::<GeoIp>::default());
+        let event_manager = Arc::new(EventManager::new());
+        let manager = ActiveUserManager::new(&config, &geoip, &event_manager);
+
+        let evicted_addr: SocketAddr = "127.0.0.1:55113".parse().unwrap();
+        let protected_addr: SocketAddr = "127.0.0.1:55114".parse().unwrap();
+        let fingerprint = Fingerprint::new("fp-vod-guard".to_string(), "127.0.0.1".to_string(), evicted_addr);
+        let mut user = ProxyUserCredentials::default();
+        user.username = String::from("vod-guard-user");
+        user.max_connections = 1;
+        let mut channel = test_channel(2019);
+        channel.item_type = PlaylistItemType::Video;
+        channel.cluster = XtreamCluster::Video;
+        channel.url = "http://localhost/movie.mkv".intern();
+
+        manager.add_connection(&evicted_addr).await;
+        manager.add_connection(&protected_addr).await;
+        manager
+            .create_user_session(CreateUserSessionParams {
+                user: &user,
+                session_token: "tok-guard-vod",
+                virtual_id: channel.virtual_id,
+                provider: "provider-a",
+                stream_url: channel.url.as_ref(),
+                addr: &evicted_addr,
+                connection_permission: UserConnectionPermission::Allowed,
+                connection_kind: Some(ConnectionKind::Normal),
+                socket_bound: false,
+            })
+            .await;
+        manager
+            .update_connection(ActiveUserConnectionParams {
+                uid: 19,
+                meter_uid: 0,
+                username: &user.username,
+                max_connections: 1,
+                soft_connections: 0,
+                connection_kind: ConnectionKind::Normal,
+                priority: 0,
+                soft_priority: 0,
+                fingerprint: &fingerprint,
+                provider: "provider-a".intern(),
+                stream_channel: &channel,
+                user_agent: Cow::Borrowed("ua"),
+                session_token: Some("tok-guard-vod"),
+            })
+            .await;
+
+        manager
+            .mark_recent_eviction_guard_for_addr(&evicted_addr, protected_addr, 10)
+            .await;
+
+        assert_eq!(
+            manager
+                .recently_evicted_session_protected_addr("tok-guard-vod")
+                .await,
+            Some(protected_addr)
+        );
+        let connections = manager.connections.read().await;
+        assert!(
+            connections.recent_socket_reentry_guards.is_empty(),
+            "provider-affine VOD must not be guarded by transient socket identity"
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_affine_stream_without_session_token_uses_socket_reentry_fallback() {
+        let config = Config::default();
+        let geoip = Arc::new(ArcSwapOption::<GeoIp>::default());
+        let event_manager = Arc::new(EventManager::new());
+        let manager = ActiveUserManager::new(&config, &geoip, &event_manager);
+
+        let evicted_addr: SocketAddr = "127.0.0.1:55115".parse().unwrap();
+        let protected_addr: SocketAddr = "127.0.0.1:55116".parse().unwrap();
+        let fingerprint = Fingerprint::new("fp-vod-no-token".to_string(), "127.0.0.1".to_string(), evicted_addr);
+        let mut channel = test_channel(2020);
+        channel.item_type = PlaylistItemType::Video;
+        channel.cluster = XtreamCluster::Video;
+        channel.url = "http://localhost/movie-no-token.mkv".intern();
+
+        manager.add_connection(&evicted_addr).await;
+        manager
+            .update_connection(ActiveUserConnectionParams {
+                uid: 20,
+                meter_uid: 0,
+                username: "vod-no-token-user",
+                max_connections: 1,
+                soft_connections: 0,
+                connection_kind: ConnectionKind::Normal,
+                priority: 0,
+                soft_priority: 0,
+                fingerprint: &fingerprint,
+                provider: "provider-a".intern(),
+                stream_channel: &channel,
+                user_agent: Cow::Borrowed("ua"),
+                session_token: None,
+            })
+            .await;
+
+        manager
+            .mark_recent_eviction_guard_for_addr(&evicted_addr, protected_addr, 10)
+            .await;
+
+        assert_eq!(
+            manager
+                .recent_socket_reentry_protected_addr("vod-no-token-user", "127.0.0.1", channel.virtual_id)
+                .await,
+            Some(protected_addr)
+        );
+    }
+
+    #[tokio::test]
     async fn test_reused_logical_stream_refreshes_normal_priority() {
         let config = Config::default();
         let geoip = Arc::new(ArcSwapOption::<GeoIp>::default());
@@ -5169,6 +5292,67 @@ mod tests {
         assert_eq!(streams.len(), 2);
         assert!(streams.iter().any(|stream| stream.uid == 31));
         assert!(streams.iter().any(|stream| stream.uid == 32));
+    }
+
+    #[tokio::test]
+    async fn unlimited_user_can_open_same_and_different_live_streams_from_same_ip() {
+        let config = Config::default();
+        let geoip = Arc::new(ArcSwapOption::<GeoIp>::default());
+        let event_manager = Arc::new(EventManager::new());
+        let manager = ActiveUserManager::new(&config, &geoip, &event_manager);
+
+        let username = "unlimited-same-ip";
+        let client_ip = "10.9.0.1";
+        let addrs = [
+            "10.9.0.1:55101".parse::<SocketAddr>().unwrap(),
+            "10.9.0.1:55102".parse::<SocketAddr>().unwrap(),
+            "10.9.0.1:55103".parse::<SocketAddr>().unwrap(),
+        ];
+        let fingerprints = [
+            Fingerprint::new("fp-unlimited-1".to_string(), client_ip.to_string(), addrs[0]),
+            Fingerprint::new("fp-unlimited-2".to_string(), client_ip.to_string(), addrs[1]),
+            Fingerprint::new("fp-unlimited-3".to_string(), client_ip.to_string(), addrs[2]),
+        ];
+
+        for addr in addrs {
+            manager.add_connection(&addr).await;
+        }
+
+        for (idx, (fingerprint, virtual_id)) in fingerprints.iter().zip([4100, 4100, 4101]).enumerate() {
+            let token = format!("tok-unlimited-{idx}");
+            manager
+                .update_connection(ActiveUserConnectionParams {
+                    uid: 410 + u32::try_from(idx).unwrap_or_default(),
+                    meter_uid: 0,
+                    username,
+                    max_connections: 0,
+                    soft_connections: 0,
+                    connection_kind: ConnectionKind::Normal,
+                    priority: 0,
+                    soft_priority: 0,
+                    fingerprint,
+                    provider: "provider-a".intern(),
+                    stream_channel: &test_channel(virtual_id),
+                    user_agent: Cow::Borrowed("ua"),
+                    session_token: Some(&token),
+                })
+                .await
+                .expect("unlimited stream should register");
+        }
+
+        assert_eq!(manager.user_connections(username).await, 3);
+        assert_eq!(manager.active_streams().await.len(), 3);
+        assert_eq!(
+            manager.connection_admission(username, 0, 0).await.permission,
+            UserConnectionPermission::Allowed
+        );
+        assert_eq!(
+            manager
+                .connection_admission_for_session(username, 0, 0, "tok-unlimited-new")
+                .await
+                .permission,
+            UserConnectionPermission::Allowed
+        );
     }
 
     #[tokio::test]

--- a/backend/src/api/model/streams/active_client_stream.rs
+++ b/backend/src/api/model/streams/active_client_stream.rs
@@ -1055,6 +1055,7 @@ fn stream_grace_period(request: GracePeriodParams) -> (Option<Arc<AtomicU8>>, Op
                                 crate::api::api_utils::EvictionReentryGuard::SocketPlayback { virtual_id }
                             } else {
                                 crate::api::api_utils::EvictionReentryGuard::Session(
+                                    // Defensive fallback: an empty token will not match any real session.
                                     session_token.as_deref().unwrap_or_default(),
                                 )
                             };

--- a/backend/src/api/model/streams/active_client_stream.rs
+++ b/backend/src/api/model/streams/active_client_stream.rs
@@ -108,6 +108,7 @@ pub(crate) struct ActiveClientStreamParams<'a> {
     pub connection_kind: crate::api::model::active_provider_manager::ConnectionKind,
     pub fingerprint: &'a Fingerprint,
     pub stream_channel: StreamChannel,
+    pub socket_bound: bool,
     pub session_token: Option<&'a str>,
     pub req_headers: &'a HeaderMap,
     pub meter_uid: u32,
@@ -722,6 +723,7 @@ pub(crate) async fn create_active_client_stream(request: ActiveClientStreamParam
         connection_kind,
         fingerprint,
         stream_channel,
+        socket_bound,
         session_token,
         req_headers,
         meter_uid,
@@ -834,7 +836,7 @@ pub(crate) async fn create_active_client_stream(request: ActiveClientStreamParam
         grace_active_version,
         grace_resolution_context: owned_grace_ctx,
         grace_kind: Some(connection_kind),
-        socket_bound: stream_channel.item_type.uses_socket_bound_session(),
+        socket_bound,
     });
 
     let cfg = &app_state.app_config;
@@ -1905,6 +1907,7 @@ mod tests {
             connection_kind: crate::api::model::ConnectionKind::Normal,
             fingerprint: &test_fingerprint,
             stream_channel: create_test_stream_channel(1, "http://provider-1.example/live/1"),
+            socket_bound: true,
             session_token: None,
             req_headers: &HeaderMap::default(),
             meter_uid: 0,
@@ -1979,6 +1982,7 @@ mod tests {
             connection_kind: crate::api::model::ConnectionKind::Normal,
             fingerprint: &test_fingerprint,
             stream_channel: create_test_shared_stream_channel(1, "http://provider-1.example/live/1"),
+            socket_bound: true,
             session_token: None,
             req_headers: &HeaderMap::default(),
             meter_uid: 0,
@@ -2459,6 +2463,7 @@ mod tests {
             connection_kind: crate::api::model::ConnectionKind::Normal,
             fingerprint: &test_fingerprint,
             stream_channel: create_test_stream_channel(1, "http://provider-1.example/live/1"),
+            socket_bound: true,
             session_token: None,
             req_headers: &HeaderMap::default(),
             meter_uid: 55,

--- a/backend/src/api/model/streams/shared_stream_manager.rs
+++ b/backend/src/api/model/streams/shared_stream_manager.rs
@@ -26,7 +26,7 @@ use tokio::{
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
 
-const DEFAULT_SHARED_BUFFER_SIZE_BYTES: usize = 1024 * 1024 * 12;
+const DEFAULT_SHARED_BUFFER_SIZE_BYTES: usize = 1024 * 1024 * 96;
 const YIELD_COUNTER: usize = 64;
 const SHARED_BURST_BYTES_PER_BUFFER_SLOT: usize = 12 * 1024;
 

--- a/backend/src/api/model/streams/shared_stream_manager.rs
+++ b/backend/src/api/model/streams/shared_stream_manager.rs
@@ -26,7 +26,7 @@ use tokio::{
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
 
-const DEFAULT_SHARED_BUFFER_SIZE_BYTES: usize = 1024 * 1024 * 96;
+const DEFAULT_SHARED_BUFFER_SIZE_BYTES: usize = 1024 * 1024 * 32;
 const YIELD_COUNTER: usize = 64;
 const SHARED_BURST_BYTES_PER_BUFFER_SLOT: usize = 12 * 1024;
 

--- a/docs/src/configuration/connection-handling-runtime-flow.md
+++ b/docs/src/configuration/connection-handling-runtime-flow.md
@@ -150,6 +150,7 @@ HLS is session-oriented:
 - reconnects during a running playback
 
 Tuliprox therefore treats HLS as one logical playback with many follow-up requests.
+Separate HLS playlist starts can still get separate session tokens, so two players behind the same IP/user-agent can watch the same channel independently.
 
 ### Catchup
 
@@ -165,11 +166,16 @@ Plain TS live is much stricter:
 
 - the first request is the actual playback start
 - a new parallel request is a new connection attempt
+- every active TS socket is counted separately when user limits are enabled
+- with `max_connections: 0`, the user-side limit does not block the same IP from opening the same or different TS streams
 - it may replace another stream if admission strategies allow that
+- provider capacity and shared-stream behavior still apply separately
 
 ### VOD / Series
 
 VOD and series can use reopen and range-style behavior, but they still do not have the same manifest/segment split as HLS.
+Tuliprox therefore treats follow-up range, seek, and reopen requests as the same logical playback when the session identity matches.
+They are provider-affine like HLS/catchup, but they are not plain TS socket-bound playback.
 
 ## 7. What happens when the user is already at the limit
 

--- a/docs/src/configuration/connection-handling-session-implementation-notes.md
+++ b/docs/src/configuration/connection-handling-session-implementation-notes.md
@@ -40,7 +40,13 @@ This page is deliberately narrower than the runtime-internals page:
 
 ### Session token
 
-The session token is the stable logical playback identity.
+The session token is the playback identity used by admission, address tracking, and provider affinity.
+
+It is stable for follow-up requests of the same playback, but it is not always derived from the same fields:
+
+- plain TS live uses a socket-scoped playback token
+- VOD, series, catchup, and local playback use a logical token suitable for reopen/seek/range workflows
+- HLS/DASH playlist starts use a token scoped to that initial adaptive playback start, and rewritten segment URLs carry that token forward
 
 It is used to answer questions like:
 
@@ -108,8 +114,8 @@ Why:
 - VOD uses range and seek requests that still belong to one playback
 - HLS fetches many chunk requests that still belong to one playback
 
-This means the same logical HLS or VOD stream must keep the same provider account for its follow-up requests, even though  
-those requests may arrive on different sockets.
+This means the same provider-affine HLS, VOD, series, or catchup stream must keep the same provider account for
+its follow-up requests, even though those requests may arrive on different sockets.
 
 ### Adaptive preserved session
 
@@ -142,9 +148,16 @@ Important:
 
 ### TS live, VOD, series
 
-The regular M3U and Xtream playback endpoints build a stable playback token with:
+The regular M3U and Xtream playback endpoints build playback tokens with:
 
-- `create_session_fingerprint(fingerprint, username, virtual_id)`
+- `create_playback_session_fingerprint(...)`
+
+The helper deliberately keeps the token matrix different per playback type:
+
+- plain TS live is socket-scoped, so two TS sockets are two independent playback attempts
+- VOD and series are logical, so range/seek/reopen requests can continue the same playback
+- HLS/DASH playlist starts are scoped to the initial adaptive playback start, so two players behind the same
+  IP/user-agent can watch the same HLS/DASH channel independently
 
 ### Catchup
 
@@ -160,11 +173,11 @@ On segment fetch:
 
 - Tuliprox decodes the HLS token
 - extracts the session token if present
-- falls back to `create_session_fingerprint(...)` if needed
+- falls back to a logical `create_session_fingerprint(...)` only for legacy or malformed tokens without an embedded session token
 
 ### Local playback
 
-Local playback uses a stable `playback_session_token` passed into `local_stream_response(...)`.
+Local playback uses a stable logical `playback_session_token` passed into `local_stream_response(...)`.
 
 ## The three decisions that must stay separate
 
@@ -222,7 +235,7 @@ Intended model:
 If you collapse this into socket-binding, you get the wrong matrix:
 
 - TS would be over-pinned
-- VOD/HLS would be under-pinned
+- VOD/series/HLS would be under-pinned
 
 ## Current code flow
 
@@ -303,7 +316,8 @@ That is what allows a VOD session to survive:
 
 The address move itself is not the provider-affinity rule.
 
-Provider-affinity is the separate invariant that follow-up requests for the same VOD/HLS playback should continue on the same provider account.
+Provider-affinity is the separate invariant that follow-up requests for the same VOD/series/HLS playback should
+continue on the same provider account.
 
 This also explains why seek/reopen behavior must not be confused with:
 
@@ -367,6 +381,10 @@ These tests cover the most fragile parts of the current logic:
 - `resolve_admission_with_strategies_allows_existing_session_even_when_user_is_at_limit`
 - `local_stream_response_reuses_stable_playback_session_token_across_reopens`
 - `vod_session_survives_overlapping_and_seek_sockets`
+- `playback_session_fingerprint_keeps_ts_socket_bound_but_vod_logical`
+- `adaptive_playback_session_fingerprint_is_unique_per_initial_socket`
+- `unlimited_user_can_open_same_and_different_live_streams_from_same_ip`
+- `recently_evicted_vod_uses_session_reentry_guard`
 - `update_session_addr_prunes_previous_registration_for_socket_bound_session`
 - `test_adaptive_session_release_connection_preserves_logical_stream_and_start_time`
 

--- a/docs/src/configuration/connection-handling-sessions-and-reconnects.md
+++ b/docs/src/configuration/connection-handling-sessions-and-reconnects.md
@@ -35,8 +35,10 @@ A session is the logical playback identity of a user for one stream activity.
 Important distinction:
 
 - HLS and catchup rely heavily on logical sessions
-- regular TS/VOD/local playback is counted by active socket-backed stream, not by a long-lived playback session
-- this means opening the same TS/VOD stream twice on two sockets counts as 2 connections
+- plain TS live playback is counted by active socket-backed stream, not by a long-lived playback session
+- VOD, series, catchup, and local playback use logical sessions for reopen/seek/range continuity
+- this means opening the same TS live stream twice on two sockets counts as 2 user connections when user limits are enabled
+- if the user has `max_connections: 0`, user-limit admission is unlimited and those TS sockets are not rejected by the user limit
 
 It helps Tuliprox decide:
 
@@ -92,8 +94,9 @@ It does not mean that every later socket should always be treated as the same pl
 In particular:
 
 - HLS and catchup may reuse session identity within their configured TTL
-- regular TS/VOD/local playback remains socket-bound and is counted per active stream/socket
-- a second TS/VOD socket therefore consumes another user connection or soft slot
+- plain TS live playback remains socket-bound and is counted per active stream/socket
+- a second TS socket therefore consumes another user connection or soft slot when user limits are enabled
+- VOD, series, and local playback are not socket-bound for session tracking because seek/range/reopen requests often belong to the same playback
 
 The TTL does not automatically mean:
 
@@ -206,7 +209,8 @@ Depending on timing, Tuliprox may:
 - or discard the session once the window expires
 
 This is most relevant for HLS and catchup continuity.
-Regular TS/VOD/local playback should be understood primarily as socket-bound admission.
+Plain TS live playback should be understood primarily as socket-bound admission.
+VOD, series, and local playback should be understood as session-based reopen/seek workflows rather than plain socket-bound playback.
 
 ## What matters when shared streams and sessions meet
 

--- a/docs/src/configuration/connection-handling.md
+++ b/docs/src/configuration/connection-handling.md
@@ -89,14 +89,17 @@ This matters especially for:
 
 - HLS
 - catchup
+- VOD/series range and seek requests
+- quick reconnects
+- channel switches with a brief overlap
 
 It does not apply equally to every stream type:
 
 - HLS and catchup are session-oriented because many follow-up HTTP requests still belong to one logical playback
-- regular TS/VOD/local playback is socket-bound for admission and connection counting
-- for TS/VOD, a second socket is a second connection even if it is the same user, same IP, and same stream
-- quick reconnects
-- channel switches with a brief overlap
+- VOD, series, and local playback use logical sessions for reopen, seek, and range-style behavior
+- plain TS live playback is socket-bound for admission and connection counting
+- for plain TS live, a second active socket is a second connection when user limits are enabled
+- if `max_connections: 0`, user-side admission is unlimited and the same IP may open the same or different TS streams
 
 ### Grace
 
@@ -142,12 +145,15 @@ Examples:
 
 If Tuliprox recognizes the same playback, not every follow-up request is treated like a completely new stream.
 
-This recognition is mainly relevant for HLS and catchup style playback.
-Regular TS/VOD playback is intentionally stricter:
+This recognition is mainly relevant for HLS, catchup, VOD, series, and local reopen/seek workflows.
+Plain TS live playback is intentionally stricter:
 
 - one active socket-backed stream counts as one connection
 - a parallel reopen on another socket counts as another connection
 - if `max_connections` is already exhausted, only a soft slot, admission strategy, or rejection remains
+
+If `max_connections` is `0`, this user-side limit does not reject additional TS sockets.
+Provider capacity and shared-stream behavior still apply separately.
 
 ### 2. Normal connection
 
@@ -273,7 +279,8 @@ Only the second case is temporarily suppressed.
 Important:
 
 - for HLS/catchup, this protection is scoped to the same session identity where Tuliprox has a stable session token
-- for socket-bound TS/VOD/local playback, Tuliprox uses a short same-user, same-IP, same-channel winner protection instead
+- for VOD, series, and local playback, this protection follows the logical session identity used for reopen/seek behavior
+- for socket-bound plain TS live playback, Tuliprox uses a short same-user, same-IP, same-channel winner protection instead
 - switching to a different channel is not blocked by it
 - soft admission can still succeed if a soft slot is free
 - the goal is to stop endless eviction ping-pong between aggressive player reconnect loops


### PR DESCRIPTION
Fix: Session handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback activation revalidation, refined provider-alias URL rewriting and retention, stricter handling when provider mapping fails, and tightened session-token scoping to prevent incorrect reconnects and eviction-guard misclassification.

* **Performance**
  * Increased shared stream buffer size for smoother playback.

* **Documentation**
  * Clarified session tracking and provider-affinity distinctions across HLS, VOD/series, local, and plain TS live.

* **Tests**
  * Added/updated tests for URL rewriting, provider matching, revalidation, and socket-vs-session binding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euzu/tuliprox/pull/757)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->