### PR TITLE
fix stream history time processing

### DIFF
--- a/frontend/src/app/components/dashboard/stream_history_view.rs
+++ b/frontend/src/app/components/dashboard/stream_history_view.rs
@@ -65,8 +65,9 @@ fn today_start_ts() -> i64 {
     today.and_hms_opt(0, 0, 0).map(|dt| dt.and_utc().timestamp()).unwrap_or(0)
 }
 
-fn ts_to_date_str(ts: i64) -> String {
-    chrono::DateTime::from_timestamp(ts, 0).map_or_else(String::new, |dt| dt.format("%Y-%m-%d").to_string())
+use chrono::{Local, TimeZone, Utc};
+pub fn format_ts(ts: u64) -> String {
+    chrono::DateTime::from_timestamp(ts as i64, 0).map_or_else(|| ts.to_string(),|dt| {dt.with_timezone(&Local).format("%Y-%m-%d %H:%M:%S").to_string()},)
 }
 
 fn optional_record_text_str(value: Option<&str>) -> &str { value.unwrap_or("-") }


### PR DESCRIPTION
fix stream history time processing to local time

The time format in the stream history would be presented to the browser in UTC, however the current time in the EPG panel would be corrent. Changed the frontend to show the local time format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Stream history timestamps now display both date and time information with precise temporal granularity, replacing the previous date-only display format. This enhancement provides users with greater context and more detailed information when reviewing stream activity and tracking when specific events occurred.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euzu/tuliprox/pull/760?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->