### PR TITLE
Fixed m3u playlist with urls containing query

### DIFF
--- a/backend/src/api/api_utils.rs
+++ b/backend/src/api/api_utils.rs
@@ -1360,10 +1360,12 @@ fn get_stream_alternative_url_m3u(
     input: &ConfigInput,
     alias_input: &Arc<ProviderConfig>,
 ) -> Option<String> {
-    let alt_input_user_info = alias_input.get_user_info()?;
     if let Some((source_base_url, source_username, source_password)) =
         find_input_account_by_signature(stream_url, input)
     {
+        let Some(alt_input_user_info) = alias_input.get_user_info() else {
+            return Some(stream_url.to_string());
+        };
         let modified = stream_url.replacen(&source_base_url, &alt_input_user_info.base_url, 1);
         let mut url = Url::parse(&modified).ok()?;
 
@@ -1382,10 +1384,27 @@ fn get_stream_alternative_url_m3u(
 
         return Some(url.to_string());
     }
+    let Some(alt_input_user_info) = alias_input.get_user_info() else {
+        let Ok(url) = Url::parse(stream_url) else {
+            return None;
+        };
+        if providerless_m3u_url_has_explicit_credentials(&url) {
+            return None;
+        }
+        return Some(stream_url.to_string());
+    };
     if stream_url_has_account_signature(stream_url, &alt_input_user_info) {
         return None;
     }
     Some(stream_url.to_string())
+}
+
+fn providerless_m3u_url_has_explicit_credentials(url: &Url) -> bool {
+    !url.username().is_empty()
+        || url.password().is_some()
+        || url
+        .query_pairs()
+        .any(|(key, _)| key.eq_ignore_ascii_case("username") || key.eq_ignore_ascii_case("password"))
 }
 
 /// Look for an account signature in the stream URL that matches the input
@@ -2095,8 +2114,9 @@ where
     P: PlaylistEntry,
 {
     pub fn get_query_path(&self, provider_id: u32, url: &str) -> String {
-        let extension =
-            self.stream_ext.map_or_else(|| extract_extension_from_url(url).unwrap_or_default(), ToString::to_string);
+        let extension = self
+            .stream_ext
+            .map_or_else(|| extract_extension_from_url(url).map_or_else(String::new, ToString::to_string), ToString::to_string);
 
         // if there is an action_path (like for timeshift duration/start), it will be added in front of the stream_id
         if self.action_path.is_empty() {
@@ -2512,7 +2532,7 @@ pub(crate) async fn stream_response(
     let virtual_id = stream_channel.virtual_id;
     let item_type = stream_channel.item_type;
     let playback_extension = extract_extension_from_url(stream_url);
-    let socket_bound = is_socket_bound_playback_session(item_type, playback_extension.as_deref());
+    let socket_bound = is_socket_bound_playback_session(item_type, playback_extension);
     let mut connection_permission = connection_permission;
     let mut connection_kind = connection_kind;
     let activation = activate_session_before_stream_open(
@@ -3031,8 +3051,7 @@ async fn try_shared_stream_response_if_any(
             let mut stream_details = StreamDetails::from_stream(stream, grace_period_options);
 
             stream_details.provider_name = provider;
-            let socket_bound =
-                is_socket_bound_playback_session(stream_channel.item_type, extract_extension_from_url(stream_url).as_deref());
+            let socket_bound = is_socket_bound_playback_session(stream_channel.item_type, extract_extension_from_url(stream_url));
             if let Some(provider_name) = stream_details.provider_name.as_deref() {
                 let _ = app_state
                     .active_users
@@ -3250,7 +3269,7 @@ pub(crate) async fn local_stream_response(
     } else {
         stream
     };
-    let socket_bound = is_socket_bound_playback_session(pli.item_type, extract_extension_from_url(&pli.url).as_deref());
+    let socket_bound = is_socket_bound_playback_session(pli.item_type, extract_extension_from_url(&pli.url));
     let mut connection_kind = connection_kind;
     if let Some(session_token) = playback_session_token {
         let activation = activate_session_before_stream_open(
@@ -4087,6 +4106,20 @@ mod tests {
         ))
     }
 
+    fn test_runtime_provider_without_credentials(url: &str, input_type: InputType) -> Arc<RuntimeProviderConfig> {
+        let input = ConfigInput {
+            name: "provider".intern(),
+            url: url.to_string(),
+            input_type,
+            ..ConfigInput::default()
+        };
+        Arc::new(RuntimeProviderConfig::new(
+            &input,
+            Arc::new(RwLock::new(ProviderConfigConnection::default())),
+            Arc::new(|_, _| {}),
+        ))
+    }
+
     #[tokio::test]
     async fn test_is_seek_request() {
         let mut headers = HeaderMap::new();
@@ -4436,6 +4469,53 @@ mod tests {
         let stream_url = "https://hnpsechtsc.turknet.ercdn.net/xpnvudnlsv/cnbc-e/cnbc-e.m3u8";
 
         assert_eq!(get_stream_alternative_url(stream_url, &input, &alias), Some(stream_url.to_string()));
+    }
+
+    #[test]
+    fn get_stream_alternative_url_keeps_open_external_m3u_url_for_provider_without_credentials() {
+        let input = ConfigInput {
+            name: "source".intern(),
+            url: "http://provider.example/playlist.m3u8".to_string(),
+            input_type: InputType::M3u,
+            ..ConfigInput::default()
+        };
+        let provider = test_runtime_provider_without_credentials("http://provider.example/playlist.m3u8", InputType::M3u);
+        let stream_url = "http://s.only4.tv/17113/video.m3u8?token=abc";
+
+        assert_eq!(get_stream_alternative_url(stream_url, &input, &provider), Some(stream_url.to_string()));
+    }
+
+    #[test]
+    fn get_stream_alternative_url_rejects_query_credentials_for_provider_without_credentials() {
+        let input = ConfigInput {
+            name: "source".intern(),
+            url: "http://provider.example/playlist.m3u8".to_string(),
+            input_type: InputType::M3u,
+            ..ConfigInput::default()
+        };
+        let provider = test_runtime_provider_without_credentials("http://provider.example/playlist.m3u8", InputType::M3u);
+
+        assert_eq!(
+            get_stream_alternative_url(
+                "http://cdn.example/segment.ts?username=other-user&password=other-pass",
+                &input,
+                &provider
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn get_stream_alternative_url_rejects_basic_auth_credentials_for_provider_without_credentials() {
+        let input = ConfigInput {
+            name: "source".intern(),
+            url: "http://provider.example/playlist.m3u8".to_string(),
+            input_type: InputType::M3u,
+            ..ConfigInput::default()
+        };
+        let provider = test_runtime_provider_without_credentials("http://provider.example/playlist.m3u8", InputType::M3u);
+
+        assert_eq!(get_stream_alternative_url("http://user:pass@cdn.example/segment.ts", &input, &provider), None);
     }
 
     #[test]

--- a/backend/src/api/endpoints/m3u_api.rs
+++ b/backend/src/api/endpoints/m3u_api.rs
@@ -196,7 +196,7 @@ pub(in crate::api) async fn m3u_api_stream_loaded(
         pli.item_type
     );
     let extracted_ext = extract_extension_from_url(&pli.url).unwrap_or_default();
-    let extension = stream_ext.unwrap_or(extracted_ext.as_str());
+    let extension = stream_ext.unwrap_or(extracted_ext);
     let session_key = if pli.item_type == PlaylistItemType::Catchup {
         create_m3u_catchup_session_key(
             fingerprint,

--- a/backend/src/api/endpoints/xtream_api.rs
+++ b/backend/src/api/endpoints/xtream_api.rs
@@ -575,7 +575,7 @@ pub(crate) fn get_query_path(
     } else if let Some(ext) = stream_ext {
         ext.into()
     } else {
-        extract_extension_from_url(&pli.url).unwrap_or_default()
+        extract_extension_from_url(&pli.url).map_or_else(String::new, ToString::to_string)
     };
 
     let provider_id = pli.provider_id.to_string();
@@ -595,7 +595,7 @@ fn resolve_xtream_playback_extension(stream_ext: Option<&str>, pli: &XtreamPlayl
         .get_container_extension()
         .filter(|ext| !ext.is_empty())
         .map(|ext| concat_string!(".", ext.as_ref()))
-        .or_else(|| extract_extension_from_url(&pli.url).and_then(|ext| (!ext.is_empty()).then_some(ext)));
+        .or_else(|| extract_extension_from_url(&pli.url).map(ToString::to_string));
 
     if pli.item_type.is_live() {
         requested_extension.or(canonical_extension)

--- a/backend/src/api/model/active_user_manager.rs
+++ b/backend/src/api/model/active_user_manager.rs
@@ -385,7 +385,7 @@ fn is_stable_session_stream(stream: &StreamInfo) -> bool {
     stream.channel.item_type == PlaylistItemType::Catchup
         || stream.channel.item_type.is_live_adaptive()
         || matches!(
-            extract_extension_from_url(stream.channel.url.as_ref()).as_deref(),
+            extract_extension_from_url(stream.channel.url.as_ref()),
             Some(ext) if ext == HLS_EXT || ext == DASH_EXT
         )
 }
@@ -393,7 +393,7 @@ fn is_stable_session_stream(stream: &StreamInfo) -> bool {
 fn uses_session_reentry_guard(stream: &StreamInfo) -> bool {
     stream.channel.item_type.requires_provider_affinity()
         || matches!(
-            extract_extension_from_url(stream.channel.url.as_ref()).as_deref(),
+            extract_extension_from_url(stream.channel.url.as_ref()),
             Some(ext) if ext == HLS_EXT || ext == DASH_EXT
         )
 }

--- a/backend/src/processing/parser/hls.rs
+++ b/backend/src/processing/parser/hls.rs
@@ -11,7 +11,7 @@ const TOKEN_SEPARATOR_STR: &str = "\x1F";
 fn create_hls_session_token_and_url(secret: &[u8], session_token: &str, stream_url: &str) -> String {
     let cookie_value = obfuscate_text(secret, &concat_string!(session_token, TOKEN_SEPARATOR_STR, stream_url));
     if let Some(ext) = extract_extension_from_url(stream_url) {
-        return concat_string!(&cookie_value, &ext);
+        return concat_string!(&cookie_value, ext);
     }
     cookie_value
 }
@@ -19,7 +19,7 @@ fn create_hls_session_token_and_url(secret: &[u8], session_token: &str, stream_u
 fn create_hls_url_without_session_token(secret: &[u8], stream_url: &str) -> String {
     let token = obfuscate_text(secret, stream_url);
     if let Some(ext) = extract_extension_from_url(stream_url) {
-        return concat_string!(&token, &ext);
+        return concat_string!(&token, ext);
     }
     token
 }

--- a/backend/src/repository/m3u_playlist_iterator.rs
+++ b/backend/src/repository/m3u_playlist_iterator.rs
@@ -79,7 +79,7 @@ fn build_rewritten_url(
 
     if append_extension {
         extract_extension_from_url(source_url)
-            .map(|ext| shared::concat_string!(&rewritten_url, &ext))
+            .map(|ext| shared::concat_string!(&rewritten_url, ext))
             .unwrap_or(rewritten_url)
     } else {
         rewritten_url

--- a/backend/src/utils/network/xtream.rs
+++ b/backend/src/utils/network/xtream.rs
@@ -568,7 +568,7 @@ pub fn create_vod_info_from_item(pli: &XtreamPlaylistItem) -> String {
         .get_container_extension()
         .filter(|ce| !ce.is_empty())
         .map(|s| s.to_string())
-        .or_else(|| extract_extension_from_url(&pli.url))
+        .or_else(|| extract_extension_from_url(&pli.url).map(ToString::to_string))
         .unwrap_or_default();
 
     let mut doc = XtreamVideoInfoDoc::default();

--- a/shared/src/model/playlist.rs
+++ b/shared/src/model/playlist.rs
@@ -1087,7 +1087,7 @@ impl PlaylistItem {
                     XtreamCluster::Live => None,
                     XtreamCluster::Video => {
                         let container_extension = extract_extension_from_url(&header.url)
-                            .map(|e| e.strip_prefix('.').unwrap_or(&*e).to_string())
+                            .map(|e| e.strip_prefix('.').unwrap_or(e).to_string())
                             .unwrap_or_default();
                         Some(StreamProperties::Video(Box::new(VideoStreamProperties {
                             name: header.name.clone(),
@@ -1110,7 +1110,7 @@ impl PlaylistItem {
                     XtreamCluster::Series => {
                         if header.item_type == PlaylistItemType::Series {
                             let container_extension = extract_extension_from_url(&header.url)
-                                .map(|e| e.strip_prefix('.').unwrap_or(&e).to_string())
+                                .map(|e| e.strip_prefix('.').unwrap_or(e).to_string())
                                 .unwrap_or_default();
                             // TODO maybe from link ? like s01e02 or something like this
                             Some(StreamProperties::Episode(Box::new(EpisodeStreamProperties {

--- a/shared/src/model/stream_info.rs
+++ b/shared/src/model/stream_info.rs
@@ -165,7 +165,7 @@ fn stream_technical_from_properties(properties: Option<&StreamProperties>, url: 
 
     info.container = container_raw
         .and_then(normalize_container)
-        .or_else(|| extract_extension_from_url(url).and_then(|ext| normalize_container(&ext)))
+        .or_else(|| extract_extension_from_url(url).and_then(normalize_container))
         .unwrap_or_default();
 
     if info.is_empty() {

--- a/shared/src/utils/request.rs
+++ b/shared/src/utils/request.rs
@@ -38,37 +38,27 @@ pub fn sanitize_sensitive_info(query: &str) -> Cow<'_, str> {
     Cow::Owned(result)
 }
 
-/// Extracts the file extension from a URL path (fragment stripped).
+/// Extracts the file extension from a URL path (query and fragment stripped).
 /// Returns the extension **prefixed with a dot** (e.g., ".m3u8").
-pub fn extract_extension_from_url(input: &str) -> Option<String> {
-    // 1. Remove fragment (#)
-    let base = input.split('#').next()?;
+pub fn extract_extension_from_url(input: &str) -> Option<&str> {
+    let bytes = input.as_bytes();
+    let end = bytes.iter().position(|b| matches!(*b, b'?' | b'#')).unwrap_or(bytes.len());
 
-    // 2. Get last path segment (after last '/')
-    let last_segment = base.rsplit('/').next().filter(|s| !s.is_empty())?;
-
-    // 3. Define the search area (last 6 characters to include the dot + 5 extension chars)
-    // We use char_indices to handle UTF-8 safely
-    let len = last_segment.len();
-    let search_start = len.saturating_sub(6);
-    let search_area = &last_segment[search_start..];
-
-    // 4. Find the dot in the restricted search area
-    if let Some(dot_index) = search_area.rfind('.') {
-        // Slice INCLUDING the dot
-        let extension_with_dot = &search_area[dot_index..];
-
-        // Validation (Note: length is now +1 because of the dot)
-        if extension_with_dot.len() > 1
-            && extension_with_dot.len() <= 5
-            && !extension_with_dot.contains('?')
-            && !extension_with_dot.eq_ignore_ascii_case(".php")
-        {
-            return Some(extension_with_dot.to_string());
-        }
+    let segment_start = bytes[..end].iter().rposition(|b| *b == b'/').map_or(0, |idx| idx + 1);
+    if segment_start >= end {
+        return None;
     }
 
-    None
+    let segment = &bytes[segment_start..end];
+    let dot = segment.iter().rposition(|b| *b == b'.')?;
+    let extension_start = segment_start + dot + 1;
+    let extension = &input[extension_start..end];
+
+    if extension.is_empty() || extension.len() > 4 || extension.eq_ignore_ascii_case("php") {
+        return None;
+    }
+
+    Some(&input[extension_start - 1..end])
 }
 
 pub fn is_hls_url(url: &str) -> bool {
@@ -182,7 +172,22 @@ pub fn parse_provider_scheme_url_parts(stream_url: &str) -> Result<(&str, &str),
 
 #[cfg(test)]
 mod tests {
-    use super::{sanitize_sensitive_info, set_sanitize_sensitive_info};
+    use super::{extract_extension_from_url, sanitize_sensitive_info, set_sanitize_sensitive_info};
+
+    #[test]
+    fn extract_extension_from_url_ignores_query_and_fragment() {
+        let cases = [
+            ("http://provider.example/live/video.m3u8?token=abc", Some(".m3u8")),
+            ("http://provider.example/live/video.m3u8?token=abc#frag", Some(".m3u8")),
+            ("http://provider.example/live/video.m3u8?next=http://cdn.example/segment.ts", Some(".m3u8")),
+            ("http://provider.example/live/video.ts?token=abc", Some(".ts")),
+            ("http://provider.example/live/video.pHp?token=abc", None),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(extract_extension_from_url(input), expected, "input: {input}");
+        }
+    }
 
     #[test]
     fn sanitize_sensitive_info_masks_xtream_path_credentials_for_all_supported_schemes() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved M3U stream handling when providers lack configured credentials
  * Enhanced URL extension extraction and stream container type resolution across HLS, XTream, and VOD formats

* **Tests**
  * Added test coverage for credential-less M3U URL scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->