### PR TITLE
Derive authenticated-token IV synthetically so STRM files stop churning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -343,6 +343,15 @@
 
 ## 🐛 Fixes
 
+- **STRM files are no longer rewritten on every playlist update**: authenticated tokens (STRM
+  `/provider/resolve/…` URLs and M3U catchup URLs) used a random IV, so re-encoding the same item produced a
+  different token every run. That made every STRM file's content differ on each update, so the existing
+  `has_strm_file_same_hash` skip in `strm_repository` never matched and the whole STRM tree was rewritten every
+  time (measured: ~28k files rewritten by a no-op update). The IV is now derived synthetically (SIV) from the
+  secret, domain and payload, so the same item always encodes to the same token and unchanged STRM files are left
+  alone. The token wire format is unchanged and the IV is still read from the token on decode, so **tokens issued
+  by older versions keep working** — no STRM regeneration required.
+
 - **Playlist Cache Load Failures No Longer Silent**: Xtream and M3U storage loads that fail due to corruption,
   version mismatch, or task panics now log an error before falling back to an empty playlist, instead of silently
   serving empty data. A genuinely missing storage file (first run) is logged at debug only, so normal startup stays

--- a/backend/src/utils/crypto_utils.rs
+++ b/backend/src/utils/crypto_utils.rs
@@ -36,15 +36,32 @@ fn authenticated_token_mac(secret: &[u8; 16], domain: &[u8], data: &[u8]) -> bla
     blake3::keyed_hash(&mac_key, data)
 }
 
+/// Derives the AES-CTR IV synthetically (SIV) from the secret, the domain and the plaintext,
+/// so that encoding the same payload twice yields the same token.
+///
+/// The IV stays unpredictable to anyone without `secret`, and distinct payloads (or domains)
+/// still get distinct IVs, so the CTR keystream is never reused across different plaintexts.
+/// Encoding the same payload twice deliberately produces an identical token: these tokens are
+/// stable per-item URLs (STRM files, M3U catchup URLs), and equality of two tokens reveals only
+/// that they point at the same item — which their surrounding filename/playlist entry already says.
+fn derive_synthetic_iv(secret: &[u8; 16], domain: &[u8], plaintext: &[u8]) -> [u8; AES_128_CTR_IV_LEN] {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"tuliprox.authenticated-token.siv.v1");
+    hasher.update(&(domain.len() as u64).to_be_bytes());
+    hasher.update(domain);
+    hasher.update(secret);
+    hasher.update(plaintext);
+    let mut iv = [0u8; AES_128_CTR_IV_LEN];
+    iv.copy_from_slice(&hasher.finalize().as_bytes()[..AES_128_CTR_IV_LEN]);
+    iv
+}
+
 pub fn obscure_authenticated_bytes(
     secret: &[u8; 16],
     domain: &[u8],
     plaintext: &[u8],
 ) -> Result<String, TuliproxError> {
-    let mut iv = [0u8; AES_128_CTR_IV_LEN];
-    if OsRng.try_fill_bytes(&mut iv).is_err() {
-        rand::rng().fill_bytes(&mut iv);
-    }
+    let iv = derive_synthetic_iv(secret, domain, plaintext);
 
     let data_len = 1 + AES_128_CTR_IV_LEN + plaintext.len();
     let mut out = Vec::with_capacity(data_len + BLAKE3_MAC_LEN);
@@ -128,7 +145,8 @@ pub fn deobscure_text(secret: &[u8; 16], encoded: &str) -> Result<String, Tulipr
 #[cfg(test)]
 mod tests {
     use crate::utils::crypto_utils::{
-        apply_aes_128_ctr, deobscure_authenticated_bytes, deobscure_text, obscure_authenticated_bytes, obscure_text,
+        apply_aes_128_ctr, authenticated_token_mac, deobscure_authenticated_bytes, deobscure_text,
+        obscure_authenticated_bytes, obscure_text, AES_128_CTR_IV_LEN, AUTH_TOKEN_VERSION,
     };
     use base64::{engine::general_purpose, Engine as _};
     use rand::Rng;
@@ -194,5 +212,61 @@ mod tests {
         let decoded = deobscure_authenticated_bytes(&secret, b"other-domain", &token);
 
         assert!(decoded.is_err());
+    }
+
+    #[test]
+    fn authenticated_token_is_deterministic() {
+        let secret: [u8; 16] = rand::rng().random();
+
+        let first = obscure_authenticated_bytes(&secret, b"provider-resolve", b"payload").unwrap();
+        let second = obscure_authenticated_bytes(&secret, b"provider-resolve", b"payload").unwrap();
+
+        assert_eq!(first, second, "same payload must encode to the same token");
+    }
+
+    #[test]
+    fn authenticated_token_differs_per_payload() {
+        let secret: [u8; 16] = rand::rng().random();
+
+        let first = obscure_authenticated_bytes(&secret, b"provider-resolve", b"payload-a").unwrap();
+        let second = obscure_authenticated_bytes(&secret, b"provider-resolve", b"payload-b").unwrap();
+
+        // distinct payloads must get distinct IVs, otherwise the CTR keystream would be reused
+        let first_iv = &general_purpose::URL_SAFE_NO_PAD.decode(&first).unwrap()[1..17];
+        let second_iv = &general_purpose::URL_SAFE_NO_PAD.decode(&second).unwrap()[1..17];
+        assert_ne!(first_iv, second_iv);
+    }
+
+    #[test]
+    fn authenticated_token_differs_per_domain() {
+        let secret: [u8; 16] = rand::rng().random();
+
+        let first = obscure_authenticated_bytes(&secret, b"provider-resolve", b"payload").unwrap();
+        let second = obscure_authenticated_bytes(&secret, b"m3u-catchup", b"payload").unwrap();
+
+        assert_ne!(first, second, "domain must be bound into the IV");
+    }
+
+    #[test]
+    fn authenticated_token_still_decodes_legacy_random_iv_tokens() {
+        // Tokens minted before the synthetic IV carry a random IV in the same wire format.
+        // The decoder reads the IV out of the token, so they must keep decoding unchanged —
+        // no regeneration of already-written STRM files is required.
+        let secret: [u8; 16] = rand::rng().random();
+        let payload = b"legacy-payload";
+        let random_iv: [u8; AES_128_CTR_IV_LEN] = rand::rng().random();
+
+        let mut out = Vec::new();
+        out.push(AUTH_TOKEN_VERSION);
+        out.extend_from_slice(&random_iv);
+        out.extend_from_slice(payload);
+        apply_aes_128_ctr(&secret, &random_iv, &mut out[1 + AES_128_CTR_IV_LEN..]).unwrap();
+        let mac = authenticated_token_mac(&secret, b"provider-resolve", &out);
+        out.extend_from_slice(mac.as_bytes());
+        let legacy_token = general_purpose::URL_SAFE_NO_PAD.encode(out);
+
+        let decoded = deobscure_authenticated_bytes(&secret, b"provider-resolve", &legacy_token).unwrap();
+
+        assert_eq!(decoded, payload);
     }
 }

--- a/backend/src/utils/crypto_utils.rs
+++ b/backend/src/utils/crypto_utils.rs
@@ -232,8 +232,8 @@ mod tests {
         let second = obscure_authenticated_bytes(&secret, b"provider-resolve", b"payload-b").unwrap();
 
         // distinct payloads must get distinct IVs, otherwise the CTR keystream would be reused
-        let first_iv = &general_purpose::URL_SAFE_NO_PAD.decode(&first).unwrap()[1..17];
-        let second_iv = &general_purpose::URL_SAFE_NO_PAD.decode(&second).unwrap()[1..17];
+        let first_iv = &general_purpose::URL_SAFE_NO_PAD.decode(&first).unwrap()[1..=AES_128_CTR_IV_LEN];
+        let second_iv = &general_purpose::URL_SAFE_NO_PAD.decode(&second).unwrap()[1..=AES_128_CTR_IV_LEN];
         assert_ne!(first_iv, second_iv);
     }
 
@@ -244,7 +244,12 @@ mod tests {
         let first = obscure_authenticated_bytes(&secret, b"provider-resolve", b"payload").unwrap();
         let second = obscure_authenticated_bytes(&secret, b"m3u-catchup", b"payload").unwrap();
 
-        assert_ne!(first, second, "domain must be bound into the IV");
+        // Compare the IVs, not the whole tokens: the MAC key is already domain-separated, so the
+        // tokens would differ even if derive_synthetic_iv ignored the domain. Only asserting on the
+        // IV actually pins the domain binding in derive_synthetic_iv.
+        let first_iv = &general_purpose::URL_SAFE_NO_PAD.decode(&first).unwrap()[1..=AES_128_CTR_IV_LEN];
+        let second_iv = &general_purpose::URL_SAFE_NO_PAD.decode(&second).unwrap()[1..=AES_128_CTR_IV_LEN];
+        assert_ne!(first_iv, second_iv, "domain must be bound into the IV");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`obscure_authenticated_bytes` picks a **random IV** per call, so encoding the same payload twice yields a different token each time. STRM URLs (`/provider/resolve/<token>`) are built this way, so **every STRM file's content changes on every playlist update**, even when the item is untouched.

`strm_repository` already tries to avoid pointless writes:

```rust
if file_exists && has_strm_file_same_hash(&target_file_path, content_hash).await { /* skip */ }
```

but the random IV makes the content hash differ every run, so **that skip can never match**. The whole STRM tree is rewritten on each update.

Measured on a ~28k-item library: a **no-op** playlist update (no config change, no catalogue change) rewrote all ~28,000 STRM files. Before/after `md5` of the concatenated tree: `b20a7871…` → `1ff5e234…`.

## Fix

Derive the IV **synthetically** (SIV) — a keyed BLAKE3 over the secret, domain and plaintext — instead of `OsRng`.

Same payload → same IV → same token → `has_strm_file_same_hash` matches → unchanged STRM files are left alone.

## Why this is safe

- **Distinct payloads (and domains) still get distinct IVs**, so the CTR keystream is never reused across different plaintexts.
- The IV stays **unpredictable without the secret** (the hash is keyed with it).
- The **MAC is unchanged** — tamper/forgery protection and domain separation are untouched.
- **Determinism is the intended property**: these tokens are stable per-item URLs, and two equal tokens reveal only that they address the same item — which the surrounding STRM filename or playlist entry already states.

## Backward compatible — no migration

The wire format is unchanged and the decoder still **reads the IV out of the token** rather than recomputing it, so **tokens minted by older versions keep decoding**. Already-written STRM files keep working; nothing needs regenerating. There's a test that mints a legacy random-IV token and decodes it.

## Scope

Both callers of `obscure_authenticated_bytes` (provider-resolve tokens and M3U catchup tokens) become deterministic. `obscure_text` (XMLTV/M3U resource URL obfuscation) keeps its random IV — it isn't affected by this problem.

## Tests

Full workspace suite passes (2519 tests). New cases in `crypto_utils`:

- `authenticated_token_is_deterministic` — same payload encodes identically
- `authenticated_token_differs_per_payload` — distinct payloads get distinct IVs (no keystream reuse)
- `authenticated_token_differs_per_domain` — domain is bound into the IV
- `authenticated_token_still_decodes_legacy_random_iv_tokens` — old tokens keep working

Existing round-trip / tamper-rejection / wrong-domain tests still pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed STRM files being rewritten on every playlist update.
  * Improved “unchanged item” detection by making authenticated tokens reproducible for identical inputs.
  * Ensured backward compatibility by still supporting tokens produced by previous versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->