### PR TITLE
Fixed webui path for authentication

### DIFF
--- a/backend/src/api/endpoints/web_index.rs
+++ b/backend/src/api/endpoints/web_index.rs
@@ -405,6 +405,9 @@ pub fn index_register_with_path(web_dir_path: &Path, web_ui_path: &str) -> axum:
 #[cfg(test)]
 mod tests {
     use super::api_user_can_access_web_ui;
+    use axum::{body::Body, http::{Method, Request, StatusCode}, routing::{get, post}, Router};
+    use shared::utils::concat_path_leading_slash;
+    use tower::ServiceExt;
 
     #[test]
     fn rejects_api_user_when_ui_is_disabled() {
@@ -414,5 +417,28 @@ mod tests {
     #[test]
     fn allows_api_user_when_ui_is_enabled() {
         assert!(api_user_can_access_web_ui(true));
+    }
+
+    #[tokio::test]
+    async fn auth_route_remains_reachable_when_web_ui_uses_sub_path() {
+        let web_ui_path = "tuli";
+        let auth_router = Router::new().route("/token", post(|| async { StatusCode::OK }));
+        let web_ui_router = Router::new().fallback(get(|| async { StatusCode::NOT_FOUND }));
+        let router = Router::new()
+            .nest(&concat_path_leading_slash(web_ui_path, "auth"), auth_router)
+            .nest(&format!("/{web_ui_path}/"), web_ui_router);
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/tuli/auth/token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
     }
 }

--- a/frontend/src/app/components/login.rs
+++ b/frontend/src/app/components/login.rs
@@ -98,7 +98,7 @@ pub fn Login() -> Html {
            </div>
            <div class={"tp__login-view__header"}>
                 <div class={"tp__login-view__header-logo"}>{app_logo.as_ref().clone()}</div>
-                <div class={"tp__login-view__header-title"}>{ format!("{app_title}") }</div>
+                <div class={"tp__login-view__header-title"}>{ app_title.to_string() }</div>
             </div>
             <div class="tp__login-view__message">{translation.t("MESSAGES.LOGIN.MESSAGE")}</div>
             <form>

--- a/frontend/src/app/mod.rs
+++ b/frontend/src/app/mod.rs
@@ -51,6 +51,15 @@ fn versioned_static_asset_url(path: &str) -> String {
 
 fn versioned_config_url() -> String { versioned_static_asset_url("config.json") }
 
+fn router_basename(config: &WebConfig) -> Option<String> {
+    config
+        .web_path
+        .as_ref()
+        .map(|path| path.trim())
+        .filter(|path| !path.is_empty() && *path != "/")
+        .map(ToOwned::to_owned)
+}
+
 fn resolve_effective_language(languages: &[LanguageInfo], active_language: &str) -> String {
     if languages.iter().any(|language| language.code == active_language) {
         active_language.to_string()
@@ -210,9 +219,10 @@ pub fn App() -> Html {
         active: effective_language.clone(),
         on_change: on_language_change,
     };
+    let basename = router_basename(config);
 
     html! {
-        <BrowserRouter>
+        <BrowserRouter basename={basename}>
             <ServiceContextProvider config={config.clone()}>
                 <IconContextProvider icons={icons.clone()}>
                     <ContextProvider<LanguageState> context={language_state}>
@@ -255,6 +265,18 @@ mod tests {
             versioned_static_asset_url("assets/i18n/en.json?lang=en"),
             format!("assets/i18n/en.json?lang=en&v={}", env!("CARGO_PKG_VERSION"))
         );
+    }
+
+    #[test]
+    fn router_basename_uses_non_root_web_path() {
+        let config = WebConfig { web_path: Some("/tuli".to_string()), ..WebConfig::default() };
+        assert_eq!(router_basename(&config), Some("/tuli".to_string()));
+    }
+
+    #[test]
+    fn router_basename_ignores_root_path() {
+        let config = WebConfig { web_path: Some("/".to_string()), ..WebConfig::default() };
+        assert_eq!(router_basename(&config), None);
     }
 
     #[test]

--- a/frontend/src/hooks/use_service_context.rs
+++ b/frontend/src/hooks/use_service_context.rs
@@ -29,7 +29,7 @@ pub struct Services {
 impl Services {
     pub fn new(web_config: &WebConfig, flags_service: FlagsService) -> Self {
         let event = Rc::new(EventService::new());
-        let auth = Rc::new(AuthService::new());
+        let auth = Rc::new(AuthService::new(web_config));
         let config = Rc::new(ConfigService::new(web_config, Rc::clone(&auth), Rc::clone(&event)));
         let status = Rc::new(StatusService::new());
         let stream_history = Rc::new(StreamHistoryService::new());

--- a/frontend/src/services/auth_service.rs
+++ b/frontend/src/services/auth_service.rs
@@ -1,5 +1,8 @@
 use super::{check_dummy_token, get_base_href, request_post, set_token};
-use crate::error::{Error, Error::Unauthorized};
+use crate::{
+    error::{Error, Error::Unauthorized},
+    model::WebConfig,
+};
 use base64::{engine::general_purpose, Engine as _};
 use futures_signals::signal::{Mutable, SignalExt};
 use log::warn;
@@ -18,6 +21,16 @@ fn decode_jwt_payload(token: &str) -> Option<Claims> {
     serde_json::from_slice::<Claims>(&payload_bytes).ok()
 }
 
+fn resolve_auth_path(config: &WebConfig) -> String {
+    let auth_url = config.api.auth_url.trim();
+    if !auth_url.is_empty() {
+        return auth_url.to_string();
+    }
+
+    let base_href = get_base_href();
+    concat_path_leading_slash(&base_href, "auth")
+}
+
 pub struct AuthService {
     auth_path: String,
     username: RefCell<String>,
@@ -28,10 +41,9 @@ pub struct AuthService {
 }
 
 impl AuthService {
-    pub fn new() -> Self {
-        let base_href = get_base_href();
+    pub fn new(config: &WebConfig) -> Self {
         Self {
-            auth_path: concat_path_leading_slash(&base_href, "auth"),
+            auth_path: resolve_auth_path(config),
             username: RefCell::new(String::new()),
             auth_channel: Mutable::new(false),
             roles: RefCell::new(vec![]),
@@ -150,5 +162,21 @@ impl AuthService {
 }
 
 impl Default for AuthService {
-    fn default() -> Self { Self::new() }
+    fn default() -> Self { Self::new(&WebConfig::default()) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_auth_path;
+    use crate::model::{ApiConfig, WebConfig};
+
+    #[test]
+    fn resolve_auth_path_prefers_configured_auth_url() {
+        let config = WebConfig {
+            api: ApiConfig { api_url: "/tuli/api/v1/".to_string(), auth_url: "/tuli/auth".to_string() },
+            ..WebConfig::default()
+        };
+
+        assert_eq!(resolve_auth_path(&config), "/tuli/auth");
+    }
 }


### PR DESCRIPTION
Fixed webui path for authentication

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Web UI now supports mounting under custom path prefixes with correct routing
  * Authentication endpoint paths are now configurable through web settings

* **Refactor**
  * Updated service initialization to use web configuration for routing

* **Tests**
  * Added tests validating sub-path routing and auth path configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->