### PR TITLE
catchup handling fix, streaming fix

### DIFF
--- a/backend/src/api/api_utils.rs
+++ b/backend/src/api/api_utils.rs
@@ -20,7 +20,7 @@ use crate::{
         plex::client::PlexCatalogClient,
         MediaServerError, MediaServerErrorKind, MediaServerHttpClient, MediaServerImageRef,
     },
-    model::{AppConfig, ConfigInput, ConfigTarget, ProxyUserCredentials},
+    model::{AppConfig, ConfigInput, ConfigTarget, InputUserInfo, ProxyUserCredentials},
     utils::{
         async_file_reader, async_file_writer, create_new_file_for_write, debug_if_enabled, get_file_extension, request,
         request::{content_type_from_ext, parse_range, send_with_retry_and_provider},
@@ -1308,17 +1308,30 @@ async fn activate_session_before_stream_open(
 }
 
 pub fn get_stream_alternative_url(stream_url: &str, input: &ConfigInput, alias_input: &Arc<ProviderConfig>) -> Option<String> {
-    let (source_base_url, source_username, source_password) = input.get_matched_config_by_url(stream_url)?;
+    if input.input_type.is_m3u() && input.get_matched_config_by_url(stream_url).is_none() {
+        return get_stream_alternative_url_m3u(stream_url, input, alias_input);
+    }
+
+    let (source_base_url, source_username, source_password, matched_via_external_signature) =
+        if let Some(matched) = input.get_matched_config_by_url(stream_url) {
+            (matched.0.to_string(), matched.1.cloned(), matched.2.cloned(), false)
+        } else {
+            let (base_url, username, password) = find_input_account_by_signature(stream_url, input)?;
+            (base_url, username, password, true)
+        };
+    if matched_via_external_signature && !input.input_type.is_m3u() {
+        return None;
+    }
     let alt_input_user_info = alias_input.get_user_info()?;
 
-    let modified = stream_url.replacen(source_base_url, &alt_input_user_info.base_url, 1);
+    let modified = stream_url.replacen(&source_base_url, &alt_input_user_info.base_url, 1);
     let mut url = Url::parse(&modified).ok()?;
 
     if let (Some(old_username), Some(old_password)) = (source_username, source_password) {
         let auth_updated = rewrite_url_auth_fields(
             &mut url,
-            old_username,
-            old_password,
+            &old_username,
+            &old_password,
             &alt_input_user_info.username,
             &alt_input_user_info.password,
         );
@@ -1328,6 +1341,76 @@ pub fn get_stream_alternative_url(stream_url: &str, input: &ConfigInput, alias_i
     }
 
     Some(url.to_string())
+}
+
+fn get_stream_alternative_url_m3u(
+    stream_url: &str,
+    input: &ConfigInput,
+    alias_input: &Arc<ProviderConfig>,
+) -> Option<String> {
+    if let Some((source_base_url, source_username, source_password)) =
+        find_input_account_by_signature(stream_url, input)
+    {
+        let alt_input_user_info = alias_input.get_user_info()?;
+        let modified = stream_url.replacen(&source_base_url, &alt_input_user_info.base_url, 1);
+        let mut url = Url::parse(&modified).ok()?;
+
+        if let (Some(old_username), Some(old_password)) = (source_username, source_password) {
+            let auth_updated = rewrite_url_auth_fields(
+                &mut url,
+                &old_username,
+                &old_password,
+                &alt_input_user_info.username,
+                &alt_input_user_info.password,
+            );
+            if !auth_updated {
+                return None;
+            }
+        }
+
+        return Some(url.to_string());
+    }
+    Some(stream_url.to_string())
+}
+
+/// Look for an account signature in the stream URL that matches the input
+/// itself or one of its configured aliases. Returns the matching entry's
+/// `(base_url, username, password)` so the caller can rewrite only the
+/// account-specific parts of the URL while preserving the original host/path.
+///
+/// This helper is used for safe credential rewrites when Tuliprox switches
+/// from one account to another. It is not the general trust gate for M3U
+/// foreign hosts: plain external URLs from a stored M3U playlist item may be
+/// accepted without a matching signature, while unrelated credential-bearing
+/// URLs still fail closed unless they provably match the input or one of its
+/// aliases.
+fn find_input_account_by_signature(
+    stream_url: &str,
+    input: &ConfigInput,
+) -> Option<(String, Option<String>, Option<String>)> {
+    // Try the input's main account first.
+    if let Some(user_info) = input.get_user_info() {
+        if stream_url_account_matches(stream_url, &user_info) {
+            return Some((input.url.clone(), Some(user_info.username), Some(user_info.password)));
+        }
+    }
+    // Then try each alias, if any. The input_type is inherited from the
+    // parent input for all aliases — see ConfigInputAlias definition.
+    if let Some(aliases) = input.aliases.as_ref() {
+        for alias in aliases {
+            if let Some(user_info) = InputUserInfo::new(
+                input.input_type,
+                alias.username.as_deref(),
+                alias.password.as_deref(),
+                &alias.url,
+            ) {
+                if stream_url_account_matches(stream_url, &user_info) {
+                    return Some((alias.url.clone(), Some(user_info.username), Some(user_info.password)));
+                }
+            }
+        }
+    }
+    None
 }
 
 fn rewrite_url_auth_fields(
@@ -1418,9 +1501,17 @@ fn rewrite_path_auth_fields(
 }
 
 fn stream_url_matches_provider(stream_url: &str, provider_cfg: &ProviderConfig) -> bool {
-    provider_cfg
-        .get_user_info()
-        .is_some_and(|user_info| stream_url_base_matches(stream_url, &user_info.base_url) && stream_url_account_matches(stream_url, &user_info))
+    let Some(user_info) = provider_cfg.get_user_info() else {
+        return false;
+    };
+    if stream_url_base_matches(stream_url, &user_info.base_url) {
+        // Same-host fast path: both base URL and account identity must match.
+        return stream_url_account_matches(stream_url, &user_info);
+    }
+    // For M3U inputs, the stored playlist entry itself is the trust anchor.
+    // External hosts are therefore allowed here even when they do not carry
+    // explicit account markers in the stream URL.
+    provider_cfg.input_type.is_m3u()
 }
 
 fn stream_url_base_matches(stream_url: &str, base_url: &str) -> bool {
@@ -3839,12 +3930,26 @@ mod tests {
     use tokio::sync::{mpsc, RwLock};
 
     fn test_runtime_provider(url: &str, username: &str, password: &str) -> Arc<RuntimeProviderConfig> {
+        test_runtime_provider_with_type(url, username, password, InputType::Xtream)
+    }
+
+    fn test_runtime_provider_with_type(
+        url: &str,
+        username: &str,
+        password: &str,
+        input_type: InputType,
+    ) -> Arc<RuntimeProviderConfig> {
+        let url = if input_type == InputType::M3u {
+            format!("{url}/playlist.m3u8?username={username}&password={password}")
+        } else {
+            url.to_string()
+        };
         let input = ConfigInput {
             name: "provider".intern(),
-            url: url.to_string(),
+            url,
             username: Some(username.to_string()),
             password: Some(password.to_string()),
-            input_type: InputType::Xtream,
+            input_type,
             ..ConfigInput::default()
         };
         Arc::new(RuntimeProviderConfig::new(
@@ -3951,6 +4056,168 @@ mod tests {
             "http://same.example/live/other-user/other-pass/123.ts",
             &provider
         ));
+    }
+
+    #[test]
+    fn stream_url_matches_provider_accepts_external_playlist_url_for_m3u_without_account_signature() {
+        let provider = test_runtime_provider_with_type(
+            "http://provider.example",
+            "selected-user",
+            "selected-pass",
+            InputType::M3u,
+        );
+
+        assert!(stream_url_matches_provider(
+            "https://hlspackager.akamaized.net/live/DB/ALYAUM_TV/HLS/ALYAUM_TV.m3u8",
+            &provider
+        ));
+        assert!(stream_url_matches_provider(
+            "https://shd-gcp-live.edgenextcdn.net/live/bitmovin-mbc-1/15cf99af5de54063fdabfefe66adc075/index.m3u8",
+            &provider
+        ));
+    }
+
+    #[test]
+    fn stream_url_matches_provider_rejects_external_cdn_url_with_wrong_account_signature() {
+        let provider = test_runtime_provider("http://provider.example", "selected-user", "selected-pass");
+
+        assert!(!stream_url_matches_provider(
+            "http://cdn.example/live/other-user/other-pass/123.ts",
+            &provider
+        ));
+        assert!(!stream_url_matches_provider(
+            "http://cdn.example/segment.ts?username=other-user&password=other-pass",
+            &provider
+        ));
+    }
+
+    #[test]
+    fn stream_url_matches_provider_rejects_open_external_cdn_url_without_account_signature_for_xtream() {
+        let provider = test_runtime_provider("http://provider.example", "selected-user", "selected-pass");
+
+        assert!(!stream_url_matches_provider("http://cdn.example/open/playlist.m3u8", &provider));
+        assert!(!stream_url_matches_provider("http://cdn.example/open/segment.ts?key=signedopaque", &provider));
+    }
+
+    #[test]
+    fn stream_url_matches_provider_rejects_external_cdn_url_for_xtream_even_with_valid_account_signature() {
+        let provider = test_runtime_provider("http://provider.example", "selected-user", "selected-pass");
+
+        assert!(!stream_url_matches_provider(
+            "http://cdn.example/live/selected-user/selected-pass/123.ts",
+            &provider
+        ));
+        assert!(!stream_url_matches_provider(
+            "http://cdn.example/segment.ts?username=selected-user&password=selected-pass",
+            &provider
+        ));
+    }
+
+    #[test]
+    fn find_input_account_by_signature_matches_main_input_and_alias_accounts() {
+        let input = ConfigInput {
+            name: "source".intern(),
+            url: "http://provider.example".to_string(),
+            username: Some("main-user".to_string()),
+            password: Some("main-pass".to_string()),
+            input_type: InputType::Xtream,
+            aliases: Some(vec![ConfigInputAlias {
+                id: 2,
+                name: "alias".intern(),
+                url: "http://alias.example".to_string(),
+                username: Some("alias-user".to_string()),
+                password: Some("alias-pass".to_string()),
+                max_connections: 1,
+                priority: 0,
+                exp_date: None,
+                enabled: true,
+            }]),
+            ..ConfigInput::default()
+        };
+
+        let main = find_input_account_by_signature(
+            "http://cdn.example/live/main-user/main-pass/1.ts",
+            &input,
+        );
+        assert_eq!(
+            main,
+            Some((
+                "http://provider.example".to_string(),
+                Some("main-user".to_string()),
+                Some("main-pass".to_string()),
+            ))
+        );
+
+        let alias = find_input_account_by_signature(
+            "http://cdn.example/live/alias-user/alias-pass/1.ts",
+            &input,
+        );
+        assert_eq!(
+            alias,
+            Some((
+                "http://alias.example".to_string(),
+                Some("alias-user".to_string()),
+                Some("alias-pass".to_string()),
+            ))
+        );
+
+        assert_eq!(
+            find_input_account_by_signature("http://cdn.example/live/other/other/1.ts", &input),
+            None
+        );
+        assert_eq!(find_input_account_by_signature("http://cdn.example/open/playlist.m3u8", &input), None);
+    }
+
+    #[test]
+    fn get_stream_alternative_url_rewrites_external_cdn_url_with_valid_account_signature_for_alias_account() {
+        let input = ConfigInput {
+            name: "source".intern(),
+            url: "http://provider.example/playlist.m3u8?username=source-user&password=source-pass".to_string(),
+            username: Some("source-user".to_string()),
+            password: Some("source-pass".to_string()),
+            input_type: InputType::M3u,
+            ..ConfigInput::default()
+        };
+        let alias = test_runtime_provider_with_type("http://alias.example", "alias-user", "alias-pass", InputType::M3u);
+        let stream_url = "http://cdn.example/live/source-user/source-pass/123.ts";
+
+        let rewritten = get_stream_alternative_url(stream_url, &input, &alias);
+        assert_eq!(
+            rewritten,
+            Some("http://cdn.example/live/alias-user/alias-pass/123.ts".to_string())
+        );
+    }
+
+    #[test]
+    fn get_stream_alternative_url_keeps_open_external_playlist_url_for_m3u() {
+        let input = ConfigInput {
+            name: "source".intern(),
+            url: "http://provider.example/playlist.m3u8?username=source-user&password=source-pass".to_string(),
+            username: Some("source-user".to_string()),
+            password: Some("source-pass".to_string()),
+            input_type: InputType::M3u,
+            ..ConfigInput::default()
+        };
+        let alias = test_runtime_provider_with_type("http://alias.example", "alias-user", "alias-pass", InputType::M3u);
+        let stream_url = "https://cnbc-live.akamaized.net/cnbc/master.m3u8";
+
+        assert_eq!(get_stream_alternative_url(stream_url, &input, &alias), Some(stream_url.to_string()));
+    }
+
+    #[test]
+    fn get_stream_alternative_url_does_not_passthrough_arbitrary_open_external_url_for_xtream() {
+        let input = ConfigInput {
+            name: "source".intern(),
+            url: "http://provider.example".to_string(),
+            username: Some("source-user".to_string()),
+            password: Some("source-pass".to_string()),
+            input_type: InputType::Xtream,
+            ..ConfigInput::default()
+        };
+        let alias = test_runtime_provider("http://alias.example", "alias-user", "alias-pass");
+        let stream_url = "http://cdn.example/open/playlist.m3u8";
+
+        assert_eq!(get_stream_alternative_url(stream_url, &input, &alias), None);
     }
 
     #[test]

--- a/backend/src/api/api_utils.rs
+++ b/backend/src/api/api_utils.rs
@@ -1370,6 +1370,9 @@ fn get_stream_alternative_url_m3u(
 
         return Some(url.to_string());
     }
+    if stream_url_has_account_signature(stream_url) {
+        return None;
+    }
     Some(stream_url.to_string())
 }
 
@@ -1508,10 +1511,16 @@ fn stream_url_matches_provider(stream_url: &str, provider_cfg: &ProviderConfig) 
         // Same-host fast path: both base URL and account identity must match.
         return stream_url_account_matches(stream_url, &user_info);
     }
+    if !provider_cfg.input_type.is_m3u() {
+        return false;
+    }
     // For M3U inputs, the stored playlist entry itself is the trust anchor.
-    // External hosts are therefore allowed here even when they do not carry
-    // explicit account markers in the stream URL.
-    provider_cfg.input_type.is_m3u()
+    // Open external URLs are therefore allowed, but external URLs that carry
+    // explicit account markers must still match the selected provider account.
+    if stream_url_has_account_signature(stream_url) {
+        return stream_url_account_matches(stream_url, &user_info);
+    }
+    true
 }
 
 fn stream_url_base_matches(stream_url: &str, base_url: &str) -> bool {
@@ -1552,6 +1561,31 @@ fn stream_url_account_matches(stream_url: &str, user_info: &crate::model::InputU
     };
 
     username == Some(user_info.username.as_str()) && password == Some(user_info.password.as_str())
+}
+
+fn stream_url_has_account_signature(stream_url: &str) -> bool {
+    let Ok(url) = Url::parse(stream_url) else {
+        return false;
+    };
+
+    let (url_username, url_password) = get_credentials_from_url(&url);
+    if url_username.is_some() && url_password.is_some() {
+        return true;
+    }
+
+    let mut has_query_username = false;
+    let mut has_query_password = false;
+    for (key, _) in url.query_pairs() {
+        if key.eq_ignore_ascii_case("username") {
+            has_query_username = true;
+        } else if key.eq_ignore_ascii_case("password") {
+            has_query_password = true;
+        }
+    }
+    if has_query_username || has_query_password {
+        return has_query_username && has_query_password;
+    }
+    false
 }
 
 fn select_provider_stream_url(
@@ -4092,6 +4126,21 @@ mod tests {
     }
 
     #[test]
+    fn stream_url_matches_provider_rejects_external_cdn_url_with_wrong_account_signature_for_m3u() {
+        let provider = test_runtime_provider_with_type(
+            "http://provider.example",
+            "selected-user",
+            "selected-pass",
+            InputType::M3u,
+        );
+
+        assert!(!stream_url_matches_provider(
+            "http://cdn.example/segment.ts?username=other-user&password=other-pass",
+            &provider
+        ));
+    }
+
+    #[test]
     fn stream_url_matches_provider_rejects_open_external_cdn_url_without_account_signature_for_xtream() {
         let provider = test_runtime_provider("http://provider.example", "selected-user", "selected-pass");
 
@@ -4202,6 +4251,44 @@ mod tests {
         let stream_url = "https://cnbc-live.akamaized.net/cnbc/master.m3u8";
 
         assert_eq!(get_stream_alternative_url(stream_url, &input, &alias), Some(stream_url.to_string()));
+    }
+
+    #[test]
+    fn get_stream_alternative_url_keeps_open_external_multisegment_playlist_url_for_m3u() {
+        let input = ConfigInput {
+            name: "source".intern(),
+            url: "http://provider.example/playlist.m3u8?username=source-user&password=source-pass".to_string(),
+            username: Some("source-user".to_string()),
+            password: Some("source-pass".to_string()),
+            input_type: InputType::M3u,
+            ..ConfigInput::default()
+        };
+        let alias = test_runtime_provider_with_type("http://alias.example", "alias-user", "alias-pass", InputType::M3u);
+        let stream_url = "https://hnpsechtsc.turknet.ercdn.net/xpnvudnlsv/cnbc-e/cnbc-e.m3u8";
+
+        assert_eq!(get_stream_alternative_url(stream_url, &input, &alias), Some(stream_url.to_string()));
+    }
+
+    #[test]
+    fn get_stream_alternative_url_rejects_external_m3u_url_with_unmatched_account_signature() {
+        let input = ConfigInput {
+            name: "source".intern(),
+            url: "http://provider.example/playlist.m3u8?username=source-user&password=source-pass".to_string(),
+            username: Some("source-user".to_string()),
+            password: Some("source-pass".to_string()),
+            input_type: InputType::M3u,
+            ..ConfigInput::default()
+        };
+        let alias = test_runtime_provider_with_type("http://alias.example", "alias-user", "alias-pass", InputType::M3u);
+
+        assert_eq!(
+            get_stream_alternative_url(
+                "http://cdn.example/segment.ts?username=other-user&password=other-pass",
+                &input,
+                &alias,
+            ),
+            None
+        );
     }
 
     #[test]

--- a/backend/src/api/endpoints/custom_video_stream_api.rs
+++ b/backend/src/api/endpoints/custom_video_stream_api.rs
@@ -184,7 +184,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cvs_api_accepts_internal_api_proxy_user_for_channel_unavailable() {
+    async fn cvs_api_internal_api_proxy_user_returns_bad_request_for_channel_unavailable() {
         let app_state = create_test_app_state();
         let router = cvs_api_register().with_state(app_state);
         let token = crate::auth::create_access_token(&[0; 32], 30);

--- a/backend/src/api/endpoints/custom_video_stream_api.rs
+++ b/backend/src/api/endpoints/custom_video_stream_api.rs
@@ -1,14 +1,16 @@
 use crate::{
-    api::model::{create_custom_video_stream_response, AppState, CustomVideoStreamType},
-    auth::Fingerprint,
+    api::{api_utils::create_api_proxy_user, model::{create_custom_video_stream_response, AppState, CustomVideoStreamType}},
+    auth::{verify_access_token, Fingerprint},
 };
 use axum::response::IntoResponse;
 use std::{str::FromStr, sync::Arc};
 use crate::auth::resolve_api_user_context;
+use url::form_urlencoded;
 
 async fn cvs_api(
     fingerprint: Fingerprint,
     axum::extract::Path((username, password, stream_type)): axum::extract::Path<(String, String, String)>,
+    axum::extract::RawQuery(raw_query): axum::extract::RawQuery,
     axum::extract::State(app_state): axum::extract::State<Arc<AppState>>,
 ) -> impl IntoResponse + Send {
     let cvs_type = stream_type.strip_suffix(".ts").unwrap_or(&stream_type);
@@ -16,6 +18,21 @@ async fn cvs_api(
     let Ok(custom_video_type) = CustomVideoStreamType::from_str(cvs_type) else {
         return axum::http::StatusCode::NOT_FOUND.into_response();
     };
+
+    let api_proxy_user = create_api_proxy_user(&app_state);
+    if username == api_proxy_user.username && password == api_proxy_user.password {
+        let token = raw_query.as_deref().and_then(|query| {
+            form_urlencoded::parse(query.as_bytes())
+                .find_map(|(key, value)| (key == "token").then(|| value.into_owned()))
+        });
+        let Some(token) = token.as_deref() else {
+            return app_state.app_config.get_auth_error_status().into_response();
+        };
+        if !verify_access_token(token, &app_state.app_config.access_token_secret) {
+            return app_state.app_config.get_auth_error_status().into_response();
+        }
+        return create_custom_video_stream_response(&app_state, &fingerprint.addr, custom_video_type).into_response();
+    }
 
     let Some((user, target)) = app_state.app_config.get_target_for_user(&username, &password) else {
         return app_state.app_config.get_auth_error_status().into_response();
@@ -30,4 +47,170 @@ async fn cvs_api(
 
 pub fn cvs_api_register() -> axum::Router<Arc<AppState>> {
     axum::Router::new().route("/cvs/{username}/{password}/{stream_type}", axum::routing::get(cvs_api))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::cvs_api_register;
+    use crate::{
+        api::model::{
+            ActiveProviderManager, ActiveUserManager, AppState, CancelTokens, ConnectionManager, DownloadQueue,
+            EventManager, MetadataUpdateManager, PlaylistStorageState, SharedStreamManager, TransportStreamBuffer,
+            UpdateGuard,
+        },
+        model::{
+            AppConfig, Config, ConfigInput, CustomStreamResponse, MediaToolCapabilities, SourcesConfig,
+        },
+    };
+    use arc_swap::{ArcSwap, ArcSwapOption};
+    use axum::{body::Body, http::{Request, StatusCode}, Router};
+    use crate::utils::{FileLockManager, GeoIp};
+    use std::{collections::HashMap, sync::Arc};
+    use tower::ServiceExt;
+    use tokio::sync::mpsc;
+    use tokio_util::sync::CancellationToken;
+    use shared::model::{ConfigPaths, InputFetchMethod, InputType};
+
+    fn create_test_app_config_with_channel_unavailable() -> AppConfig {
+        let input = Arc::new(ConfigInput {
+            id: 1,
+            name: "provider_1".into(),
+            input_type: InputType::Xtream,
+            headers: HashMap::default(),
+            url: "http://provider-1.example".to_string(),
+            username: Some("user1".to_string()),
+            password: Some("pass1".to_string()),
+            enabled: true,
+            priority: 0,
+            max_connections: 1,
+            method: InputFetchMethod::default(),
+            aliases: None,
+            ..ConfigInput::default()
+        });
+        let sources = SourcesConfig { inputs: vec![input], ..SourcesConfig::default() };
+
+        let app_cfg = AppConfig {
+            config: Arc::new(ArcSwap::from_pointee(Config::default())),
+            sources: Arc::new(ArcSwap::from_pointee(sources)),
+            hdhomerun: Arc::new(ArcSwapOption::default()),
+            api_proxy: Arc::new(ArcSwapOption::default()),
+            file_locks: Arc::new(FileLockManager::default()),
+            paths: Arc::new(ArcSwap::from_pointee(ConfigPaths {
+                home_path: String::new(),
+                config_path: String::new(),
+                storage_path: String::new(),
+                config_file_path: String::new(),
+                sources_file_path: String::new(),
+                mapping_file_path: None,
+                mapping_files_used: None,
+                template_file_path: None,
+                template_files_used: None,
+                api_proxy_file_path: String::new(),
+                custom_stream_response_path: None,
+            })),
+            custom_stream_response: Arc::new(ArcSwapOption::default()),
+            access_token_secret: [0; 32],
+            encrypt_secret: [0; 16],
+            media_tools: Arc::new(MediaToolCapabilities::new()),
+        };
+
+        let mut ts_packet = vec![0_u8; 188];
+        ts_packet[0] = 0x47;
+        app_cfg.custom_stream_response.store(Some(Arc::new(CustomStreamResponse {
+            channel_unavailable: Some(TransportStreamBuffer::new(ts_packet)),
+            user_connections_exhausted: None,
+            provider_connections_exhausted: None,
+            low_priority_preempted: None,
+            user_account_expired: None,
+            panel_api_provisioning: None,
+        })));
+        app_cfg
+    }
+
+    fn create_test_app_state() -> Arc<AppState> {
+        let app_cfg = Arc::new(create_test_app_config_with_channel_unavailable());
+        let event_manager = Arc::new(EventManager::new());
+        let active_provider = Arc::new(ActiveProviderManager::new(&app_cfg, &event_manager));
+        let shared_stream_manager = Arc::new(SharedStreamManager::new(Arc::clone(&active_provider)));
+        active_provider.set_shared_stream_manager(Arc::clone(&shared_stream_manager));
+
+        let geoip = Arc::new(ArcSwapOption::<GeoIp>::default());
+        let config = app_cfg.config.load();
+        let active_users = Arc::new(ActiveUserManager::new(&config, &geoip, &event_manager));
+        let connection_manager = Arc::new(ConnectionManager::new(
+            &active_users,
+            &active_provider,
+            &shared_stream_manager,
+            &event_manager,
+            None,
+        ));
+
+        let tokens = CancelTokens {
+            scheduler: CancellationToken::new(),
+            hdhomerun: CancellationToken::new(),
+            file_watch: CancellationToken::new(),
+            provider_dns: CancellationToken::new(),
+            metadata: CancellationToken::new(),
+            qos_aggregation: CancellationToken::new(),
+            downloads: CancellationToken::new(),
+        };
+        let metadata_manager = Arc::new(MetadataUpdateManager::new(tokens.metadata.clone()));
+        let (manual_update_sender, _) = mpsc::channel::<Arc<crate::model::ProcessTargets>>(1);
+
+        Arc::new(AppState {
+            forced_targets: Arc::new(ArcSwap::from_pointee(crate::model::ProcessTargets {
+                enabled: false,
+                inputs: Vec::new(),
+                targets: Vec::new(),
+                target_names: Vec::new(),
+            })),
+            app_config: app_cfg,
+            http_client: Arc::new(ArcSwap::from_pointee(reqwest::Client::new())),
+            http_client_no_redirect: Arc::new(ArcSwap::from_pointee(reqwest::Client::new())),
+            downloads: Arc::new(DownloadQueue::new()),
+            cache: Arc::new(ArcSwapOption::default()),
+            shared_stream_manager,
+            active_users,
+            active_provider,
+            connection_manager,
+            event_manager,
+            cancel_tokens: Arc::new(ArcSwap::from_pointee(tokens)),
+            playlists: Arc::new(PlaylistStorageState::new()),
+            geoip,
+            update_guard: UpdateGuard::new(),
+            metadata_manager,
+            manual_update_sender,
+        })
+    }
+
+    #[tokio::test]
+    async fn cvs_api_accepts_internal_api_proxy_user_for_channel_unavailable() {
+        let app_state = create_test_app_state();
+        let router = cvs_api_register().with_state(app_state);
+        let token = crate::auth::create_access_token(&[0; 32], 30);
+        let request = Request::builder()
+            .method("GET")
+            .uri(format!("/cvs/api_user/api_user/channel_unavailable.ts?token={token}"))
+            .body(Body::empty())
+            .expect("request");
+
+        let response = Router::into_service(router).oneshot(request).await.expect("response");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn cvs_api_rejects_internal_api_proxy_user_without_token() {
+        let app_state = create_test_app_state();
+        let router = cvs_api_register().with_state(app_state);
+        let request = Request::builder()
+            .method("GET")
+            .uri("/cvs/api_user/api_user/channel_unavailable.ts")
+            .body(Body::empty())
+            .expect("request");
+
+        let response = Router::into_service(router).oneshot(request).await.expect("response");
+
+        assert!(response.status().is_client_error());
+    }
 }

--- a/backend/src/api/endpoints/hls_api.rs
+++ b/backend/src/api/endpoints/hls_api.rs
@@ -2,7 +2,7 @@ use crate::{
     api::{
         api_utils::{
             admission_failure_response, connection_priority_for_kind,
-            create_playback_session_fingerprint, create_session_fingerprint, force_provider_stream_response, get_headers_from_request,
+            create_api_proxy_user, create_playback_session_fingerprint, create_session_fingerprint, force_provider_stream_response, get_headers_from_request,
             get_hls_session_ttl_secs, get_stream_alternative_url, is_seek_request, local_stream_response,
             try_option_bad_request, try_unwrap_body,
             HeaderFilter,
@@ -11,7 +11,7 @@ use crate::{
             AppState, CustomVideoStreamType, ProviderAllocation, UserSession,
         },
     },
-    auth::Fingerprint,
+    auth::{create_access_token, Fingerprint},
     model::{ConfigInput, ConfigInputFlags, ConfigTarget, InputSource, ProxyUserCredentials},
     processing::parser::hls::{get_hls_session_token_and_url_from_token, rewrite_hls, RewriteHlsProps},
     repository::{m3u_get_item_for_stream_id, xtream_get_item_for_stream_id},
@@ -87,6 +87,7 @@ pub(in crate::api) fn m3u_archive_epg_reference_ts(stream_url: &str) -> Option<i
 struct HlsApiPathParams {
     username: String,
     password: String,
+    target_id: u16,
     input_id: u16,
     stream_id: u32,
     token: String,
@@ -158,6 +159,7 @@ pub(in crate::api) async fn handle_hls_stream_request(
     fingerprint: &Fingerprint,
     app_state: &Arc<AppState>,
     user: &ProxyUserCredentials,
+    target_id: u16,
     user_session: Option<&UserSession>,
     hls_url: &str,
     archive_reference: Option<i64>,
@@ -349,6 +351,7 @@ pub(in crate::api) async fn handle_hls_stream_request(
                 base_url: &base_url,
                 content: &content,
                 hls_url: response_url,
+                target_id,
                 virtual_id,
                 input_id: input.id,
                 user_token: session_token.as_deref(),
@@ -367,8 +370,9 @@ pub(in crate::api) async fn handle_hls_stream_request(
 
             let custom_stream_response = app_state.app_config.custom_stream_response.load();
             if custom_stream_response.as_ref().and_then(|c| c.channel_unavailable.as_ref()).is_some() {
+                let custom_stream_token = create_access_token(&app_state.app_config.access_token_secret, 30);
                 let url = format!(
-                    "{}/{CUSTOM_VIDEO_PREFIX}/{}/{}/{}.ts",
+                    "{}/{CUSTOM_VIDEO_PREFIX}/{}/{}/{}.ts?token={custom_stream_token}",
                     server_info.get_base_url(),
                     user.username,
                     user.password,
@@ -449,19 +453,55 @@ async fn hls_api_stream(
     axum::extract::Path(params): axum::extract::Path<HlsApiPathParams>,
     axum::extract::State(app_state): axum::extract::State<Arc<AppState>>,
 ) -> impl IntoResponse + Send {
-    let Some((user, target)) = app_state.app_config.get_target_for_user(&params.username, &params.password) else {
-        return axum::http::StatusCode::BAD_REQUEST.into_response();
+    let api_proxy_user = create_api_proxy_user(&app_state);
+    let (user, target) = if params.username == api_proxy_user.username && params.password == api_proxy_user.password {
+        let Some(target) = app_state.app_config.get_target_by_id(params.target_id) else {
+            return axum::http::StatusCode::BAD_REQUEST.into_response();
+        };
+        (Arc::new(api_proxy_user), target)
+    } else {
+        let Some((user, target)) = app_state.app_config.get_target_for_user(&params.username, &params.password) else {
+            return axum::http::StatusCode::BAD_REQUEST.into_response();
+        };
+        if target.id != params.target_id {
+            return axum::http::StatusCode::BAD_REQUEST.into_response();
+        }
+        (user, target)
     };
+    hls_api_stream_resolved(
+        fingerprint,
+        req_headers,
+        app_state,
+        user,
+        target,
+        params.input_id,
+        params.stream_id,
+        params.token,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+async fn hls_api_stream_resolved(
+    fingerprint: Fingerprint,
+    req_headers: HeaderMap,
+    app_state: Arc<AppState>,
+    user: Arc<ProxyUserCredentials>,
+    target: Arc<ConfigTarget>,
+    input_id: u16,
+    stream_id: u32,
+    token: String,
+) -> axum::response::Response {
     // Network access check only - permission check is done later with full stream info
     if let Err(e) = check_network_access_only(&user, &fingerprint, &app_state) {
         return e.into_player_response(app_state.app_config.get_auth_error_status());
     }
     let target_name = &target.name;
-    let virtual_id = params.stream_id;
+    let virtual_id = stream_id;
     let input = try_option_bad_request!(
-        app_state.app_config.get_input_by_id(params.input_id),
+        app_state.app_config.get_input_by_id(input_id),
         true,
-        format!("Can't find input {} for target {target_name}, stream_id {virtual_id}, hls", params.input_id)
+        format!("Can't find input {} for target {target_name}, stream_id {virtual_id}, hls", input_id)
     );
 
     if user.permission_denied(&app_state) {
@@ -477,9 +517,9 @@ async fn hls_api_stream(
         );
     }
 
-    debug_if_enabled!("ID chain for hls endpoint: request_stream_id={} -> virtual_id={virtual_id}", params.stream_id);
+    debug_if_enabled!("ID chain for hls endpoint: request_stream_id={stream_id} -> virtual_id={virtual_id}");
     let encrypt_secret = app_state.get_encrypt_secret();
-    let Some(decoded_hls_token) = get_hls_session_token_and_url_from_token(&encrypt_secret, &params.token) else {
+    let Some(decoded_hls_token) = get_hls_session_token_and_url_from_token(&encrypt_secret, &token) else {
         return axum::http::StatusCode::BAD_REQUEST.into_response();
     };
     let lookup_session_token = decoded_hls_token
@@ -610,6 +650,7 @@ async fn hls_api_stream(
                 &fingerprint,
                 &app_state,
                 &user,
+                target.id,
                 Some(session),
                 &session.stream_url,
                 archive_reference,
@@ -666,7 +707,7 @@ async fn hls_api_stream(
 
 pub fn hls_api_register() -> axum::Router<Arc<AppState>> {
     axum::Router::new()
-        .route("/hls/{username}/{password}/{input_id}/{stream_id}/{token}", axum::routing::get(hls_api_stream))
+        .route("/hls/{username}/{password}/{target_id}/{input_id}/{stream_id}/{token}", axum::routing::get(hls_api_stream))
     //cfg.service(web::resource("/hls/{token}/{stream}").route(web::get().to(xtream_player_api_hls_stream)));
     //cfg.service(web::resource("/play/{token}/{type}").route(web::get().to(xtream_player_api_play_stream)));
 }

--- a/backend/src/api/endpoints/m3u_api.rs
+++ b/backend/src/api/endpoints/m3u_api.rs
@@ -329,9 +329,15 @@ async fn m3u_api_stream_loaded(
     }
 
     let is_session_request = is_session_based_playback(pli.item_type, Some(extension));
+    // The archive/catchup EPG reference timestamp is parsed from the request
+    // URL once and shared between the HLS and the non-HLS branch. The HLS
+    // handler threads it into its own manifest construction; the non-HLS
+    // branch attaches it to the StreamChannel so the frontend's stream_epg
+    // request can centre its EPG window on the archive timestamp instead of
+    // falling back to `now`.
+    let archive_reference = m3u_archive_epg_reference_ts(&pli.url);
     // Reverse proxy mode — only route genuine HLS into the HLS handler, not DASH
     if is_session_request && extension == shared::utils::HLS_EXT {
-        let archive_reference = m3u_archive_epg_reference_ts(&pli.url);
         return handle_hls_stream_request(
             fingerprint,
             app_state,
@@ -359,7 +365,7 @@ async fn m3u_api_stream_loaded(
         app_state,
         &session_key,
         Some(request_class),
-        pli.to_stream_channel(target.id),
+        pli.to_stream_channel(target.id).with_epg_reference_ts(archive_reference),
         &session_url,
         pinned_provider,
         req_headers,

--- a/backend/src/api/endpoints/m3u_api.rs
+++ b/backend/src/api/endpoints/m3u_api.rs
@@ -117,7 +117,7 @@ async fn m3u_api_post(
 }
 
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
-async fn m3u_api_stream_loaded(
+pub(in crate::api) async fn m3u_api_stream_loaded(
     user: Arc<ProxyUserCredentials>,
     target: Arc<ConfigTarget>,
     fingerprint: &Fingerprint,
@@ -342,6 +342,7 @@ async fn m3u_api_stream_loaded(
             fingerprint,
             app_state,
             &user,
+            target.id,
             user_session.as_ref(),
             &pli.url,
             archive_reference,

--- a/backend/src/api/endpoints/v1_api_playlist.rs
+++ b/backend/src/api/endpoints/v1_api_playlist.rs
@@ -1,14 +1,15 @@
 use crate::api::api_utils::resource_response;
 use crate::{api::{
-    api_utils::{create_api_proxy_user, json_or_bin_response},
+    api_utils::{create_api_proxy_user, json_or_bin_response, try_option_bad_request, try_result_bad_request},
     endpoints::{
         api_playlist_utils::{get_playlist_for_custom_provider, get_playlist_for_input, get_playlist_for_target},
         extract_accept_header::ExtractAcceptHeader,
+        m3u_api::m3u_api_stream_loaded,
         xmltv_api::{rewrite_epg_channel_resource_url, serve_epg_web_ui, stream_epg_api},
-        xtream_api::xtream_get_stream_info_response,
+        xtream_api::{xtream_get_stream_info_response, xtream_player_api_stream_with_token, ApiStreamContext, ApiStreamRequest},
     },
     model::AppState,
-}, auth::{create_access_token, permission_layer}, model::{parse_xmltv_for_web_ui_from_file, parse_xmltv_for_web_ui_from_url, AppConfig, ConfigInput, ConfigInputFlags, ConfigInputOptions}, processing::parser::xmltv::merge_epg_channels_by_priority, repository::xtream_get_item_for_stream_id, utils::{epg::get_input_raw_epg_file_path, file_exists_async}};
+}, auth::{create_access_token, permission_layer, verify_access_token}, model::{parse_xmltv_for_web_ui_from_file, parse_xmltv_for_web_ui_from_url, AppConfig, ConfigInput, ConfigInputFlags, ConfigInputOptions}, processing::parser::xmltv::merge_epg_channels_by_priority, repository::{m3u_get_item_for_stream_id, xtream_get_item_for_stream_id}, utils::{epg::get_input_raw_epg_file_path, file_exists_async}};
 use axum::{response::IntoResponse, Router};
 use log::{debug, error};
 use serde_json::json;
@@ -21,7 +22,7 @@ use shared::{
     },
     utils::{concat_path_leading_slash, sanitize_sensitive_info, Internable},
 };
-use std::sync::Arc;
+use std::{str::FromStr, sync::Arc};
 use url::Url;
 
 fn create_config_input_for_m3u(url: &str) -> ConfigInput {
@@ -112,7 +113,7 @@ fn build_playlist_webplayer_url(
     cluster: XtreamCluster,
 ) -> String {
     format!(
-        "{base_url}/token/{access_token}/{}/{}/{}",
+        "{base_url}/api/v1/playlist/webplayer/{access_token}/{}/{}/{}",
         target_id,
         cluster.as_stream_type(),
         virtual_id
@@ -374,6 +375,55 @@ fn playlist_webplayer(
     build_playlist_webplayer_url(&base_url, &access_token, target_id, virtual_id, cluster).into_response()
 }
 
+async fn playlist_webplayer_stream(
+    fingerprint: crate::auth::Fingerprint,
+    axum::extract::Path((token, target_id, cluster, stream_id)): axum::extract::Path<(String, u16, String, String)>,
+    axum::extract::State(app_state): axum::extract::State<Arc<AppState>>,
+    req_headers: axum::http::HeaderMap,
+) -> impl IntoResponse + Send {
+    if !verify_access_token(&token, &app_state.app_config.access_token_secret) {
+        return axum::http::StatusCode::FORBIDDEN.into_response();
+    }
+
+    let ctxt = try_result_bad_request!(ApiStreamContext::from_str(cluster.as_str()));
+    let Some(target) = app_state.app_config.get_target_by_id(target_id) else {
+        return axum::http::StatusCode::BAD_REQUEST.into_response();
+    };
+
+    if target.has_output(TargetType::Xtream) {
+        return xtream_player_api_stream_with_token(
+            &fingerprint,
+            &req_headers,
+            &app_state,
+            target_id,
+            ApiStreamRequest::from_access_token(ctxt, &token, &stream_id, ""),
+        )
+        .await
+        .into_response();
+    }
+
+    if !target.has_output(TargetType::M3u) {
+        return axum::http::StatusCode::BAD_REQUEST.into_response();
+    }
+
+    let req_virtual_id: u32 = try_result_bad_request!(stream_id.trim().parse());
+    let pli = try_result_bad_request!(
+        m3u_get_item_for_stream_id(req_virtual_id, &app_state, &target).await,
+        true,
+        format!("Failed to read m3u item for stream id {req_virtual_id}")
+    );
+    let input = try_option_bad_request!(
+        app_state.app_config.get_input_by_name(&pli.input_name),
+        true,
+        format!("Can't find input {} for target {}", pli.input_name, target.name)
+    );
+    let user = Arc::new(create_api_proxy_user(&app_state));
+
+    m3u_api_stream_loaded(user, target, &fingerprint, &req_headers, &app_state, pli, input, None, None)
+        .await
+        .into_response()
+}
+
 async fn playlist_epg(
     ExtractAcceptHeader(accept): ExtractAcceptHeader,
     axum::extract::State(app_state): axum::extract::State<Arc<AppState>>,
@@ -498,7 +548,12 @@ pub fn v1_api_playlist_register_protected(router: Router<Arc<AppState>>) -> axum
 pub fn v1_api_playlist_register_public(
     router: Router<Arc<AppState>>,
 ) -> axum::Router<Arc<AppState>> {
-    router.route("/playlist/resource/{resource}", axum::routing::get(playlist_resource))
+    router
+        .route("/playlist/resource/{resource}", axum::routing::get(playlist_resource))
+        .route(
+            "/playlist/webplayer/{token}/{target_id}/{cluster}/{stream_id}",
+            axum::routing::get(playlist_webplayer_stream),
+        )
 }
 
 pub fn v1_api_playlist_register_with_permissions(
@@ -898,9 +953,9 @@ mod tests {
         let series =
             super::build_playlist_webplayer_url("http://player.example", "token123", 1, 42, XtreamCluster::Series);
 
-        assert_eq!(live, "http://player.example/token/token123/1/live/42");
-        assert_eq!(movie, "http://player.example/token/token123/1/movie/42");
-        assert_eq!(series, "http://player.example/token/token123/1/series/42");
+        assert_eq!(live, "http://player.example/api/v1/playlist/webplayer/token123/1/live/42");
+        assert_eq!(movie, "http://player.example/api/v1/playlist/webplayer/token123/1/movie/42");
+        assert_eq!(series, "http://player.example/api/v1/playlist/webplayer/token123/1/series/42");
     }
 
     #[test]

--- a/backend/src/api/endpoints/xtream_api.rs
+++ b/backend/src/api/endpoints/xtream_api.rs
@@ -510,6 +510,7 @@ async fn xtream_player_api_stream(
             fingerprint,
             app_state,
             &user,
+            target.id,
             user_session.as_ref(),
             &stream_url,
             None,
@@ -605,7 +606,7 @@ fn resolve_xtream_playback_extension(stream_ext: Option<&str>, pli: &XtreamPlayl
 
 #[allow(clippy::too_many_lines)]
 // Used by webui
-async fn xtream_player_api_stream_with_token(
+pub(in crate::api) async fn xtream_player_api_stream_with_token(
     fingerprint: &Fingerprint,
     req_headers: &HeaderMap,
     app_state: &Arc<AppState>,
@@ -687,6 +688,7 @@ async fn xtream_player_api_stream_with_token(
                 fingerprint,
                 app_state,
                 &user,
+                target.id,
                 None,
                 &pli.url,
                 None,

--- a/backend/src/api/model/active_provider_manager.rs
+++ b/backend/src/api/model/active_provider_manager.rs
@@ -573,6 +573,7 @@ impl ActiveProviderManager {
         let allocation_id = self.next_allocation_id.fetch_add(1, Ordering::Relaxed);
         let cancel_token = CancellationToken::new();
         let now = Instant::now();
+        let is_unlimited = allocation.is_unlimited_provider();
 
         let mut connections = self.connections.write().await;
         let per_addr = connections.single.entry(*addr).or_default();
@@ -588,17 +589,26 @@ impl ActiveProviderManager {
             },
         );
 
-        connections.by_provider.entry(provider_name.clone()).or_default().insert((*addr, allocation_id));
-        Self::upsert_priority_entry(
-            &mut connections,
-            &provider_name,
-            (priority, Reverse(now), allocation_id),
-            PriorityOwner::Single(*addr),
-            kind,
-        );
+        // Unlimited providers are not subject to preemption, so we deliberately
+        // skip populating the by_provider / priority_index / soft_priority_index
+        // indices. The connection itself is still tracked via `single`, so all
+        // capacity and lifecycle invariants hold. Without this skip, an
+        // unlimited provider's connection can be selected as a preemption victim
+        // even though it cannot be exhausted, contradicting the configured
+        // `max_connections: 0` semantics.
+        if !is_unlimited {
+            connections.by_provider.entry(provider_name.clone()).or_default().insert((*addr, allocation_id));
+            Self::upsert_priority_entry(
+                &mut connections,
+                &provider_name,
+                (priority, Reverse(now), allocation_id),
+                PriorityOwner::Single(*addr),
+                kind,
+            );
+        }
 
         debug_if_enabled!(
-            "Added provider connection {provider_name:?} for {} (prio={}, kind={kind:?})",
+            "Added provider connection {provider_name:?} for {} (prio={}, kind={kind:?}, unlimited={is_unlimited})",
             sanitize_sensitive_info(&addr.to_string()),
             priority
         );
@@ -993,23 +1003,29 @@ impl ActiveProviderManager {
         self.providers.is_exhausted(provider_name).await
     }
 
+    #[allow(clippy::too_many_lines)]
     pub async fn release_connection(&self, addr: &SocketAddr) {
         // Single connection - all index updates in one lock scope
         let single_allocations = {
             let mut connections = self.connections.write().await;
             if let Some(allocations) = connections.single.remove(addr) {
-                // Remove from by_provider and priority_index while still holding the lock
+                // Remove from by_provider and priority_index while still holding the lock.
+                // Skip these index updates for unlimited providers: they were never
+                // added to the preemption indices by `register_allocation`, so there
+                // is nothing to remove and the keys/values won't be present.
                 for (id, info) in &allocations {
-                    if let Some(name) = info.allocation.get_provider_name() {
-                        if let Some(list) = connections.by_provider.get_mut(&name) {
-                            list.remove(&(*addr, *id));
+                    if !info.allocation.is_unlimited_provider() {
+                        if let Some(name) = info.allocation.get_provider_name() {
+                            if let Some(list) = connections.by_provider.get_mut(&name) {
+                                list.remove(&(*addr, *id));
+                            }
+                            Self::remove_priority_entry(
+                                &mut connections,
+                                &name,
+                                &(info.priority, Reverse(info.created_at), *id),
+                                info.kind,
+                            );
                         }
-                        Self::remove_priority_entry(
-                            &mut connections,
-                            &name,
-                            &(info.priority, Reverse(info.created_at), *id),
-                            info.kind,
-                        );
                     }
                 }
                 Some(allocations)
@@ -1050,45 +1066,53 @@ impl ActiveProviderManager {
             // Always remove stale key-by-addr entry
             connections.shared.key_by_addr.remove(addr);
 
+            let shared_is_unlimited = shared.allocation.is_unlimited_provider();
+
             if shared.connections.is_empty() {
                 // If this was the last user of the shared allocation:
                 connections.shared.by_key.remove(&key);
                 connections.shared.shared_by_allocation_id.remove(&shared.allocation_id);
-                if let Some(name) = shared.allocation.get_provider_name() {
-                    if let Some(list) = connections.by_provider.get_mut(&name) {
-                        list.retain(|(_, i)| *i != shared.allocation_id);
+                if !shared_is_unlimited {
+                    if let Some(name) = shared.allocation.get_provider_name() {
+                        if let Some(list) = connections.by_provider.get_mut(&name) {
+                            list.retain(|(_, i)| *i != shared.allocation_id);
+                        }
+                        Self::remove_priority_entry(
+                            &mut connections,
+                            &name,
+                            &(shared.priority, Reverse(shared.created_at), shared.allocation_id),
+                            shared.kind,
+                        );
                     }
-                    Self::remove_priority_entry(
-                        &mut connections,
-                        &name,
-                        &(shared.priority, Reverse(shared.created_at), shared.allocation_id),
-                        shared.kind,
-                    );
                 }
                 Some(shared.allocation)
             } else {
                 // Recompute shared priority from remaining subscribers so preemption decisions
-                // reflect who is actually still watching the shared stream.
-                let old_priority = shared.priority;
-                let old_kind = shared.kind;
-                shared.kind = Self::shared_effective_kind(&shared.connections);
-                if let Some(new_priority) = Self::shared_effective_priority(&shared.connections, shared.kind) {
-                    shared.priority = new_priority;
-                    if (new_priority, shared.kind) != (old_priority, old_kind) {
-                        if let Some(name) = shared.allocation.get_provider_name() {
-                            Self::remove_priority_entry(
-                                &mut connections,
-                                &name,
-                                &(old_priority, Reverse(shared.created_at), shared.allocation_id),
-                                old_kind,
-                            );
-                            Self::upsert_priority_entry(
-                                &mut connections,
-                                &name,
-                                (new_priority, Reverse(shared.created_at), shared.allocation_id),
-                                PriorityOwner::Shared(shared.allocation_id),
-                                shared.kind,
-                            );
+                // reflect who is actually still watching the shared stream. Unlimited
+                // shared streams are not in the preemption index, so this rebalance
+                // must be skipped for them.
+                if !shared_is_unlimited {
+                    let old_priority = shared.priority;
+                    let old_kind = shared.kind;
+                    shared.kind = Self::shared_effective_kind(&shared.connections);
+                    if let Some(new_priority) = Self::shared_effective_priority(&shared.connections, shared.kind) {
+                        shared.priority = new_priority;
+                        if (new_priority, shared.kind) != (old_priority, old_kind) {
+                            if let Some(name) = shared.allocation.get_provider_name() {
+                                Self::remove_priority_entry(
+                                    &mut connections,
+                                    &name,
+                                    &(old_priority, Reverse(shared.created_at), shared.allocation_id),
+                                    old_kind,
+                                );
+                                Self::upsert_priority_entry(
+                                    &mut connections,
+                                    &name,
+                                    (new_priority, Reverse(shared.created_at), shared.allocation_id),
+                                    PriorityOwner::Shared(shared.allocation_id),
+                                    shared.kind,
+                                );
+                            }
                         }
                     }
                 }
@@ -1124,12 +1148,18 @@ impl ActiveProviderManager {
                         connections.single.remove(&handle.client_id);
                     }
 
-                    // Remove from by_provider index
-                    if let Some(name) = released.as_ref().and_then(ProviderAllocation::get_provider_name) {
-                        if let Some(list) = connections.by_provider.get_mut(&name) {
-                            list.remove(&(handle.client_id, handle.allocation_id));
+                    // Remove from by_provider index. Skip for unlimited providers:
+                    // they were never inserted by `register_allocation`, so the
+                    // keys/values are not present and a removal would be a no-op
+                    // at best and could race with concurrent unrelated operations
+                    // on the same HashSet entry at worst.
+                    if !released.as_ref().is_some_and(ProviderAllocation::is_unlimited_provider) {
+                        if let Some(name) = released.as_ref().and_then(ProviderAllocation::get_provider_name) {
+                            if let Some(list) = connections.by_provider.get_mut(&name) {
+                                list.remove(&(handle.client_id, handle.allocation_id));
+                            }
+                            released_priority_key = Some((name, pkey, released_kind));
                         }
-                        released_priority_key = Some((name, pkey, released_kind));
                     }
                 }
             }
@@ -1139,15 +1169,18 @@ impl ActiveProviderManager {
                 if let Some(key) = connections.shared.shared_by_allocation_id.remove(&handle.allocation_id) {
                     if let Some(shared) = connections.shared.by_key.remove(&key) {
                         let pkey = (shared.priority, Reverse(shared.created_at), handle.allocation_id);
-                        released = Some(shared.allocation);
+                        released = Some(shared.allocation.clone());
+                        let shared_is_unlimited = shared.allocation.is_unlimited_provider();
                         for addr in shared.connections.keys() {
                             connections.shared.key_by_addr.remove(addr);
                         }
-                        if let Some(name) = released.as_ref().and_then(ProviderAllocation::get_provider_name) {
-                            if let Some(list) = connections.by_provider.get_mut(&name) {
-                                list.retain(|(_, i)| *i != handle.allocation_id);
+                        if !shared_is_unlimited {
+                            if let Some(name) = released.as_ref().and_then(ProviderAllocation::get_provider_name) {
+                                if let Some(list) = connections.by_provider.get_mut(&name) {
+                                    list.retain(|(_, i)| *i != handle.allocation_id);
+                                }
+                                released_priority_key = Some((name, pkey, shared.kind));
                             }
-                            released_priority_key = Some((name, pkey, shared.kind));
                         }
                     }
                 }
@@ -1177,7 +1210,14 @@ impl ActiveProviderManager {
                     info.kind = kind;
                     info.priority = priority;
                     let new_key = (info.priority, Reverse(info.created_at), *allocation_id);
-                    index_updates.push((provider_name, old_key, old_kind, new_key, owner, info.kind));
+                    // Skip preemption-index updates for unlimited providers: they
+                    // are intentionally absent from `by_provider` / `priority_index`
+                    // / `soft_priority_index`, so the old entry was never inserted.
+                    // Performing the upsert here would re-introduce them into the
+                    // preemption index and contradict `max_connections: 0`.
+                    if !info.allocation.is_unlimited_provider() {
+                        index_updates.push((provider_name, old_key, old_kind, new_key, owner, info.kind));
+                    }
                 }
             }
             for (provider_name, old_key, old_kind, new_key, owner, new_kind) in index_updates {
@@ -1196,6 +1236,7 @@ impl ActiveProviderManager {
         let Some(subscriber) = shared_allocation.connections.get_mut(addr) else {
             return false;
         };
+        let shared_is_unlimited = shared_allocation.allocation.is_unlimited_provider();
 
         let old_priority = shared_allocation.priority;
         let old_kind = shared_allocation.kind;
@@ -1212,26 +1253,32 @@ impl ActiveProviderManager {
         let provider_name = shared_allocation.allocation.get_provider_name();
         let _ = shared_allocation;
 
-        if let Some(provider_name) = provider_name {
-            let owner = PriorityOwner::Shared(allocation_id);
-            Self::remove_priority_entry(
-                &mut connections,
-                &provider_name,
-                &(old_priority, Reverse(created_at), allocation_id),
-                old_kind,
-            );
-            Self::upsert_priority_entry(
-                &mut connections,
-                &provider_name,
-                (new_priority, Reverse(created_at), allocation_id),
-                owner,
-                new_kind,
-            );
+        // Mirror the single-connection rule: skip priority-index rebuild for
+        // shared allocations backed by an unlimited provider. The kind/priority
+        // transition on the per-subscriber state is still applied above.
+        if !shared_is_unlimited {
+            if let Some(provider_name) = provider_name {
+                let owner = PriorityOwner::Shared(allocation_id);
+                Self::remove_priority_entry(
+                    &mut connections,
+                    &provider_name,
+                    &(old_priority, Reverse(created_at), allocation_id),
+                    old_kind,
+                );
+                Self::upsert_priority_entry(
+                    &mut connections,
+                    &provider_name,
+                    (new_priority, Reverse(created_at), allocation_id),
+                    owner,
+                    new_kind,
+                );
+            }
         }
 
         true
     }
 
+    #[allow(clippy::too_many_lines)]
     pub async fn make_shared_connection(&self, addr: &SocketAddr, key: &str) {
         let extras = {
             let mut connections = self.connections.write().await;
@@ -1250,30 +1297,37 @@ impl ActiveProviderManager {
                         // Collect others as extras to release
                         let extra_entries: Vec<_> = iter.collect();
 
-                        // Cleanup indices
-                        if let Some(name) = info.allocation.get_provider_name() {
-                            if let Some(list) = connections.by_provider.get_mut(&name) {
-                                list.remove(&(*addr, id));
-                            }
-                            Self::remove_priority_entry(
-                                &mut connections,
-                                &name,
-                                &(info.priority, Reverse(info.created_at), id),
-                                info.kind,
-                            );
-                        }
-                        // Remove extras from provider-specific indexes.
-                        for (extra_id, extra_info) in &extra_entries {
-                            if let Some(extra_provider_name) = extra_info.allocation.get_provider_name() {
-                                if let Some(list) = connections.by_provider.get_mut(&extra_provider_name) {
-                                    list.remove(&(*addr, *extra_id));
+                        // Cleanup indices. Skip for unlimited providers: their
+                        // entries were never inserted into `by_provider` /
+                        // `priority_index` / `soft_priority_index`, so the
+                        // removal would be a no-op.
+                        if !info.allocation.is_unlimited_provider() {
+                            if let Some(name) = info.allocation.get_provider_name() {
+                                if let Some(list) = connections.by_provider.get_mut(&name) {
+                                    list.remove(&(*addr, id));
                                 }
                                 Self::remove_priority_entry(
                                     &mut connections,
-                                    &extra_provider_name,
-                                    &(extra_info.priority, Reverse(extra_info.created_at), *extra_id),
-                                    extra_info.kind,
+                                    &name,
+                                    &(info.priority, Reverse(info.created_at), id),
+                                    info.kind,
                                 );
+                            }
+                        }
+                        // Remove extras from provider-specific indexes.
+                        for (extra_id, extra_info) in &extra_entries {
+                            if !extra_info.allocation.is_unlimited_provider() {
+                                if let Some(extra_provider_name) = extra_info.allocation.get_provider_name() {
+                                    if let Some(list) = connections.by_provider.get_mut(&extra_provider_name) {
+                                        list.remove(&(*addr, *extra_id));
+                                    }
+                                    Self::remove_priority_entry(
+                                        &mut connections,
+                                        &extra_provider_name,
+                                        &(extra_info.priority, Reverse(extra_info.created_at), *extra_id),
+                                        extra_info.kind,
+                                    );
+                                }
                             }
                         }
 
@@ -1330,14 +1384,18 @@ impl ActiveProviderManager {
                     .shared_by_allocation_id
                     .insert(handle.0.allocation_id, shared_key);
 
-                // Insert new shared entry into priority_index
-                Self::upsert_priority_entry(
-                    &mut connections,
-                    &provider_name,
-                    (handle.1, Reverse(handle.3), handle.0.allocation_id),
-                    PriorityOwner::Shared(handle.0.allocation_id),
-                    handle.2,
-                );
+                // Insert new shared entry into priority_index. Skip for
+                // unlimited providers: they are not subject to preemption, so
+                // they must not appear in the priority index.
+                if !handle.0.allocation.is_unlimited_provider() {
+                    Self::upsert_priority_entry(
+                        &mut connections,
+                        &provider_name,
+                        (handle.1, Reverse(handle.3), handle.0.allocation_id),
+                        PriorityOwner::Shared(handle.0.allocation_id),
+                        handle.2,
+                    );
+                }
             }
             extras
         };
@@ -1364,10 +1422,11 @@ impl ActiveProviderManager {
                 s.priority,
                 s.kind,
                 s.created_at,
+                s.allocation.is_unlimited_provider(),
             )
         });
 
-        let Some((alloc_id, provider_name, old_priority, old_kind, created_at)) = metadata else {
+        let Some((alloc_id, provider_name, old_priority, old_kind, created_at, shared_is_unlimited)) = metadata else {
             let err = format!(
                 "Failed to add shared connection for {addr}: url {} not found",
                 sanitize_sensitive_info(key)
@@ -1402,7 +1461,9 @@ impl ActiveProviderManager {
         let updated_priority = shared_allocation.priority;
         let needs_reindex = (updated_priority, updated_kind) != (old_priority, old_kind);
         let _ = shared_allocation;
-        if needs_reindex {
+        // Skip priority-index rebuild for unlimited providers: they are not
+        // subject to preemption and therefore must not be in the index.
+        if !shared_is_unlimited && needs_reindex {
             Self::remove_priority_entry(
                 &mut connections,
                 &provider_name,
@@ -1449,6 +1510,7 @@ mod tests {
         model::{ConfigPaths, InputFetchMethod, InputType},
         utils::Internable,
     };
+    use std::collections::HashSet;
     use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
     use shared::utils::{default_probe_user_priority, default_user_priority};
 
@@ -1517,6 +1579,94 @@ mod tests {
     fn create_test_app_config_single_provider_pool() -> AppConfig { build_test_app_config(None, 1) }
 
     fn create_test_app_config_single_unlimited_provider_pool() -> AppConfig { build_test_app_config(None, 0) }
+
+    #[tokio::test]
+    async fn unlimited_provider_connection_is_not_in_priority_index() {
+        let app_cfg = create_test_app_config_single_unlimited_provider_pool();
+        let event_manager = Arc::new(EventManager::new());
+        let manager = ActiveProviderManager::new(&app_cfg, &event_manager);
+
+        let input_name = "provider_1".intern();
+        let addr_1: SocketAddr = "127.0.0.1:44001".parse().unwrap();
+        let addr_2: SocketAddr = "127.0.0.1:44002".parse().unwrap();
+        let addr_3: SocketAddr = "127.0.0.1:44003".parse().unwrap();
+
+        manager
+            .acquire_connection(&input_name, &addr_1, default_user_priority(), ConnectionKind::Normal)
+            .await
+            .expect("acquire #1 on unlimited provider");
+        manager
+            .acquire_connection(&input_name, &addr_2, default_user_priority(), ConnectionKind::Normal)
+            .await
+            .expect("acquire #2 on unlimited provider");
+        manager
+            .acquire_connection(&input_name, &addr_3, default_user_priority(), ConnectionKind::Normal)
+            .await
+            .expect("acquire #3 on unlimited provider");
+
+        {
+            let connections = manager.connections.read().await;
+            let priority_tree = connections.priority_index.get(&input_name);
+            assert!(
+                priority_tree.is_none_or(std::collections::BTreeMap::is_empty),
+                "unlimited provider must not be present in priority_index, found {priority_tree:?}"
+            );
+            let soft_tree = connections.soft_priority_index.get(&input_name);
+            assert!(
+                soft_tree.is_none_or(std::collections::BTreeMap::is_empty),
+                "unlimited provider must not be present in soft_priority_index, found {soft_tree:?}"
+            );
+            let by_provider = connections.by_provider.get(&input_name);
+            assert!(
+                by_provider.is_none_or(std::collections::HashSet::is_empty),
+                "unlimited provider must not be present in by_provider, found {by_provider:?}"
+            );
+        }
+
+        manager.release_connection(&addr_1).await;
+        manager.release_connection(&addr_2).await;
+        manager.release_connection(&addr_3).await;
+    }
+
+    #[tokio::test]
+    async fn preemption_does_not_select_unlimited_provider_as_victim() {
+        let app_cfg = create_test_app_config_single_unlimited_provider_pool();
+        let event_manager = Arc::new(EventManager::new());
+        let manager = ActiveProviderManager::new(&app_cfg, &event_manager);
+
+        let input_name = "provider_1".intern();
+        let low_addr: SocketAddr = "127.0.0.1:45001".parse().unwrap();
+        let high_addr: SocketAddr = "127.0.0.1:45002".parse().unwrap();
+
+        // Acquire one low-priority and one high-priority connection on the unlimited provider.
+        let low = manager
+            .acquire_connection(&input_name, &low_addr, 50, ConnectionKind::Normal)
+            .await
+            .expect("low-priority acquire on unlimited provider");
+        let low_token = low.cancel_token.clone().expect("cancel token for low-priority connection");
+        let _high = manager
+            .acquire_connection(&input_name, &high_addr, 0, ConnectionKind::Normal)
+            .await
+            .expect("high-priority acquire on unlimited provider");
+
+        // A request at an even higher priority must not be able to preempt the unlimited
+        // provider's connection, because the connection is intentionally absent from the
+        // preemption indices.
+        let candidate = {
+            let connections = manager.connections.read().await;
+            manager.select_preemption_candidate(&connections, &input_name, 0, ConnectionKind::Normal, &HashSet::new())
+        };
+        assert!(
+            candidate.is_none(),
+            "select_preemption_candidate must not return an unlimited-provider connection as a victim, got {candidate:?}"
+        );
+
+        // The low-priority connection is still alive and its cancel token has not been fired.
+        assert!(!low_token.is_cancelled(), "low-priority unlimited-provider connection must not be cancelled by preemption");
+
+        manager.release_connection(&low_addr).await;
+        manager.release_connection(&high_addr).await;
+    }
 
     #[tokio::test]
     async fn test_force_exact_acquire_does_not_overallocate_busy_provider() {

--- a/backend/src/api/model/provider_config.rs
+++ b/backend/src/api/model/provider_config.rs
@@ -162,6 +162,9 @@ impl ProviderConfig {
     pub fn max_connections(&self) -> usize { self.max_connections }
 
     #[inline]
+    pub fn is_unlimited(&self) -> bool { self.max_connections == 0 }
+
+    #[inline]
     pub(crate) fn exp_date(&self) -> Option<i64> { self.exp_date }
 
     pub fn get_user_info(&self) -> Option<InputUserInfo> {
@@ -304,8 +307,12 @@ impl ProviderConfig {
     pub async fn release(&self) {
         let mut guard = self.connection.write().await;
         // Don't reset grace tracking when current_connections == 1 - this happens during
-        // last connection release and should preserve grace state until after decrement
-        if guard.current_connections > self.max_connections {
+        // last connection release and should preserve grace state until after decrement.
+        // The `max_connections > 0` guard short-circuits the dead branch for unlimited
+        // providers: with `max_connections == 0` the condition `current > max` is
+        // always true but grace was never granted in the first place, so resetting it
+        // here is a no-op that obscures the invariant.
+        if self.max_connections > 0 && guard.current_connections > self.max_connections {
             guard.granted_grace = false;
             guard.grace_ts = 0;
         }
@@ -360,4 +367,74 @@ impl Deref for ProviderConfigWrapper {
     type Target = ProviderConfig;
 
     fn deref(&self) -> &Self::Target { &self.inner }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shared::model::{InputFetchMethod, InputType};
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn build_test_config(max_connections: u16) -> ProviderConfig {
+        let input = ConfigInput {
+            id: 1,
+            name: Arc::from("test-provider"),
+            url: "http://test".to_string(),
+            username: Some("u".to_string()),
+            password: Some("p".to_string()),
+            max_connections,
+            priority: 0,
+            input_type: InputType::Xtream,
+            headers: HashMap::new(),
+            epg: None,
+            persist: None,
+            enabled: true,
+            options: None,
+            media_server: None,
+            aliases: None,
+            method: InputFetchMethod::default(),
+            staged: None,
+            exp_date: None,
+            t_batch_url: None,
+            panel_api: None,
+            provider_configs: None,
+            cache_duration_seconds: 0,
+        };
+        let conn = Arc::new(RwLock::new(ProviderConfigConnection::default()));
+        let counter = Arc::new(AtomicUsize::new(0));
+        let cb_counter = Arc::clone(&counter);
+        let cb: ProviderConnectionChangeCallback = Arc::new(move |_name, count| {
+            cb_counter.store(count, Ordering::SeqCst);
+        });
+        ProviderConfig::new(&input, conn, cb)
+    }
+
+    #[tokio::test]
+    async fn release_does_not_touch_grace_for_unlimited_provider() {
+        // For unlimited providers (max_connections == 0) the grace-reset branch in
+        // `release` must be a no-op even if the fields contain non-default values.
+        // This is stronger than checking defaults and catches regressions where the
+        // old `current > max` branch would clear grace state for unlimited inputs.
+        let provider = build_test_config(0);
+        assert!(provider.is_unlimited());
+
+        // Drive connection count up so `release` executes its normal path.
+        assert!(provider.force_allocate().await);
+        assert!(provider.force_allocate().await);
+        assert_eq!(provider.get_current_connections().await, 2);
+
+        {
+            let mut guard = provider.connection.write().await;
+            guard.granted_grace = true;
+            guard.grace_ts = 12_345;
+        }
+
+        provider.release().await;
+
+        let guard = provider.connection.read().await;
+        assert_eq!(guard.current_connections, 1, "release must still decrement connection count");
+        assert!(guard.granted_grace, "release must not clear granted_grace for unlimited provider");
+        assert_eq!(guard.grace_ts, 12_345, "release must not clear grace_ts for unlimited provider");
+    }
 }

--- a/backend/src/api/model/provider_lineup_manager.rs
+++ b/backend/src/api/model/provider_lineup_manager.rs
@@ -117,6 +117,11 @@ impl ProviderAllocation {
             }
         }
     }
+
+    #[inline]
+    pub fn is_unlimited_provider(&self) -> bool {
+        matches!(self, Self::Available(c) | Self::GracePeriod(c) if c.is_unlimited())
+    }
 }
 
 impl PartialEq for ProviderAllocation {

--- a/backend/src/api/model/streams/shared_stream_manager.rs
+++ b/backend/src/api/model/streams/shared_stream_manager.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use bytes::Bytes;
 use futures::{stream::BoxStream, Stream, StreamExt};
-use log::{debug, trace, warn};
+use log::{debug, warn};
 use shared::utils::sanitize_sensitive_info;
 use std::{
     collections::{HashMap, VecDeque},
@@ -403,6 +403,14 @@ impl SharedStreamState {
                     consecutive_lag_count = 0;
                 }
 
+                trace_if_enabled!(
+                    "shared_stream.subscribe: read {} chunks (next_seq={}, skipped={}) for {}",
+                    read_chunks.len(),
+                    read.next_sequence,
+                    read.skipped,
+                    sanitize_sensitive_info(&address.to_string())
+                );
+
                 if !read_chunks.is_empty() {
                     for data in read_chunks.drain(..) {
                         let chunk_len = data.len();
@@ -444,22 +452,38 @@ impl SharedStreamState {
                     biased;
 
                     () = cancel_token.cancelled() => {
-                        debug!("Client disconnected from shared stream: {address}");
+                        trace_if_enabled!(
+                            "shared_stream.subscribe: cancel_received for {}",
+                            sanitize_sensitive_info(&address.to_string())
+                        );
                         break;
                     }
 
                     () = &mut idle_check => {
                         if last_active.elapsed() > timeout_duration {
-                            debug!("Client timed out due to inactivity: {address}");
+                            trace_if_enabled!(
+                                "shared_stream.subscribe: idle_check_fired (inactivity>={}s) for {}",
+                                timeout_duration.as_secs(),
+                                sanitize_sensitive_info(&address.to_string())
+                            );
                             cancel_token.cancel();
                             break;
                         }
                         idle_check.as_mut().reset(Instant::now() + idle_check_interval);
                     }
 
-                    () = notified_fut => {}
+                    () = notified_fut => {
+                        trace_if_enabled!(
+                            "shared_stream.subscribe: empty_buffer_waiting waker for {}",
+                            sanitize_sensitive_info(&address.to_string())
+                        );
+                    }
 
                     () = preempted_token.cancelled() => {
+                        trace_if_enabled!(
+                            "shared_stream.subscribe: preempted for {}",
+                            sanitize_sensitive_info(&address.to_string())
+                        );
                         if let Some(mut fallback) = low_priority_preempted {
                             debug_if_enabled!(
                                 "Shared stream subscriber {} switching to low_priority_preempted fallback",
@@ -490,7 +514,12 @@ impl SharedStreamState {
     }
 
     #[allow(clippy::too_many_lines)]
-    fn broadcast<S, E>(&self, stream_url: &str, bytes_stream: S, shared_streams: Arc<SharedStreamManager>)
+    fn broadcast<S, E>(
+        self: &Arc<Self>,
+        stream_url: &str,
+        bytes_stream: S,
+        shared_streams: Arc<SharedStreamManager>,
+    )
     where
         S: Stream<Item=Result<Bytes, E>> + Unpin + 'static + Send,
         E: std::fmt::Debug + Send,
@@ -511,6 +540,12 @@ impl SharedStreamState {
             let mut startup_chunks_seen = 0_usize;
             let mut startup_bytes_seen = 0_usize;
             let mut startup_stats_logged = false;
+            // Track the time of the most recent upstream push so the broadcast can
+            // detect a stalled source before the global idle timeout fires. This is
+            // the diagnostic signal for H1 (broadcast stall with stale burst replay).
+            let mut last_push_at: Option<Instant> = None;
+            let mut idle_warning_emitted = false;
+            let idle_warn_threshold = idle_timeout / 2;
 
             loop {
                 tokio::select! {
@@ -525,7 +560,11 @@ impl SharedStreamState {
                     }
 
                     () = &mut idle => {
-                        debug!("shared stream idle for too long, closing");
+                        debug_if_enabled!(
+                            "Shared stream source idle timeout after {}s for {}",
+                            STREAM_IDLE_TIMEOUT,
+                            sanitize_sensitive_info(&streaming_url)
+                        );
                         stop_token.cancel();
                         break;
                     }
@@ -534,6 +573,23 @@ impl SharedStreamState {
                         idle.as_mut().reset(Instant::now() + idle_timeout);
                         match chunk {
                             Some(Ok(data)) => {
+                                let chunk_len = data.len();
+                                let push_seq = {
+                                    let mut buffer = burst_buffer.lock().await;
+                                    let seq = buffer.next_sequence;
+                                    buffer.push(data);
+                                    seq
+                                };
+                                live_notification.notify_waiters();
+                                last_push_at = Some(Instant::now());
+                                idle_warning_emitted = false;
+                                trace_if_enabled!(
+                                    "shared_stream.broadcast: push seq={} len={} url={}",
+                                    push_seq,
+                                    chunk_len,
+                                    sanitize_sensitive_info(&streaming_url)
+                                );
+
                                 if !first_source_chunk_logged {
                                     debug_if_enabled!(
                                         "Shared stream source produced first chunk for {} after {} ms",
@@ -544,7 +600,7 @@ impl SharedStreamState {
                                 }
                                 if !startup_stats_logged {
                                     startup_chunks_seen = startup_chunks_seen.saturating_add(1);
-                                    startup_bytes_seen = startup_bytes_seen.saturating_add(data.len());
+                                    startup_bytes_seen = startup_bytes_seen.saturating_add(chunk_len);
                                     if broadcast_started_at.elapsed() >= Duration::from_secs(5) {
                                         debug_if_enabled!(
                                             "Shared stream source startup throughput for {}: chunks={} bytes={} over {} ms",
@@ -556,11 +612,6 @@ impl SharedStreamState {
                                         startup_stats_logged = true;
                                     }
                                 }
-                                {
-                                    let mut buffer = burst_buffer.lock().await;
-                                    buffer.push(data);
-                                }
-                                live_notification.notify_waiters();
 
                                 counter = counter.saturating_add(1);
                                 if counter >= YIELD_COUNTER {
@@ -569,12 +620,16 @@ impl SharedStreamState {
                                 }
                             }
                             Some(Err(e)) => {
-                                trace!("Shared stream received error: {e:?}");
+                                trace_if_enabled!(
+                                    "Shared stream source error for {}: {:?}",
+                                    sanitize_sensitive_info(&streaming_url),
+                                    e
+                                );
                                 tokio::task::yield_now().await;
                             }
                             None => {
                                 debug_if_enabled!(
-                                    "Source stream ended. Closing shared provider stream {}",
+                                    "Shared stream source stream ended for {}",
                                     sanitize_sensitive_info(&streaming_url)
                                 );
                                 break;
@@ -582,11 +637,30 @@ impl SharedStreamState {
                         }
                     }
                 }
+
+                // Edge-triggered stall warning: fires once when the broadcast has
+                // not seen an upstream push for STREAM_IDLE_TIMEOUT/2 seconds, then
+                // resets on the next successful push. Operators correlate this
+                // warning with the "stuck in resending same buffer" symptom (H1).
+                if let Some(last) = last_push_at {
+                    let stalled_for = last.elapsed();
+                    if stalled_for >= idle_warn_threshold && !idle_warning_emitted {
+                        warn!(
+                            "shared_stream.broadcast: no upstream bytes for {}s on url={}; \
+                             source may be stalled. Subscribers will see cached burst until {}s timeout.",
+                            stalled_for.as_secs(),
+                            sanitize_sensitive_info(&streaming_url),
+                            STREAM_IDLE_TIMEOUT
+                        );
+                        idle_warning_emitted = true;
+                    }
+                }
             }
 
             debug_if_enabled!(
-                "Shared stream exhausted. Closing shared provider stream {}",
-                sanitize_sensitive_info(&streaming_url)
+                "Shared stream exiting for {} (last_push_age_secs={})",
+                sanitize_sensitive_info(&streaming_url),
+                last_push_at.map_or(0, |t| t.elapsed().as_secs())
             );
             shared_streams.unregister(&streaming_url, false).await;
         });
@@ -849,7 +923,11 @@ impl SharedStreamManager {
             registration_started_at.elapsed().as_millis()
         );
         if subscribed_stream.is_some() {
-            shared_state.broadcast(stream_url, bytes_stream, Arc::clone(&app_state.shared_stream_manager));
+            shared_state.broadcast(
+                stream_url,
+                bytes_stream,
+                Arc::clone(&app_state.shared_stream_manager),
+            );
             debug_if_enabled!(
                 "Created shared provider stream {} (channel_capacity={buf_size}, burst_buffer_min={min_buffer_bytes} bytes)",
                 sanitize_sensitive_info(stream_url)
@@ -930,6 +1008,7 @@ mod tests {
     use std::borrow::Cow;
     use std::{collections::HashMap, net::SocketAddr, sync::Arc};
     use tokio::{sync::mpsc, time::{timeout, Duration}};
+    use tokio_stream::wrappers::ReceiverStream;
     use tokio_util::sync::CancellationToken;
 
     fn create_test_app_config() -> AppConfig {
@@ -1420,5 +1499,57 @@ mod tests {
             None => panic!("fallback stream ended unexpectedly"),
         };
         assert!(!chunk.is_empty(), "fallback chunk must contain MPEG-TS bytes");
+    }
+
+    #[tokio::test]
+    async fn broadcast_does_not_emit_shared_stream_health_events() {
+        let app_cfg = create_test_app_config();
+        let event_manager = Arc::new(EventManager::new());
+        let provider_manager = Arc::new(ActiveProviderManager::new(&app_cfg, &event_manager));
+        let shared_manager = Arc::new(SharedStreamManager::new(provider_manager));
+        let mut events = event_manager.get_event_channel();
+        let stream_url = "https://user:pass@example.invalid/live/health.ts";
+        let state = Arc::new(SharedStreamState::new(Vec::new(), CHANNEL_SIZE.max(8), None, 1024, None));
+        {
+            let mut reg = shared_manager.shared_streams.write().await;
+            reg.by_key.insert(Arc::from(stream_url), Arc::clone(&state));
+        }
+
+        let (tx, rx) = mpsc::channel::<Result<Bytes, std::io::Error>>(8);
+        state.broadcast(
+            stream_url,
+            ReceiverStream::new(rx),
+            Arc::clone(&shared_manager),
+        );
+
+        assert!(
+            timeout(Duration::from_millis(100), events.recv()).await.is_err(),
+            "broadcast startup must not emit runtime events"
+        );
+
+        // Pushing data must also not emit a per-chunk health event.
+        tx.send(Ok(Bytes::from_static(b"payload-1")))
+            .await
+            .unwrap_or_else(|_| panic!("send chunk should succeed"));
+        assert!(
+            timeout(Duration::from_millis(100), events.recv()).await.is_err(),
+            "pushing a chunk must not emit runtime events"
+        );
+
+        drop(tx);
+        let ended = timeout(Duration::from_secs(2), async {
+            loop {
+                if shared_manager.get_shared_state(stream_url).await.is_none() {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await;
+        assert!(ended.is_ok(), "broadcast must exit after source end");
+        assert!(
+            timeout(Duration::from_millis(100), events.recv()).await.is_err(),
+            "broadcast shutdown must not emit runtime events"
+        );
     }
 }

--- a/backend/src/processing/parser/hls.rs
+++ b/backend/src/processing/parser/hls.rs
@@ -50,6 +50,7 @@ pub struct RewriteHlsProps<'a> {
     pub base_url: &'a str,
     pub content: &'a str,
     pub hls_url: String,
+    pub target_id: u16,
     pub virtual_id: u32,
     pub input_id: u16,
     pub user_token: Option<&'a str>,
@@ -84,11 +85,12 @@ fn rewrite_uri_attrib<'a>(line: &'a str, props: &RewriteHlsProps, user: &ProxyUs
         create_hls_url_without_session_token(props.secret, &rewritten)
     };
 
-    let final_uri = format!(
-        "{}/{HLS_PREFIX}/{}/{}/{}/{}/{}",
+        let final_uri = format!(
+        "{}/{HLS_PREFIX}/{}/{}/{}/{}/{}/{}",
         props.base_url,
         user.username,
         user.password,
+        props.target_id,
         props.input_id,
         props.virtual_id,
         token
@@ -124,10 +126,11 @@ pub fn rewrite_hls(user: &ProxyUserCredentials, props: &RewriteHlsProps) -> Stri
             create_hls_url_without_session_token(props.secret, &target_url)
         };
         let url = format!(
-            "{}/{HLS_PREFIX}/{}/{}/{}/{}/{}",
+            "{}/{HLS_PREFIX}/{}/{}/{}/{}/{}/{}",
             props.base_url,
             username,
             password,
+            props.target_id,
             props.input_id,
             props.virtual_id,
             token
@@ -238,6 +241,7 @@ mod test {
             base_url: "http://proxy",
             content: "#EXTM3U\nsegment.ts",
             hls_url: "http://origin/live/main.m3u8".to_string(),
+            target_id: 9,
             virtual_id: 101,
             input_id: 11,
             user_token: None,
@@ -248,6 +252,7 @@ mod test {
             .lines()
             .find(|line| line.contains(&format!("/{HLS_PREFIX}/")))
             .expect("rewritten playlist should contain a segment URL");
+        assert!(segment_line.contains("/hls/u/p/9/11/101/"));
         let token = segment_line
             .rsplit('/')
             .next()

--- a/backend/src/repository/m3u_playlist_iterator.rs
+++ b/backend/src/repository/m3u_playlist_iterator.rs
@@ -384,8 +384,13 @@ impl Stream for M3uPlaylistM3uTextIterator {
 
 #[cfg(test)]
 mod tests {
-    use super::{apply_rewrite, M3uPlaylistIteratorFlags, M3uPlaylistIteratorFlagsSet, UrlRewriteContext};
+    use super::{
+        apply_rewrite, M3uPlaylistIterator, M3uPlaylistIteratorFlags, M3uPlaylistIteratorFlagsSet,
+        M3uPlaylistM3uTextIterator, UrlRewriteContext,
+    };
     use crate::model::{ConfigInput, ConfigProvider, ProviderDnsCache};
+    use crate::repository::LockedReceiverStream;
+    use futures::StreamExt;
     use shared::{
         model::{M3uPlaylistItem, PlaylistItemType, ProviderUrlSelectionPolicy, ProxyType},
         utils::Internable,
@@ -394,6 +399,7 @@ mod tests {
         collections::HashMap,
         sync::{atomic::AtomicUsize, Arc},
     };
+    use tokio::sync::mpsc;
 
     fn provider_input() -> Arc<ConfigInput> {
         Arc::new(ConfigInput {
@@ -527,5 +533,26 @@ mod tests {
         );
 
         assert_eq!(rewritten.t_stream_url.as_ref(), "https://example.com/m3u-stream/user/pass/813294.ts");
+    }
+
+    // Regression lock: the streaming M3U response used by `m3u_api` must emit a
+    // bare `#EXTM3U` header line, never a proxy-rewritten `url-tvg` from the
+    // source playlist. The parser does not capture the source's `url-tvg`
+    // attribute (`M3uPlaylistItem` has no field for it), and the writer must
+    // therefore emit the bare marker regardless of what the upstream feed
+    // declared. The inner channel is closed immediately so the iterator yields
+    // no item lines, which lets the assertion focus on the header line only.
+    #[tokio::test]
+    async fn m3u_text_iterator_emits_bare_extm3u_header_without_proxying_source_url_tvg() {
+        let (tx, rx) = mpsc::channel::<(M3uPlaylistItem, bool)>(1);
+        drop(tx);
+        let inner_iter = M3uPlaylistIterator { inner: LockedReceiverStream::new_empty(rx) };
+        let mut text_iter = M3uPlaylistM3uTextIterator { inner: inner_iter, started: false, target_options: None };
+
+        let first = text_iter.next().await;
+        assert_eq!(first.as_deref(), Some("#EXTM3U"), "EXTM3U header must be bare, never contain url-tvg");
+
+        let second = text_iter.next().await;
+        assert_eq!(second, None, "inner channel is closed, so no item lines should follow");
     }
 }

--- a/shared/src/model/stream_info.rs
+++ b/shared/src/model/stream_info.rs
@@ -65,6 +65,18 @@ pub struct StreamChannel {
     pub epg_reference_ts: Option<i64>,
 }
 
+impl StreamChannel {
+    /// Returns a copy of this channel with the supplied EPG reference timestamp
+    /// installed. Used by the M3U non-HLS path to thread an archive/catchup
+    /// timestamp parsed from the request URL into the `StreamChannel` that the
+    /// frontend then carries to the `stream_epg` endpoint.
+    #[must_use]
+    pub fn with_epg_reference_ts(mut self, epg_reference_ts: Option<i64>) -> Self {
+        self.epg_reference_ts = epg_reference_ts;
+        self
+    }
+}
+
 pub fn create_stream_channel_with_type(
     target_id: u16,
     pli: &XtreamPlaylistItem,
@@ -346,7 +358,7 @@ impl StreamInfo {
 mod tests {
     use super::create_stream_channel_with_type;
     use crate::{
-        model::{PlaylistItemType, XtreamCluster, XtreamPlaylistItem},
+        model::{M3uPlaylistItem, PlaylistItemType, XtreamCluster, XtreamPlaylistItem},
         utils::Internable,
     };
 
@@ -405,5 +417,76 @@ mod tests {
         let stream_channel = playlist_item.to_stream_channel(1);
 
         assert_eq!(stream_channel.input_name.as_ref(), "provider-input");
+    }
+
+    #[test]
+    fn m3u_to_stream_channel_with_epg_reference_ts_propagates_value() {
+        let pli = M3uPlaylistItem {
+            virtual_id: 42,
+            provider_id: "42".intern(),
+            name: "Channel".intern(),
+            chno: 0,
+            logo: "".intern(),
+            logo_small: "".intern(),
+            group: "G".intern(),
+            title: "T".intern(),
+            parent_code: "".intern(),
+            audio_track: "".intern(),
+            time_shift: "".intern(),
+            rec: "".intern(),
+            url: "http://provider/live/42.m3u8".intern(),
+            epg_channel_id: Some("ch1".intern()),
+            input_name: "in".intern(),
+            item_type: PlaylistItemType::Live,
+            t_stream_url: "".intern(),
+            t_resource_url: None,
+            t_catchup_source: None,
+            t_catchup_mode: None,
+            source_ordinal: 0,
+            additional_properties: None,
+        };
+
+        let channel = pli.to_stream_channel(7).with_epg_reference_ts(Some(1_700_000_000));
+
+        assert_eq!(channel.target_id, 7);
+        assert_eq!(channel.virtual_id, 42);
+        assert_eq!(channel.epg_channel_id.as_deref(), Some("ch1"));
+        assert_eq!(channel.epg_reference_ts, Some(1_700_000_000));
+    }
+
+    #[test]
+    fn m3u_to_stream_channel_with_epg_reference_ts_explicit_none_matches_default() {
+        let pli = M3uPlaylistItem {
+            virtual_id: 42,
+            provider_id: "42".intern(),
+            name: "Channel".intern(),
+            chno: 0,
+            logo: "".intern(),
+            logo_small: "".intern(),
+            group: "G".intern(),
+            title: "T".intern(),
+            parent_code: "".intern(),
+            audio_track: "".intern(),
+            time_shift: "".intern(),
+            rec: "".intern(),
+            url: "http://provider/live/42.m3u8".intern(),
+            epg_channel_id: None,
+            input_name: "in".intern(),
+            item_type: PlaylistItemType::Live,
+            t_stream_url: "".intern(),
+            t_resource_url: None,
+            t_catchup_source: None,
+            t_catchup_mode: None,
+            source_ordinal: 0,
+            additional_properties: None,
+        };
+
+        // to_stream_channel() defaults to None, and with_epg_reference_ts(None)
+        // must keep that invariant.
+        let default_channel = pli.to_stream_channel(7);
+        let cleared_channel = pli.to_stream_channel(7).with_epg_reference_ts(None);
+
+        assert_eq!(default_channel.epg_reference_ts, None);
+        assert_eq!(cleared_channel.epg_reference_ts, None);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for unlimited provider connections; webplayer/HLS routes now include target identifiers; EPG centers on archive timestamps for archived/catchup streams.

* **Bug Fixes**
  * Improved M3U credential handling with stricter fail-closed behavior for mismatched external playlist credentials.
  * Better upstream-stall detection and diagnostics; fixed connection allocation/priority handling for unlimited providers.

* **Tests**
  * Expanded tests covering M3U, Xtream, HLS rewriting, and provider connection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->