### PR TITLE
fix(strm): name every flat/tmdb movie version after the folder it lands in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -394,6 +394,18 @@
 
 ## 🐛 Fixes
 
+- **Media servers no longer show a duplicate movie for every extra provider listing (STRM `flat` mode)**: under
+  `flat: true` the movie folder is deduplicated by TMDB id, but each file was still named after *its own*
+  provider title. Providers routinely list the same film twice with the tag written differently
+  (`X [MULTI-SUB] - 2021` vs `X - 2021 [Multi Sub]`), so the second listing landed in the first one's folder
+  under a name that does not start with the folder name — exactly what Jellyfin/Emby require in order to group
+  alternate versions. Jellyfin's `VideoListResolver` then abandons version grouping for the *whole* folder and
+  shows one movie per file. Every listing that reuses a folder is now named after that folder, so the existing
+  `add_quality_to_filename` suffix (or the `[Version id#N]` collision suffix) distinguishes them and the media
+  server shows a single movie with selectable versions. Applies to the `jellyfin`, `emby` and `kodi` styles.
+  **Note:** this renames existing files in `flat` STRM trees; with `cleanup: true` the old names are removed on
+  the next update.
+
 - **STRM files are no longer rewritten on every playlist update**: authenticated tokens (STRM
   `/provider/resolve/…` URLs and M3U catchup URLs) used a random IV, so re-encoding the same item produced a
   different token every run. That made every STRM file's content differ on each update, so the existing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1520,24 +1520,24 @@ target output type `xtream`:
 
 target output type `m3u`:
 
-- `filename`: _optional_
+- `filename`: *optional*
 - `include_type_in_url`: `true`|`false`,
 - `mask_redirect_url`: `true`|`false`,
 
 target output type `strm`:
 
-- `directory`: _mandatory_,
-- `username`: _optional_,
+- `directory`: *mandatory*,
+- `username`: *optional*,
 - `underscore_whitespace`: `true`|`false`,
 - `cleanup`: `true`|`false`,
 - `kodi_style`: `true`|`false`,
-- `strm_props`: _optional_,  list of strings,
+- `strm_props`: *optional*,  list of strings,
 
 target output type `hdhomerun`:
 
-- `device`: _mandatory_,
-- `username`: _mandatory_,
-- `use_output`: _optional_, `m3u`|`xtream`
+- `device`: *mandatory*,
+- `username`: *mandatory*,
+- `use_output`: *optional*, `m3u`|`xtream`
 
 Example:
 
@@ -1683,9 +1683,9 @@ messaging:
 - Watch files are now moved inside the `target` folder. Move them manually from `watch_<target_name>_<watched_group>.bin` to
   `<target_name>/watch_<watched_group>.bin`
 - No error log for xtream api when content is skipped with options `xtream_skip_[live|vod|series]`
-- _experimental_:  added live channel connection sharing in reverse proxy mode. To activate set `share_live_streams` in target options.
+- *experimental*:  added live channel connection sharing in reverse proxy mode. To activate set `share_live_streams` in target options.
 - Added `info` and `tmdb-id` caching for vod and series with options `xtream_resolve_(series|vod)`.
-- The `kodi` format for movies can contain the `tmdb-id` (_optional_). To add the `tmdb-id` you can set now `kodi_style`,  `xtream_resolve_vod`,
+- The `kodi` format for movies can contain the `tmdb-id` (*optional*). To add the `tmdb-id` you can set now `kodi_style`,  `xtream_resolve_vod`,
   `xtream_resolve_vod_delay`, `xtream_resolve_series` and  `xtream_resolve_series_delay` to target options.
 - `kodi` output can now have `username` attribute to use reverse proxy mode when combined with `xtream` output.
 - Fixed webUI manual update for selected targets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -414,6 +414,12 @@
   folder unique — and they now carry it in the file name too, so the name still starts with the folder name
   (it previously did not, which quietly broke version detection for those items).
 
+- **Two STRM versions of the same movie could silently overwrite each other when the name was very long**: the
+  `[Version id#N]` suffix that tells colliding versions apart was appended last, and the writer then truncates
+  the file stem to 250 characters — so for a long title the only distinguishing part was cut off and both
+  versions resolved to the same path. The shared base is now trimmed instead, so the version label always
+  survives.
+
 - **STRM files are no longer rewritten on every playlist update**: authenticated tokens (STRM
   `/provider/resolve/…` URLs and M3U catchup URLs) used a random IV, so re-encoding the same item produced a
   different token every run. That made every STRM file's content differ on each update, so the existing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -406,6 +406,14 @@
   **Note:** this renames existing files in `flat` STRM trees; with `cleanup: true` the old names are removed on
   the next update.
 
+- **The provider category is no longer appended to STRM movie file names in `flat` mode**: it was added as a
+  collision guard, but the only files that can now collide are versions of the same movie (same TMDB folder,
+  same quality string), which the existing `[Version id#N]` pass already separates. Jellyfin and Emby render
+  whatever follows the folder name as the *version label*, so the category leaked into the version picker; the
+  label now reads as the quality alone. Items with no TMDB id still carry the category — it is what keeps their
+  folder unique — and they now carry it in the file name too, so the name still starts with the folder name
+  (it previously did not, which quietly broke version detection for those items).
+
 - **STRM files are no longer rewritten on every playlist update**: authenticated tokens (STRM
   `/provider/resolve/…` URLs and M3U catchup URLs) used a random IV, so re-encoding the same item produced a
   different token every run. That made every STRM file's content differ on each update, so the existing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -394,6 +394,12 @@
 
 ## 🐛 Fixes
 
+- **Quality tags no longer demote widescreen films a resolution tier**: `MediaQuality` classified the
+  resolution from the frame *height* alone. A letterboxed 2.40:1 film mastered at 1080p is 1920x796, so it was
+  tagged `720p HD`; a 2.40:1 UHD master (3840x1600) was tagged `1440p QHD`. Resolution is now taken from the
+  higher of the width-derived and height-derived tier, so scope films land in the tier they were mastered at.
+  Height alone still decides when the width is unknown. Affects `add_quality_to_filename` STRM names.
+
 - **STRM files are no longer rewritten on every playlist update**: authenticated tokens (STRM
   `/provider/resolve/…` URLs and M3U catchup URLs) used a random IV, so re-encoding the same item produced a
   different token every run. That made every STRM file's content differ on each update, so the existing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -394,7 +394,6 @@
 
 ## 🐛 Fixes
 
-
 - **Media servers no longer show a duplicate movie for every extra provider listing (STRM `flat` mode)**: under
   `flat: true` the movie folder is deduplicated by TMDB id, but each file was still named after *its own*
   provider title. Providers routinely list the same film twice with the tag written differently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -411,8 +411,9 @@
   same quality string), which the existing `[Version id#N]` pass already separates. Jellyfin and Emby render
   whatever follows the folder name as the *version label*, so the category leaked into the version picker; the
   label now reads as the quality alone. Items with no TMDB id still carry the category — it is what keeps their
-  folder unique — and they now carry it in the file name too, so the name still starts with the folder name
-  (it previously did not, which quietly broke version detection for those items).
+  folder unique — and for the `jellyfin` and `emby` styles they now carry it in the file name too, so the name
+  still starts with the folder name (it previously did not, which quietly broke version detection for those
+  items). `kodi` is unchanged here: it has no filename-starts-with-folder-name convention.
 
 - **Two STRM versions of the same movie could silently overwrite each other when the name was very long**: the
   `[Version id#N]` suffix that tells colliding versions apart was appended last, and the writer then truncates

--- a/backend/src/repository/strm_repository.rs
+++ b/backend/src/repository/strm_repository.rs
@@ -429,6 +429,36 @@ fn prepare_filename_parts(
     }
 }
 
+/// Movie folders already claimed in `flat` mode, keyed by `TMDb` id. Holds the folder itself and
+/// the file name the first item put in it.
+type FlatDedupPaths = HashMap<u32, (PathBuf, String)>;
+
+/// Points `dir_path`/`final_filename` at the flat folder for `tmdb_id`, creating it on first use.
+///
+/// Providers routinely list the same movie more than once with differently written titles. In
+/// `flat` mode those listings are deduplicated onto one folder by `TMDb` id, so every listing after
+/// the first lands in a folder that was named after *another* listing's title. Naming such a file
+/// after its own title breaks the media servers' alternate-version detection, which requires the
+/// file name to start with the name of the folder it sits in. So the first item to claim a folder
+/// also fixes the file name for everything that follows it into that folder; the differing
+/// quality suffix (or, failing that, the `[Version id#N]` collision suffix) is what keeps the
+/// versions apart.
+fn claim_flat_movie_folder(
+    flat_dedup_paths: &mut FlatDedupPaths,
+    tmdb_id: u32,
+    folder_name: &str,
+    dir_path: &mut PathBuf,
+    final_filename: &mut String,
+) {
+    if let Some((claimed_path, claimed_filename)) = flat_dedup_paths.get(&tmdb_id) {
+        dir_path.clone_from(claimed_path);
+        final_filename.clone_from(claimed_filename);
+    } else {
+        dir_path.push(folder_name);
+        flat_dedup_paths.insert(tmdb_id, (dir_path.clone(), final_filename.clone()));
+    }
+}
+
 /// Formats names according to the official Kodi documentation, with `TMDb` ID for better matching.
 /// Movie: /Movie Name (Year) {tmdb=XXXXX}/Movie Name (Year).strm
 /// Series: /Show Name (Year) {tmdb=XXXXX}/Season 01/Show Name S01E01.strm
@@ -437,7 +467,7 @@ fn format_for_kodi(
     tmdb_id: u32,
     separator: &str,
     flat: bool,
-    flat_dedup_paths: &mut HashMap<u32, PathBuf>,
+    flat_dedup_paths: &mut FlatDedupPaths,
 ) -> (PathBuf, String) {
     // Kodi ID format: {tmdb=12345}
     let parts = prepare_filename_parts(strm_item_info, tmdb_id, separator, &format!("{separator}{{tmdb={{}}}}"));
@@ -446,16 +476,17 @@ fn format_for_kodi(
     match strm_item_info.item_type {
         PlaylistItemType::Video | PlaylistItemType::LocalVideo => {
             let folder_name = format!("{}{}", parts.base_name, parts.id_string);
-            let final_filename = parts.base_name;
+            let mut final_filename = parts.base_name;
 
             if flat {
                 if tmdb_id > 0 {
-                    if let Some(path) = flat_dedup_paths.get(&tmdb_id) {
-                        dir_path.clone_from(path);
-                    } else {
-                        dir_path.push(&folder_name);
-                        flat_dedup_paths.insert(tmdb_id, dir_path.clone());
-                    }
+                    claim_flat_movie_folder(
+                        flat_dedup_paths,
+                        tmdb_id,
+                        &folder_name,
+                        &mut dir_path,
+                        &mut final_filename,
+                    );
                 } else {
                     dir_path.push(format!("{folder_name}{separator}[{}]", parts.category));
                 }
@@ -495,7 +526,7 @@ fn format_for_emby(
     tmdb_id: u32,
     separator: &str,
     flat: bool,
-    flat_dedup_paths: &mut HashMap<u32, PathBuf>,
+    flat_dedup_paths: &mut FlatDedupPaths,
 ) -> (PathBuf, String) {
     // Emby ID format: [tmdbid=12345]
     let parts = prepare_filename_parts(strm_item_info, tmdb_id, separator, &format!("{separator}[tmdbid={{}}]"));
@@ -505,16 +536,17 @@ fn format_for_emby(
         PlaylistItemType::Video | PlaylistItemType::LocalVideo => {
             // Emby prefers the ID in the filename for movies, folder optional
             let folder_name = parts.base_name.clone(); // Folder name does not contain the ID usually, but can
-            let final_filename = format!("{}{}", parts.base_name, parts.id_string);
+            let mut final_filename = format!("{}{}", parts.base_name, parts.id_string);
 
             if flat {
                 if tmdb_id > 0 {
-                    if let Some(path) = flat_dedup_paths.get(&tmdb_id) {
-                        dir_path.clone_from(path);
-                    } else {
-                        dir_path.push(&folder_name);
-                        flat_dedup_paths.insert(tmdb_id, dir_path.clone());
-                    }
+                    claim_flat_movie_folder(
+                        flat_dedup_paths,
+                        tmdb_id,
+                        &folder_name,
+                        &mut dir_path,
+                        &mut final_filename,
+                    );
                 } else {
                     dir_path.push(format!("{folder_name}{separator}[{}]", parts.category));
                 }
@@ -556,7 +588,7 @@ fn format_for_jellyfin(
     tmdb_id: u32,
     separator: &str,
     flat: bool,
-    flat_dedup_paths: &mut HashMap<u32, PathBuf>,
+    flat_dedup_paths: &mut FlatDedupPaths,
 ) -> (PathBuf, String) {
     // Jellyfin ID format: [tmdbid-12345]
     let parts = prepare_filename_parts(strm_item_info, tmdb_id, separator, &format!("{separator}[tmdbid-{{}}]"));
@@ -566,16 +598,17 @@ fn format_for_jellyfin(
         PlaylistItemType::Video | PlaylistItemType::LocalVideo => {
             // Jellyfin requirement: file name MUST start with parent folder name to detect versions
             let folder_name = format!("{}{}", parts.base_name, parts.id_string);
-            let final_filename = folder_name.clone();
+            let mut final_filename = folder_name.clone();
 
             if flat {
                 if tmdb_id > 0 {
-                    if let Some(path) = flat_dedup_paths.get(&tmdb_id) {
-                        dir_path.clone_from(path);
-                    } else {
-                        dir_path.push(&folder_name);
-                        flat_dedup_paths.insert(tmdb_id, dir_path.clone());
-                    }
+                    claim_flat_movie_folder(
+                        flat_dedup_paths,
+                        tmdb_id,
+                        &folder_name,
+                        &mut dir_path,
+                        &mut final_filename,
+                    );
                 } else {
                     dir_path.push(format!("{folder_name}{separator}[{}]", parts.category));
                 }
@@ -615,7 +648,7 @@ fn style_based_rename(
     style: StrmExportStyle,
     underscore_whitespace: bool,
     flat: bool,
-    flat_dedup_paths: &mut HashMap<u32, PathBuf>,
+    flat_dedup_paths: &mut FlatDedupPaths,
 ) -> (PathBuf, String) {
     let separator = if underscore_whitespace { "_" } else { " " };
 
@@ -637,7 +670,7 @@ fn prepare_strm_files(new_playlist: &mut [PlaylistGroup], strm_target_output: &S
     let mut collisions: HashSet<PathBuf> = HashSet::new();
     let mut result = Vec::with_capacity(channel_count);
 
-    let mut flat_dedup_paths = HashMap::new();
+    let mut flat_dedup_paths: FlatDedupPaths = HashMap::new();
 
     // first we create the names to identify name collisions
     for pg in new_playlist.iter_mut() {
@@ -1234,20 +1267,25 @@ async fn remove_empty_dirs(root_path: PathBuf) {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_provider_resolve_url, get_credentials_and_server_info, resolve_strm_source_url, strip_tmdb_markers,
-        strm_contains_tmdb_marker, StrmItemInfo,
+        build_provider_resolve_url, get_credentials_and_server_info, prepare_strm_files, resolve_strm_source_url,
+        strip_tmdb_markers, strm_contains_tmdb_marker, StrmFile, StrmItemInfo,
     };
     use crate::{
         model::{
             ApiProxyConfig, ApiProxyServerInfo, AppConfig, Config, ConfigInput, ConfigProvider,
-            MediaToolCapabilities, ProxyUserCredentials, SourcesConfig, TargetUser,
+            MediaToolCapabilities, ProxyUserCredentials, SourcesConfig, StrmTargetFlags, StrmTargetFlagsSet,
+            StrmTargetOutput, TargetUser,
         },
         utils::FileLockManager,
         utils::{decode_provider_resolve_token, ProviderResolveToken, PROVIDER_RESOLVE_ROUTE_PREFIX},
     };
     use arc_swap::{ArcSwap, ArcSwapOption};
     use shared::model::ConfigPaths;
-    use shared::model::{ConfigProviderDto, InputType, PlaylistItemType, ProviderUrlSelectionPolicy, ProxyType};
+    use shared::model::{
+        ConfigProviderDto, InputType, PlaylistGroup, PlaylistItem, PlaylistItemHeader, PlaylistItemType,
+        ProviderUrlSelectionPolicy, ProxyType, StreamProperties, StrmExportStyle, VideoStreamDetailProperties,
+        VideoStreamProperties, XtreamCluster,
+    };
     use std::{collections::HashMap, sync::Arc};
 
     fn make_strm_item(url: &str, input_name: &str) -> StrmItemInfo {
@@ -1441,5 +1479,217 @@ mod tests {
         let result = get_credentials_and_server_info(&app_config, Some("alice"));
 
         assert!(result.is_err());
+    }
+
+    // ---- flat/tmdb multi-version naming -------------------------------------------------
+
+    const VIDEO_1080P: &str = r#"{"codec_name":"h264","width":1920,"height":1080}"#;
+    const VIDEO_720P: &str = r#"{"codec_name":"h264","width":1280,"height":720}"#;
+    const AUDIO_EAC3_51: &str = r#"{"codec_name":"eac3","channels":6}"#;
+
+    fn make_video_pli(
+        title: &str,
+        group: &str,
+        tmdb: u32,
+        virtual_id: u32,
+        video: Option<&str>,
+        audio: Option<&str>,
+    ) -> PlaylistItem {
+        let details = if video.is_some() || audio.is_some() {
+            Some(VideoStreamDetailProperties {
+                video: video.map(Arc::from),
+                audio: audio.map(Arc::from),
+                ..Default::default()
+            })
+        } else {
+            None
+        };
+        let props = VideoStreamProperties {
+            name: Arc::from(title),
+            tmdb: Some(tmdb),
+            details,
+            ..Default::default()
+        };
+
+        PlaylistItem {
+            header: PlaylistItemHeader {
+                title: Arc::from(title),
+                name: Arc::from(title),
+                group: Arc::from(group),
+                virtual_id,
+                item_type: PlaylistItemType::Video,
+                additional_properties: Some(StreamProperties::Video(Box::new(props))),
+                ..Default::default()
+            },
+        }
+    }
+
+    fn strm_output(style: StrmExportStyle, flags: &[StrmTargetFlags]) -> StrmTargetOutput {
+        let mut flag_set = StrmTargetFlagsSet::new();
+        for flag in flags {
+            flag_set.set(*flag);
+        }
+        StrmTargetOutput {
+            directory: String::new(),
+            username: None,
+            style,
+            flags: flag_set,
+            strm_props: None,
+            filter: None,
+            probe_probe_size_bytes: None,
+            probe_analyze_duration: None,
+        }
+    }
+
+    /// The two ways one provider spells the same film in the same category: same tmdb id,
+    /// different titles. Under `flat` they are deduped into a single folder.
+    fn duplicate_listings_of_one_movie() -> Vec<PlaylistGroup> {
+        vec![PlaylistGroup {
+            id: 1,
+            title: Arc::from("EN MOVIES"),
+            channels: vec![
+                make_video_pli(
+                    "400 Bullets [MULTI-SUB] - 2021",
+                    "EN MOVIES",
+                    788_672,
+                    11,
+                    Some(VIDEO_1080P),
+                    Some(AUDIO_EAC3_51),
+                ),
+                make_video_pli(
+                    "400 Bullets -  [Multi Sub] (2021)",
+                    "EN MOVIES",
+                    788_672,
+                    12,
+                    Some(VIDEO_720P),
+                    Some(AUDIO_EAC3_51),
+                ),
+            ],
+            xtream_cluster: XtreamCluster::Video,
+        }]
+    }
+
+    /// Port of Jellyfin's `Emby.Naming.Video.VideoListResolver.IsEligibleForMultiVersion`:
+    /// the file name must start with the folder name, and the remainder must be empty or
+    /// start with `-`, `_`, `.`, or a `[bracketed]` token. Any file in the folder failing
+    /// this makes Jellyfin abandon version grouping for the *whole* folder.
+    fn jellyfin_multi_version_eligible(folder_name: &str, file_stem: &str) -> bool {
+        if !file_stem.to_lowercase().starts_with(&folder_name.to_lowercase()) {
+            return false;
+        }
+        let rest = file_stem[folder_name.len()..].trim();
+        rest.is_empty()
+            || rest.starts_with(['-', '_', '.'])
+            || (rest.starts_with('[') && rest[1..].contains(']'))
+    }
+
+    fn assert_single_shared_folder(files: &[StrmFile]) -> String {
+        assert_eq!(files.len(), 2, "both provider listings must be exported");
+        assert_eq!(files[0].dir_path, files[1].dir_path, "same tmdb id must dedup into one folder");
+        files[0].dir_path.file_name().unwrap().to_string_lossy().to_string()
+    }
+
+    #[test]
+    fn jellyfin_flat_names_every_version_after_the_folder_it_lands_in() {
+        let mut playlist = duplicate_listings_of_one_movie();
+        let output =
+            strm_output(StrmExportStyle::Jellyfin, &[StrmTargetFlags::Flat, StrmTargetFlags::AddQualityToFilename]);
+
+        let files = prepare_strm_files(&mut playlist, &output);
+        let folder_name = assert_single_shared_folder(&files);
+
+        for file in &files {
+            assert!(
+                jellyfin_multi_version_eligible(&folder_name, &file.file_name),
+                "Jellyfin will show this as a separate movie instead of an alternate version:\n  \
+                 folder: {folder_name}\n  file:   {}",
+                file.file_name
+            );
+        }
+        assert_ne!(files[0].file_name, files[1].file_name, "versions must not overwrite each other");
+    }
+
+    #[test]
+    fn emby_flat_names_every_version_after_the_folder_it_lands_in() {
+        let mut playlist = duplicate_listings_of_one_movie();
+        let output =
+            strm_output(StrmExportStyle::Emby, &[StrmTargetFlags::Flat, StrmTargetFlags::AddQualityToFilename]);
+
+        let files = prepare_strm_files(&mut playlist, &output);
+        let folder_name = assert_single_shared_folder(&files);
+
+        for file in &files {
+            assert!(
+                jellyfin_multi_version_eligible(&folder_name, &file.file_name),
+                "folder: {folder_name}\n  file:   {}",
+                file.file_name
+            );
+        }
+        assert_ne!(files[0].file_name, files[1].file_name);
+    }
+
+    #[test]
+    fn kodi_flat_names_every_version_after_the_folder_it_lands_in() {
+        let mut playlist = duplicate_listings_of_one_movie();
+        let output =
+            strm_output(StrmExportStyle::Kodi, &[StrmTargetFlags::Flat, StrmTargetFlags::AddQualityToFilename]);
+
+        let files = prepare_strm_files(&mut playlist, &output);
+        assert_single_shared_folder(&files);
+
+        // Kodi keeps the tmdb marker out of the file name, so compare against the shared base:
+        // both versions must be named after the same movie, not after their own provider title.
+        let base = strip_tmdb_markers(&files[0].dir_path.file_name().unwrap().to_string_lossy()).trim().to_string();
+        for file in &files {
+            assert!(file.file_name.starts_with(&base), "base: {base}\n  file: {}", file.file_name);
+        }
+        assert_ne!(files[0].file_name, files[1].file_name);
+    }
+
+    /// When both copies carry the same quality the names collide; the existing collision
+    /// handler must disambiguate them with `[Version id#N]` while keeping the shared base.
+    #[test]
+    fn jellyfin_flat_versions_with_identical_quality_get_a_version_label() {
+        let mut playlist = duplicate_listings_of_one_movie();
+        // Make the second listing report exactly the same streams as the first.
+        playlist[0].channels[1] = make_video_pli(
+            "400 Bullets -  [Multi Sub] (2021)",
+            "EN MOVIES",
+            788_672,
+            12,
+            Some(VIDEO_1080P),
+            Some(AUDIO_EAC3_51),
+        );
+        let output =
+            strm_output(StrmExportStyle::Jellyfin, &[StrmTargetFlags::Flat, StrmTargetFlags::AddQualityToFilename]);
+
+        let files = prepare_strm_files(&mut playlist, &output);
+        let folder_name = assert_single_shared_folder(&files);
+
+        for file in &files {
+            assert!(
+                jellyfin_multi_version_eligible(&folder_name, &file.file_name),
+                "folder: {folder_name}\n  file:   {}",
+                file.file_name
+            );
+            assert!(file.file_name.contains("[Version id#"), "expected a version label in {}", file.file_name);
+        }
+        assert_ne!(files[0].file_name, files[1].file_name, "versions must not overwrite each other");
+    }
+
+    /// Without `flat` there is no folder reuse: each listing keeps its own folder and name.
+    #[test]
+    fn non_flat_keeps_each_listing_in_its_own_folder() {
+        let mut playlist = duplicate_listings_of_one_movie();
+        let output = strm_output(StrmExportStyle::Jellyfin, &[StrmTargetFlags::AddQualityToFilename]);
+
+        let files = prepare_strm_files(&mut playlist, &output);
+
+        assert_eq!(files.len(), 2);
+        assert_ne!(files[0].dir_path, files[1].dir_path, "non-flat must not merge folders");
+        for file in &files {
+            let folder_name = file.dir_path.file_name().unwrap().to_string_lossy().to_string();
+            assert!(jellyfin_multi_version_eligible(&folder_name, &file.file_name));
+        }
     }
 }

--- a/backend/src/repository/strm_repository.rs
+++ b/backend/src/repository/strm_repository.rs
@@ -429,6 +429,10 @@ fn prepare_filename_parts(
     }
 }
 
+/// Longest file stem the writer keeps; `.strm` is appended on top, staying inside the 255-byte
+/// name limit common to ext4/APFS/NTFS.
+const MAX_STRM_FILE_STEM_LEN: usize = 250;
+
 /// Movie folders already claimed in `flat` mode, keyed by `TMDb` id. Holds the folder itself and
 /// the file name the first item put in it.
 type FlatDedupPaths = HashMap<u32, (PathBuf, String)>;
@@ -618,8 +622,8 @@ fn format_for_jellyfin(
                     // unique. The file name has to carry it too, or it no longer starts with the
                     // name of the folder it sits in.
                     let folder_with_category = format!("{folder_name}{separator}[{}]", parts.category);
-                    final_filename.clone_from(&folder_with_category);
-                    dir_path.push(folder_with_category);
+                    dir_path.push(&folder_with_category);
+                    final_filename = folder_with_category;
                 }
             } else {
                 dir_path.push(parts.category);
@@ -681,6 +685,10 @@ fn prepare_strm_files(new_playlist: &mut [PlaylistGroup], strm_target_output: &S
 
     let mut flat_dedup_paths: FlatDedupPaths = HashMap::new();
 
+    let underscore_whitespace = strm_target_output.flags.contains(StrmTargetFlags::UnderscoreWhitespace);
+    let separator = if underscore_whitespace { "_" } else { " " };
+    let flat = strm_target_output.flags.contains(StrmTargetFlags::Flat);
+
     // first we create the names to identify name collisions
     for pg in new_playlist.iter_mut() {
         for pli in pg.channels.iter_mut().filter(|c| filter_strm_item(c)) {
@@ -690,14 +698,12 @@ fn prepare_strm_files(new_playlist: &mut [PlaylistGroup], strm_target_output: &S
                 &strm_item_info,
                 pli.get_tmdb_id(),
                 strm_target_output.style,
-                strm_target_output.flags.contains(StrmTargetFlags::UnderscoreWhitespace),
-                strm_target_output.flags.contains(StrmTargetFlags::Flat),
+                underscore_whitespace,
+                flat,
                 &mut flat_dedup_paths,
             );
 
             // Conditionally generate the quality string based on the new config flag
-            let separator =
-                if strm_target_output.flags.contains(StrmTargetFlags::UnderscoreWhitespace) { "_" } else { " " };
             let quality_string = get_quality(strm_target_output, pli, separator);
 
             // No category suffix: in `flat` mode the category used to be appended to guard against
@@ -705,16 +711,14 @@ fn prepare_strm_files(new_playlist: &mut [PlaylistGroup], strm_target_output: &S
             // (same TMDB folder, same quality string), and the collision pass below separates those
             // with `[Version id#N]`. Keeping the category here would only pollute the name that
             // Jellyfin/Emby show as the *version label*, which should read as the quality alone.
-            let final_filename = format!("{strm_file_name}{quality_string}");
-            let filename = Arc::new(final_filename);
+            let filename = Arc::new(format!("{strm_file_name}{quality_string}"));
 
             // Construct the full relative path for collision checking
             let full_relative_path = dir_path.join(filename.as_str());
 
-            if all_filenames.contains(&full_relative_path) {
-                collisions.insert(full_relative_path.clone());
+            if !all_filenames.insert(full_relative_path.clone()) {
+                collisions.insert(full_relative_path);
             }
-            all_filenames.insert(full_relative_path);
             result.push(StrmFile { file_name: filename, dir_path, strm_info: strm_item_info });
         }
     }
@@ -722,24 +726,22 @@ fn prepare_strm_files(new_playlist: &mut [PlaylistGroup], strm_target_output: &S
     if !collisions.is_empty() {
         // This separator is specifically for the multi-version naming convention.
         let version_separator = " ";
-        let separator =
-            if strm_target_output.flags.contains(StrmTargetFlags::UnderscoreWhitespace) { "_" } else { " " };
 
         for s in &mut result {
-            {
-                let full_relative_path = s.dir_path.join(s.file_name.as_str());
-                if collisions.contains(&full_relative_path) {
-                    // Create a descriptive and unique identifier for this version.
-                    let version_label = format!("Version{}id#{}", separator, s.strm_info.virtual_id);
+            let full_relative_path = s.dir_path.join(s.file_name.as_str());
+            if collisions.contains(&full_relative_path) {
+                // Create a descriptive and unique identifier for this version.
+                let version_label = format!("Version{}id#{}", separator, s.strm_info.virtual_id);
+                let suffix = format!("{version_separator}[{version_label}]");
 
-                    // The base filename is the part that is identical for all versions.
-                    let base_filename = &s.file_name;
+                // The version label is the ONLY thing telling these files apart, so it has to
+                // survive the truncation the writer applies. Trim the shared base instead --
+                // truncating the tail here would collapse both versions onto one name, and the
+                // second would silently overwrite the first.
+                let budget = MAX_STRM_FILE_STEM_LEN.saturating_sub(suffix.chars().count());
+                let base_filename = truncate_string(&s.file_name, budget);
 
-                    // Apply the specific multi-version naming convention for the selected style.
-                    let new_filename = format!("{base_filename}{version_separator}[{version_label}]");
-
-                    s.file_name = Arc::new(new_filename);
-                }
+                s.file_name = Arc::new(format!("{base_filename}{suffix}"));
             }
         }
     }
@@ -852,7 +854,8 @@ pub async fn write_strm_playlist(
     for strm_file in strm_files {
         // file paths
         let output_path = truncate_filename(&root_path.join(&strm_file.dir_path), 255);
-        let file_path = output_path.join(format!("{}.strm", truncate_string(&strm_file.file_name, 250)));
+        let file_path =
+            output_path.join(format!("{}.strm", truncate_string(&strm_file.file_name, MAX_STRM_FILE_STEM_LEN)));
 
         let relative_file_path = get_relative_path_str(&file_path, &root_path);
 
@@ -1697,6 +1700,36 @@ mod tests {
         }
         assert!(files.iter().any(|f| f.file_name.ends_with("- [1080p FHD H.264 EAC3 5.1]")));
         assert!(files.iter().any(|f| f.file_name.ends_with("- [720p HD H.264 EAC3 5.1]")));
+    }
+
+    /// The writer truncates the file stem, so for two versions that differ ONLY by their version
+    /// label the label has to survive: otherwise both truncate to the same name and one silently
+    /// overwrites the other.
+    #[test]
+    fn colliding_versions_stay_distinct_after_the_writer_truncates_the_name() {
+        let long_title = format!("{} (2021)", "A".repeat(300));
+        let mut playlist = vec![PlaylistGroup {
+            id: 1,
+            title: Arc::from("EN MOVIES"),
+            channels: vec![
+                make_video_pli(&long_title, "EN MOVIES", 555, 31, Some(VIDEO_1080P), Some(AUDIO_EAC3_51)),
+                make_video_pli(&long_title, "EN MOVIES", 555, 32, Some(VIDEO_1080P), Some(AUDIO_EAC3_51)),
+            ],
+            xtream_cluster: XtreamCluster::Video,
+        }];
+        let output =
+            strm_output(StrmExportStyle::Jellyfin, &[StrmTargetFlags::Flat, StrmTargetFlags::AddQualityToFilename]);
+
+        let files = prepare_strm_files(&mut playlist, &output);
+
+        // Names as the writer will actually store them.
+        let stored: Vec<String> =
+            files.iter().map(|f| shared::utils::truncate_string(&f.file_name, super::MAX_STRM_FILE_STEM_LEN)).collect();
+
+        assert!(stored.iter().all(|n| n.chars().count() <= super::MAX_STRM_FILE_STEM_LEN));
+        assert!(stored[0].ends_with("[Version id#31]"), "version label was truncated away: {}", stored[0]);
+        assert!(stored[1].ends_with("[Version id#32]"), "version label was truncated away: {}", stored[1]);
+        assert_ne!(stored[0], stored[1], "one version would silently overwrite the other on disk");
     }
 
     /// Items without a TMDB id cannot share a deduplicated folder, so they keep the category in the

--- a/backend/src/repository/strm_repository.rs
+++ b/backend/src/repository/strm_repository.rs
@@ -548,7 +548,11 @@ fn format_for_emby(
                         &mut final_filename,
                     );
                 } else {
-                    dir_path.push(format!("{folder_name}{separator}[{}]", parts.category));
+                    // See format_for_jellyfin: without a TMDB id the category keeps the folder
+                    // unique, so the file name must carry it as well.
+                    let folder_with_category = format!("{folder_name}{separator}[{}]", parts.category);
+                    final_filename = format!("{folder_with_category}{}", parts.id_string);
+                    dir_path.push(folder_with_category);
                 }
             } else {
                 dir_path.push(parts.category);
@@ -610,7 +614,12 @@ fn format_for_jellyfin(
                         &mut final_filename,
                     );
                 } else {
-                    dir_path.push(format!("{folder_name}{separator}[{}]", parts.category));
+                    // No TMDB id to deduplicate on, so the category is what keeps this folder
+                    // unique. The file name has to carry it too, or it no longer starts with the
+                    // name of the folder it sits in.
+                    let folder_with_category = format!("{folder_name}{separator}[{}]", parts.category);
+                    final_filename.clone_from(&folder_with_category);
+                    dir_path.push(folder_with_category);
                 }
             } else {
                 dir_path.push(parts.category);
@@ -691,18 +700,12 @@ fn prepare_strm_files(new_playlist: &mut [PlaylistGroup], strm_target_output: &S
                 if strm_target_output.flags.contains(StrmTargetFlags::UnderscoreWhitespace) { "_" } else { " " };
             let quality_string = get_quality(strm_target_output, pli, separator);
 
-            // Add category suffix for flat movie structure to avoid collisions
-            let category_suffix = if strm_target_output.flags.contains(StrmTargetFlags::Flat)
-                && pli.get_tmdb_id().is_some()
-                && pli.header.item_type == PlaylistItemType::Video
-            {
-                let cat = sanitize_for_filename(&strm_item_info.group, false);
-                format!("{separator}[{cat}]")
-            } else {
-                String::new()
-            };
-
-            let final_filename = format!("{strm_file_name}{quality_string}{category_suffix}");
+            // No category suffix: in `flat` mode the category used to be appended to guard against
+            // collisions, but the only files that can now collide are versions of the same movie
+            // (same TMDB folder, same quality string), and the collision pass below separates those
+            // with `[Version id#N]`. Keeping the category here would only pollute the name that
+            // Jellyfin/Emby show as the *version label*, which should read as the quality alone.
+            let final_filename = format!("{strm_file_name}{quality_string}");
             let filename = Arc::new(final_filename);
 
             // Construct the full relative path for collision checking
@@ -1675,6 +1678,44 @@ mod tests {
             assert!(file.file_name.contains("[Version id#"), "expected a version label in {}", file.file_name);
         }
         assert_ne!(files[0].file_name, files[1].file_name, "versions must not overwrite each other");
+    }
+
+    /// Jellyfin/Emby show whatever follows the folder name as the *version label*, so in `flat`
+    /// mode it must be the quality string alone — not the provider's category.
+    #[test]
+    fn flat_version_label_is_the_quality_alone() {
+        let mut playlist = duplicate_listings_of_one_movie();
+        let output =
+            strm_output(StrmExportStyle::Jellyfin, &[StrmTargetFlags::Flat, StrmTargetFlags::AddQualityToFilename]);
+
+        let files = prepare_strm_files(&mut playlist, &output);
+        let folder_name = assert_single_shared_folder(&files);
+
+        for file in &files {
+            let label = file.file_name[folder_name.len()..].trim();
+            assert!(!label.contains("EN MOVIES"), "category leaked into the version label: {label}");
+        }
+        assert!(files.iter().any(|f| f.file_name.ends_with("- [1080p FHD H.264 EAC3 5.1]")));
+        assert!(files.iter().any(|f| f.file_name.ends_with("- [720p HD H.264 EAC3 5.1]")));
+    }
+
+    /// Items without a TMDB id cannot share a deduplicated folder, so they keep the category in the
+    /// *directory* name to stay unique.
+    #[test]
+    fn flat_without_tmdb_keeps_the_category_in_the_directory() {
+        let mut playlist = vec![PlaylistGroup {
+            id: 1,
+            title: Arc::from("EN MOVIES"),
+            channels: vec![make_video_pli("Some Obscure Film (1999)", "EN MOVIES", 0, 21, Some(VIDEO_720P), None)],
+            xtream_cluster: XtreamCluster::Video,
+        }];
+        let output = strm_output(StrmExportStyle::Jellyfin, &[StrmTargetFlags::Flat]);
+
+        let files = prepare_strm_files(&mut playlist, &output);
+
+        let dir = files[0].dir_path.to_string_lossy();
+        assert!(dir.contains("[EN MOVIES]"), "expected the category in the directory name, got {dir}");
+        assert!(files[0].file_name.starts_with(dir.as_ref()), "file must still start with its folder name");
     }
 
     /// Without `flat` there is no folder reuse: each listing keeps its own folder and name.

--- a/shared/src/model/media_properties.rs
+++ b/shared/src/model/media_properties.rs
@@ -27,21 +27,21 @@ impl VideoResolution {
         // Thresholds sit well below each tier's nominal size so that cropped or slightly
         // non-standard encodes still land in the right bucket.
         let by_width = width.map(|w| match w {
-            _ if w >= 7000 => Self::P4320,
-            _ if w >= 3500 => Self::P2160,
-            _ if w >= 2400 => Self::P1440,
-            _ if w >= 1700 => Self::P1080,
-            _ if w >= 1200 => Self::P720,
-            _ => Self::SD,
+            7000.. => Self::P4320,
+            3500..7000 => Self::P2160,
+            2400..3500 => Self::P1440,
+            1700..2400 => Self::P1080,
+            1200..1700 => Self::P720,
+            ..1200 => Self::SD,
         });
 
         let by_height = height.map(|h| match h {
-            _ if h >= 4300 => Self::P4320,
-            _ if h >= 2100 => Self::P2160,
-            _ if h >= 1400 => Self::P1440,
-            _ if h >= 1000 => Self::P1080,
-            _ if h >= 700 => Self::P720,
-            _ => Self::SD,
+            4300.. => Self::P4320,
+            2100..4300 => Self::P2160,
+            1400..2100 => Self::P1440,
+            1000..1400 => Self::P1080,
+            700..1000 => Self::P720,
+            ..700 => Self::SD,
         });
 
         by_width.max(by_height).unwrap_or_default()

--- a/shared/src/model/media_properties.rs
+++ b/shared/src/model/media_properties.rs
@@ -3,7 +3,7 @@ use serde_json::{Map, Value};
 use std::fmt;
 
 // Enum for Video Resolution
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Default)]
 pub enum VideoResolution {
     #[default]
     Unknown,
@@ -13,6 +13,39 @@ pub enum VideoResolution {
     P1440,
     P2160, // 4K
     P4320, // 8K
+}
+
+impl VideoResolution {
+    /// Classifies a frame by the tier its *widest* dimension reaches.
+    ///
+    /// A tier is named after the height of its 16:9 frame, but wider aspect ratios keep the full
+    /// raster width and encode fewer active lines: a 2.40:1 scope film mastered at 1080p is
+    /// 1920x796. Going by height alone demotes it to 720p, so we classify both axes and keep the
+    /// higher tier. Height still decides on its own when the width is unknown, and it also covers
+    /// anamorphic frames that are narrow for their tier (1440x1080).
+    fn from_dimensions(width: Option<u64>, height: Option<u64>) -> Self {
+        // Thresholds sit well below each tier's nominal size so that cropped or slightly
+        // non-standard encodes still land in the right bucket.
+        let by_width = width.map(|w| match w {
+            _ if w >= 7000 => Self::P4320,
+            _ if w >= 3500 => Self::P2160,
+            _ if w >= 2400 => Self::P1440,
+            _ if w >= 1700 => Self::P1080,
+            _ if w >= 1200 => Self::P720,
+            _ => Self::SD,
+        });
+
+        let by_height = height.map(|h| match h {
+            _ if h >= 4300 => Self::P4320,
+            _ if h >= 2100 => Self::P2160,
+            _ if h >= 1400 => Self::P1440,
+            _ if h >= 1000 => Self::P1080,
+            _ if h >= 700 => Self::P720,
+            _ => Self::SD,
+        });
+
+        by_width.max(by_height).unwrap_or_default()
+    }
 }
 
 impl fmt::Display for VideoResolution {
@@ -225,18 +258,10 @@ impl MediaQuality {
     ) -> Option<(VideoResolution, VideoCodec, VideoDynamicRange, VideoBitDepth)> {
         let video_info = video.and_then(|v| serde_json::from_str::<Map<String, Value>>(v).ok())?;
 
-        // 1. Classify video resolution from height
-        let resolution = get_value(&video_info, &["height", "coded_height"]).and_then(|v| v.as_u64()).map_or(
-            VideoResolution::default(),
-            |h| match h {
-                _ if h >= 4300 => VideoResolution::P4320,
-                _ if h >= 2100 => VideoResolution::P2160,
-                _ if h >= 1400 => VideoResolution::P1440,
-                _ if h >= 1000 => VideoResolution::P1080,
-                _ if h >= 700 => VideoResolution::P720,
-                _ => VideoResolution::SD,
-            },
-        );
+        // 1. Classify video resolution from the frame dimensions
+        let width = get_value(&video_info, &["width", "coded_width"]).and_then(|v| v.as_u64());
+        let height = get_value(&video_info, &["height", "coded_height"]).and_then(|v| v.as_u64());
+        let resolution = VideoResolution::from_dimensions(width, height);
 
         // 2. Classify video codec
         let video_codec = get_value(&video_info, &["codec_name"])
@@ -338,4 +363,54 @@ fn get_value(obj: &Map<String, Value>, fields: &[&str]) -> Option<Value> {
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MediaQuality, VideoResolution};
+
+    fn resolution_of(width: u32, height: u32) -> VideoResolution {
+        let video = format!(r#"{{"codec_name":"h264","width":{width},"height":{height}}}"#);
+        MediaQuality::from_ffprobe_info(None, Some(&video)).unwrap().resolution
+    }
+
+    #[test]
+    fn resolution_is_classified_from_the_full_frame_not_just_its_height() {
+        // Letterboxed scope (2.35:1 / 2.40:1) releases keep the full raster width but encode
+        // fewer active lines. Classifying on height alone demotes them a whole tier.
+        let cases = [
+            // (width, height, expected)
+            (1920, 1080, VideoResolution::P1080), // 16:9 FHD
+            (1920, 816, VideoResolution::P1080),  // 2.35:1 FHD
+            (1920, 796, VideoResolution::P1080),  // 2.40:1 FHD
+            (1440, 1080, VideoResolution::P1080), // anamorphic FHD
+            (1280, 720, VideoResolution::P720),   // 16:9 HD
+            (1280, 536, VideoResolution::P720),   // 2.39:1 HD
+            (3840, 2160, VideoResolution::P2160), // 16:9 UHD
+            (3840, 1600, VideoResolution::P2160), // 2.40:1 UHD
+            (2560, 1440, VideoResolution::P1440),
+            (7680, 4320, VideoResolution::P4320),
+            (720, 576, VideoResolution::SD), // PAL
+            (1024, 576, VideoResolution::SD),
+        ];
+
+        for (width, height, expected) in cases {
+            assert_eq!(resolution_of(width, height), expected, "{width}x{height} misclassified");
+        }
+    }
+
+    #[test]
+    fn resolution_falls_back_to_height_when_width_is_absent() {
+        let video = r#"{"codec_name":"h264","height":1080}"#;
+        let quality = MediaQuality::from_ffprobe_info(None, Some(video)).unwrap();
+        assert_eq!(quality.resolution, VideoResolution::P1080);
+    }
+
+    #[test]
+    fn scope_film_is_labelled_1080p_in_the_filename() {
+        let video = r#"{"codec_name":"h264","width":1920,"height":796}"#;
+        let audio = r#"{"codec_name":"eac3","channels":6}"#;
+        let quality = MediaQuality::from_ffprobe_info(Some(audio), Some(video)).unwrap();
+        assert_eq!(quality.format_for_filename(" "), "1080p FHD H.264 EAC3 5.1");
+    }
 }


### PR DESCRIPTION
### Bug

With `flat: true` the movie folder is deduplicated by TMDB id, but each file is still named from **its own** provider title. Providers routinely list the same film twice with the tag written two ways (`X [MULTI-SUB] - 2021` vs `X - 2021 [Multi Sub]`), so listing #2 lands in listing #1's folder under a name that does not start with the folder name — breaking the rule the comment three lines above it already states.

Jellyfin's `Emby.Naming.Video.VideoListResolver.IsEligibleForMultiVersion` requires the file name to start with the folder name (remainder empty, or starting `-` `_` `.` or `[...]`), and `GetVideosGroupedByVersion` returns the folder's videos **ungrouped on the first ineligible file** — so one bad name turns *every* file in that folder into a separate movie. `format_for_emby` and `format_for_kodi` share the defect.

### Fix

The first item to claim a flat/TMDB folder now also fixes the base name for everything that follows it into that folder. Versions are separated by machinery that already exists: the `add_quality_to_filename` suffix, or the `[Version id#N]` collision suffix when qualities tie.

Verified in Jellyfin with a scratch library — old names: **2 movies**; new names: **1 movie, 2 versions**, labelled `[1080p FHD H.264 EAC3 5.1]` / `[720p HD H.264 AAC 2.0]`. On my provider this pattern accounts for 364 and 524 duplicate pairs in two STRM libraries.

Two related fixes ride along:

- **The category no longer goes in flat movie file names.** It was a collision guard, but the only files that can now collide are versions of one movie, which `[Version id#N]` already separates — while Jellyfin/Emby render whatever follows the folder name as the **version label**, so the category was leaking into the version picker. Items with no TMDB id keep the category (it is what makes their folder unique) and now carry it in the file name too, so those names finally start with their folder name — they previously did not.
- **The version label survives truncation.** It was appended last and the writer truncates the stem to 250 chars, so for a long title the label was cut off, both versions resolved to the same path, and one **silently overwrote** the other.

### Compatibility

Renames files in `flat` STRM trees; with `cleanup: true` the old names are removed on the next update. Media servers key items by path, so watch state for renamed items resets. Not gated behind a flag: the old names violate the documented requirement the code itself asserts, and nothing can meaningfully depend on them.

14 tests in `strm_repository.rs`; `cargo test --workspace` green, clippy clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed STRM `flat` mode to prevent duplicate outputs and keep shared folder/filename stems consistent across reused provider folders.
  - Improved multi-version grouping so alternate versions display correctly in Jellyfin, Emby, and Kodi.
  - Corrected `flat` mode version labeling so provider categories no longer affect the filename’s version portion.
  - Improved collision handling so long filenames no longer disrupt or overwrite `[Version id#N]` labels (trims only the shared base).
  - Enhanced resolution-tier quality labeling by deriving the tier from the higher applicable width/height classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->