### PR TITLE
Added new EPG tags: Category, new, live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,15 @@
   assignment, Smart Match support, configurable four-hour dummy gap filling, bounded atomic cache downloads, and
   aggregated warnings for recurring events that are detected but not expanded yet.
 
+- **Extended EPG Programme Metadata**:
+  - XMLTV imports now preserve all programme `<category>` elements, including optional `lang` attributes, as well as
+    the presence of `<live/>` and `<new/>` tags.
+  - The metadata is retained while merging EPG sources, persisted for M3U and Xtream targets, and included in served
+    XMLTV output and Web UI EPG previews.
+  - ICS `CATEGORIES` properties are converted into individual XMLTV categories, including repeated properties and
+    escaped commas; ICS events do not infer `live` or `new` without an unambiguous source value.
+  - Existing persisted EPG data remains readable and defaults the new metadata to empty categories and unset flags.
+
 - **Trakt Charts**: Xtream Trakt integration can now build virtual categories from public Trakt charts via `trakt.charts[]`.
   - MVP supports `movies/shows` with `trending` and `popular`.
   - User-owned Trakt lists remain configured separately under `trakt.lists[]`.

--- a/backend/src/api/endpoints/xmltv_api.rs
+++ b/backend/src/api/endpoints/xmltv_api.rs
@@ -401,7 +401,6 @@ async fn serve_epg_with_rewrites(
 
                     if let Err(err) = write_programme_classification_tags(&mut writer, programme).await {
                         error!("EPG classification tags write failed: {err}");
-                        return;
                     }
 
                     let _ = writer.write_event_async(Event::End(BytesEnd::new("programme"))).await;

--- a/backend/src/api/endpoints/xmltv_api.rs
+++ b/backend/src/api/endpoints/xmltv_api.rs
@@ -35,11 +35,11 @@ use shared::{
     utils::{concat_path, concat_path_leading_slash, obfuscate_text, Internable},
 };
 use std::{collections::HashMap, path::{Path, PathBuf}, sync::Arc};
-use tokio::{io::AsyncWriteExt, sync::mpsc, task};
+use tokio::{io::{AsyncWrite, AsyncWriteExt}, sync::mpsc, task};
 use tokio_stream::StreamExt;
 use tokio_util::io::ReaderStream;
 use crate::auth::resolve_api_user_context;
-use crate::model::ApiProxyServerInfo;
+use crate::model::{ApiProxyServerInfo, EPG_ATTRIB_LANG, EPG_TAG_CATEGORY, EPG_TAG_LIVE, EPG_TAG_NEW};
 
 pub fn get_empty_epg_response() -> axum::response::Response {
     try_unwrap_body!(axum::response::Response::builder()
@@ -197,6 +197,31 @@ macro_rules! continue_on_err {
             continue;
         }
     };
+}
+
+async fn write_programme_classification_tags<W: AsyncWrite + Unpin>(
+    writer: &mut quick_xml::Writer<W>,
+    programme: &EpgProgramme,
+) -> Result<(), quick_xml::Error> {
+    for category in &programme.categories {
+        let mut elem = BytesStart::new(EPG_TAG_CATEGORY);
+        if let Some(lang) = &category.lang {
+            elem.push_attribute((EPG_ATTRIB_LANG, lang.as_ref()));
+        }
+        writer.write_event_async(Event::Start(elem)).await?;
+        writer
+            .write_event_async(Event::Text(BytesText::new(category.value.as_ref())))
+            .await?;
+        writer.write_event_async(Event::End(BytesEnd::new(EPG_TAG_CATEGORY))).await?;
+    }
+
+    if programme.is_live {
+        writer.write_event_async(Event::Empty(BytesStart::new(EPG_TAG_LIVE))).await?;
+    }
+    if programme.is_new {
+        writer.write_event_async(Event::Empty(BytesStart::new(EPG_TAG_NEW))).await?;
+    }
+    Ok(())
 }
 
 #[allow(clippy::too_many_lines)]
@@ -372,6 +397,11 @@ async fn serve_epg_with_rewrites(
                         continue_on_err!(writer.write_event_async(Event::Start(elem)).await);
                         continue_on_err!(writer.write_event_async(Event::Text(BytesText::new(desc))).await);
                         continue_on_err!(writer.write_event_async(Event::End(BytesEnd::new("desc"))).await);
+                    }
+
+                    if let Err(err) = write_programme_classification_tags(&mut writer, programme).await {
+                        error!("EPG classification tags write failed: {err}");
+                        return;
                     }
 
                     let _ = writer.write_event_async(Event::End(BytesEnd::new("programme"))).await;
@@ -886,6 +916,7 @@ mod tests {
         serve_stream_epg,
         stream_epg_api,
         stream_epg_programmes_for_channel,
+        write_programme_classification_tags,
         MAX_STREAM_EPG_CHANNEL_ID_BYTES,
         MAX_STREAM_EPG_ITEMS,
     };
@@ -905,13 +936,41 @@ mod tests {
     use shared::{
         foundation::Filter,
         model::{
-            ConfigTargetOptions, EpgChannel, EpgOutputOptions, EpgProgramme, ProcessingOrder, StreamEpgItemRequest,
-            StreamEpgRequest, TargetType,
+            ConfigTargetOptions, EpgCategory, EpgChannel, EpgOutputOptions, EpgProgramme, ProcessingOrder,
+            StreamEpgItemRequest, StreamEpgRequest, TargetType,
         },
         utils::{concat_path, obfuscate_text, Internable},
     };
-    use std::{collections::HashMap, fs, sync::Arc};
+    use std::{
+        collections::HashMap,
+        fs,
+        io,
+        pin::Pin,
+        sync::Arc,
+        task::{Context, Poll},
+    };
     use tempfile::tempdir;
+    use tokio::io::AsyncWrite;
+
+    struct ErroringWriter;
+
+    impl AsyncWrite for ErroringWriter {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &[u8],
+        ) -> Poll<Result<usize, io::Error>> {
+            Poll::Ready(Err(io::Error::new(io::ErrorKind::ConnectionReset, "synthetic write failure")))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+            Poll::Ready(Ok(()))
+        }
+    }
 
     fn test_target_with_xtream_and_m3u() -> ConfigTarget {
         ConfigTarget {
@@ -1031,6 +1090,7 @@ mod tests {
                 "DTEND:20300310T160000Z\r\n",
                 "SUMMARY:Formula 1 Grand Prix\r\n",
                 "DESCRIPTION:Imported calendar programme\r\n",
+                "CATEGORIES:Motorsport,Live Event\r\n",
                 "END:VEVENT\r\n",
                 "END:VCALENDAR\r\n",
             ),
@@ -1081,6 +1141,10 @@ mod tests {
         assert!(xml.contains(r#"channel="f1.calendar""#));
         assert!(xml.contains("<title>Formula 1 Grand Prix</title>"));
         assert!(xml.contains("<desc>Imported calendar programme</desc>"));
+        assert!(xml.contains("<category>Motorsport</category>"));
+        assert!(xml.contains("<category>Live Event</category>"));
+        assert!(!xml.contains("<live"));
+        assert!(!xml.contains("<new"));
     }
 
     #[test]
@@ -1388,20 +1452,27 @@ mod tests {
     async fn xmltv_output_uses_canonical_channel_ids_and_only_lowercases_display_names() {
         let dir = tempdir().expect("temp dir");
         let epg_path = dir.path().join("epg.db");
+        let mut programme = EpgProgramme::new_all(
+            100,
+            200,
+            "source.MixedCase".intern(),
+            Some("News & Updates".intern()),
+            Some("Keep <Case>".intern()),
+            None,
+        );
+        programme.categories = vec![
+            EpgCategory { value: "News & Analysis".intern(), lang: Some("en".intern()) },
+            EpgCategory { value: "Sports".intern(), lang: None },
+        ];
+        programme.is_live = true;
+        programme.is_new = true;
         write_test_epg_db(
             &epg_path,
             EpgChannel {
                 id: "example.channel".intern(),
                 title: Some("CAFÉ NETWORK & <HD>".intern()),
                 icon: None,
-                programmes: vec![EpgProgramme::new_all(
-                    100,
-                    200,
-                    "source.MixedCase".intern(),
-                    Some("News & Updates".intern()),
-                    Some("Keep <Case>".intern()),
-                    None,
-                )],
+                programmes: vec![programme],
             },
         );
         let app_state = test_app_state();
@@ -1423,6 +1494,31 @@ mod tests {
         assert!(xml.contains("<title>News &amp; Updates</title>"));
         assert!(xml.contains("<desc>Keep &lt;Case&gt;</desc>"));
         assert!(!xml.contains("<title>news &amp; updates</title>"));
+        assert!(xml.contains(r#"<category lang="en">News &amp; Analysis</category>"#));
+        assert!(xml.contains("<category>Sports</category>"));
+        assert!(xml.contains("<live/>"));
+        assert!(xml.contains("<new/>"));
+
+        let title_pos = xml.find("<title>News").expect("title position");
+        let desc_pos = xml.find("<desc>Keep").expect("desc position");
+        let first_category_pos = xml.find("<category lang=\"en\">News").expect("first category position");
+        let second_category_pos = xml.find("<category>Sports").expect("second category position");
+        let live_pos = xml.find("<live/>").expect("live position");
+        let new_pos = xml.find("<new/>").expect("new position");
+        assert!(title_pos < desc_pos);
+        assert!(desc_pos < first_category_pos);
+        assert!(first_category_pos < second_category_pos);
+        assert!(second_category_pos < live_pos);
+        assert!(live_pos < new_pos);
+    }
+
+    #[tokio::test]
+    async fn programme_classification_writer_propagates_io_errors() {
+        let mut programme = EpgProgramme::new(100, 200, "channel".intern());
+        programme.categories = vec![EpgCategory { value: "Sports".intern(), lang: None }];
+        let mut writer = quick_xml::Writer::new(ErroringWriter);
+
+        assert!(write_programme_classification_tags(&mut writer, &programme).await.is_err());
     }
 
     #[tokio::test]

--- a/backend/src/model/xmltv.rs
+++ b/backend/src/model/xmltv.rs
@@ -9,7 +9,7 @@ use futures::TryFutureExt;
 use quick_xml::events::{Event};
 use shared::concat_string;
 use shared::error::TuliproxError;
-use shared::model::{EpgChannel, EpgProgramme, InputFetchMethod};
+use shared::model::{EpgCategory, EpgChannel, EpgProgramme, InputFetchMethod};
 use shared::utils::{sanitize_sensitive_info, Internable};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -26,10 +26,14 @@ pub const EPG_TAG_DISPLAY_NAME: &str = "display-name";
 pub const EPG_TAG_ICON: &str = "icon";
 pub const EPG_TAG_TITLE: &str = "title";
 pub const EPG_TAG_DESC: &str = "desc";
+pub const EPG_TAG_CATEGORY: &str = "category";
+pub const EPG_TAG_LIVE: &str = "live";
+pub const EPG_TAG_NEW: &str = "new";
 pub const EPG_ATTRIB_START: &str = "start";
 pub const EPG_ATTRIB_STOP: &str = "stop";
 pub const EPG_ATTRIB_CATCHUP_ID: &str = "catchup-id";
 pub const EPG_ATTRIB_SRC: &str = "src";
+pub const EPG_ATTRIB_LANG: &str = "lang";
 
 // https://github.com/XMLTV/xmltv/blob/master/xmltv.dtd
 
@@ -204,6 +208,7 @@ async fn parse_xmltv_for_web_ui<R: AsyncRead + Send + Unpin>(reader: R) -> Resul
         DisplayName,
         Title,
         Desc,
+        Category,
         Other,
     }
 
@@ -217,6 +222,7 @@ async fn parse_xmltv_for_web_ui<R: AsyncRead + Send + Unpin>(reader: R) -> Resul
     let mut current_programme: Option<EpgProgramme> = None;
 
     let mut current_tag = TextTag::Other;
+    let mut current_category_lang = None;
 
     // only 1 day old epg
     let now = Utc::now();
@@ -236,8 +242,10 @@ async fn parse_xmltv_for_web_ui<R: AsyncRead + Send + Unpin>(reader: R) -> Resul
                     EPG_TAG_DISPLAY_NAME => TextTag::DisplayName,
                     EPG_TAG_TITLE => TextTag::Title,
                     EPG_TAG_DESC => TextTag::Desc,
+                    EPG_TAG_CATEGORY => TextTag::Category,
                     _ => TextTag::Other,
                 };
+                current_category_lang = None;
 
                 match tag.as_ref() {
                     EPG_TAG_CHANNEL => {
@@ -297,6 +305,23 @@ async fn parse_xmltv_for_web_ui<R: AsyncRead + Send + Unpin>(reader: R) -> Resul
                             }
                         }
                     }
+                    EPG_TAG_CATEGORY => {
+                        current_category_lang = e
+                            .attributes()
+                            .flatten()
+                            .find(|attr| attr.key.as_ref() == EPG_ATTRIB_LANG.as_bytes())
+                            .and_then(|attr| get_attr_value(&attr));
+                    }
+                    EPG_TAG_LIVE => {
+                        if let Some(programme) = &mut current_programme {
+                            programme.is_live = true;
+                        }
+                    }
+                    EPG_TAG_NEW => {
+                        if let Some(programme) = &mut current_programme {
+                            programme.is_new = true;
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -315,6 +340,11 @@ async fn parse_xmltv_for_web_ui<R: AsyncRead + Send + Unpin>(reader: R) -> Resul
                                 program.title = Some(concat_text(program.title.as_ref(), text));
                             } else if current_tag == TextTag::Desc {
                                 program.desc = Some(concat_text(program.desc.as_ref(), text));
+                            } else if current_tag == TextTag::Category {
+                                program.categories.push(EpgCategory {
+                                    value: text.intern(),
+                                    lang: current_category_lang.take(),
+                                });
                             }
                         }
                     }
@@ -336,6 +366,7 @@ async fn parse_xmltv_for_web_ui<R: AsyncRead + Send + Unpin>(reader: R) -> Resul
                     _ => {}
                 }
                 current_tag = TextTag::Other;
+                current_category_lang = None;
             }
             Ok(Event::Eof) => break,
             Err(err) => return Err(TuliproxError::Parse(err.to_string())),
@@ -348,4 +379,37 @@ async fn parse_xmltv_for_web_ui<R: AsyncRead + Send + Unpin>(reader: R) -> Resul
     filter_channels_and_programmes(&mut channels, &mut programmes);
 
     Ok(channels)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_xmltv_for_web_ui;
+
+    #[tokio::test]
+    async fn web_ui_parser_preserves_programme_tags() {
+        let channels = parse_xmltv_for_web_ui(
+            br#"<tv>
+  <channel id="ESPN.us"><display-name>ESPN</display-name></channel>
+  <programme start="20990718180000 +0000" stop="20990718200000 +0000" channel="ESPN.us">
+    <title>Softball</title>
+    <category lang="en">Softball</category>
+    <category>Sports</category>
+    <live/>
+    <new></new>
+  </programme>
+</tv>"#
+                .as_slice(),
+        )
+        .await
+        .expect("parse XMLTV");
+
+        let programme = &channels[0].programmes[0];
+        assert_eq!(programme.categories.len(), 2);
+        assert_eq!(programme.categories[0].value.as_ref(), "Softball");
+        assert_eq!(programme.categories[0].lang.as_deref(), Some("en"));
+        assert_eq!(programme.categories[1].value.as_ref(), "Sports");
+        assert!(programme.categories[1].lang.is_none());
+        assert!(programme.is_live);
+        assert!(programme.is_new);
+    }
 }

--- a/backend/src/processing/parser/ics/event.rs
+++ b/backend/src/processing/parser/ics/event.rs
@@ -16,7 +16,7 @@ pub struct IcsEvent {
     pub summary: Option<String>,
     pub description: Option<String>,
     pub location: Option<String>,
-    pub categories: Option<String>,
+    pub categories: Vec<String>,
     pub start: Option<i64>,
     pub stop: Option<i64>,
     pub start_display: Option<String>,
@@ -270,7 +270,7 @@ fn parse_event_lines(lines: &[String], config: &IcsEpgSourceConfig) -> Result<Op
                     Some(truncate_to_byte_limit(unescape_ics_text(&property.value), MAX_ICS_DESCRIPTION_LENGTH));
             }
             "LOCATION" => event.location = Some(unescape_ics_text(&property.value)),
-            "CATEGORIES" => event.categories = Some(unescape_ics_text(&property.value)),
+            "CATEGORIES" => event.categories.extend(parse_ics_text_list(&property.value)),
             "STATUS" if property.value.eq_ignore_ascii_case("CANCELLED") => event.cancelled = true,
             "RRULE" | "RDATE" | "EXDATE" => event.unsupported_recurrence = true,
             "DTSTART" => {
@@ -374,6 +374,33 @@ fn unescape_ics_text(value: &str) -> String {
     result
 }
 
+fn parse_ics_text_list(value: &str) -> Vec<String> {
+    let mut values = Vec::new();
+    let mut start = 0;
+    let mut escaped = false;
+
+    for (index, character) in value.char_indices() {
+        if escaped {
+            escaped = false;
+        } else if character == '\\' {
+            escaped = true;
+        } else if character == ',' {
+            push_ics_text_list_value(&mut values, &value[start..index]);
+            start = index + character.len_utf8();
+        }
+    }
+    push_ics_text_list_value(&mut values, &value[start..]);
+    values
+}
+
+fn push_ics_text_list_value(values: &mut Vec<String>, raw: &str) {
+    let value = unescape_ics_text(raw);
+    let value = value.trim();
+    if !value.is_empty() {
+        values.push(value.to_string());
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -394,6 +421,15 @@ mod tests {
         assert_eq!(events[0].summary.as_deref(), Some("Practice 1"));
         assert_eq!(events[0].start, Some(1_772_800_200));
         assert_eq!(events[0].stop, Some(1_772_803_800));
+    }
+
+    #[test]
+    fn categories_split_only_on_unescaped_commas() {
+        let content = calendar(
+            "BEGIN:VEVENT\nCATEGORIES: Sports ,Team\\, Regional,,News\nCATEGORIES:Path\\\\,Extra\nDTSTART:20260306T123000Z\nDTEND:20260306T133000Z\nEND:VEVENT",
+        );
+        let events = parse_ics_events(&content, &config()).expect("events");
+        assert_eq!(events[0].categories, vec!["Sports", "Team, Regional", "News", "Path\\", "Extra"]);
     }
 
     #[test]

--- a/backend/src/processing/parser/ics/mod.rs
+++ b/backend/src/processing/parser/ics/mod.rs
@@ -8,7 +8,7 @@ pub use event::IcsEvent;
 use shared::{
     defaults::{MAX_ICS_DESCRIPTION_LENGTH, MAX_ICS_SUMMARY_LENGTH},
     error::TuliproxError,
-    model::{EpgChannel, EpgProgramme},
+    model::{EpgCategory, EpgChannel, EpgProgramme},
     utils::Internable,
 };
 use std::{path::Path, sync::Arc};
@@ -80,8 +80,10 @@ fn events_to_programmes(
             continue;
         }
 
-        let title = render_event_template(&config.event.title, &event, MAX_ICS_SUMMARY_LENGTH);
-        let mut desc = render_event_template(&config.event.description, &event, MAX_ICS_DESCRIPTION_LENGTH);
+        let categories_text = event.categories.join(",");
+        let title = render_event_template(&config.event.title, &event, &categories_text, MAX_ICS_SUMMARY_LENGTH);
+        let mut desc =
+            render_event_template(&config.event.description, &event, &categories_text, MAX_ICS_DESCRIPTION_LENGTH);
 
         if config.event.include_location {
             if let Some(location) = event.location.as_deref().filter(|value| !value.is_empty()) {
@@ -89,31 +91,37 @@ fn events_to_programmes(
             }
         }
 
-        if config.event.include_categories {
-            if let Some(categories) = event.categories.as_deref().filter(|value| !value.is_empty()) {
-                append_description_metadata(&mut desc, "Categories: ", categories);
-            }
+        if config.event.include_categories && !categories_text.is_empty() {
+            append_description_metadata(&mut desc, "Categories: ", &categories_text);
         }
 
-        result.push(EpgProgramme::new_all(
+        let categories: Vec<EpgCategory> = event
+            .categories
+            .into_iter()
+            .map(|value| EpgCategory { value: value.intern(), lang: None })
+            .collect();
+
+        let mut programme = EpgProgramme::new_all(
             start,
             stop,
             Arc::clone(channel_id),
             (!title.is_empty()).then(|| title.intern()),
             (!desc.is_empty()).then(|| desc.intern()),
             None,
-        ));
+        );
+        programme.categories = categories;
+        result.push(programme);
     }
 
     result
 }
 
-fn render_event_template(template: &str, event: &IcsEvent, max_bytes: usize) -> String {
+fn render_event_template(template: &str, event: &IcsEvent, categories: &str, max_bytes: usize) -> String {
     let replacements = [
         ("{summary}", event.summary.as_deref().unwrap_or_default()),
         ("{description}", event.description.as_deref().unwrap_or_default()),
         ("{location}", event.location.as_deref().unwrap_or_default()),
-        ("{categories}", event.categories.as_deref().unwrap_or_default()),
+        ("{categories}", categories),
         ("{uid}", event.uid.as_deref().unwrap_or_default()),
         ("{start}", event.start_display.as_deref().unwrap_or_default()),
         ("{end}", event.stop_display.as_deref().unwrap_or_default()),
@@ -164,6 +172,8 @@ fn append_utf8_bounded(target: &mut String, value: &str, max_bytes: usize) {
 mod tests {
     use super::*;
     use crate::model::{IcsEpgSourceConfig, IcsEventMapping};
+    use shared::model::EpgCategory;
+    use shared::utils::Internable;
     use std::fs;
     use tempfile::tempdir;
 
@@ -195,6 +205,15 @@ mod tests {
         assert_eq!(channel.programmes.len(), 1);
         assert_eq!(channel.programmes[0].title.as_deref(), Some("Formula 1: Practice 1"));
         assert_eq!(channel.programmes[0].desc.as_deref(), Some("Session\nLocation: Bahrain\nCategories: F1,Race"));
+        assert_eq!(
+            channel.programmes[0].categories,
+            vec![
+                EpgCategory { value: "F1".intern(), lang: None },
+                EpgCategory { value: "Race".intern(), lang: None },
+            ],
+        );
+        assert!(!channel.programmes[0].is_live);
+        assert!(!channel.programmes[0].is_new);
     }
 
     #[tokio::test]
@@ -238,11 +257,12 @@ mod tests {
             ..IcsEvent::default()
         };
         let repeated_description = "{description}".repeat(MAX_ICS_SUMMARY_LENGTH / "{description}".len());
-        let rendered_description = render_event_template(&repeated_description, &event, MAX_ICS_SUMMARY_LENGTH);
+        let rendered_description =
+            render_event_template(&repeated_description, &event, "", MAX_ICS_SUMMARY_LENGTH);
         assert!(rendered_description.len() <= MAX_ICS_SUMMARY_LENGTH);
         assert!(rendered_description.chars().all(|character| character == '€'));
 
-        let rendered_uid = render_event_template("{uid}{uid}", &event, MAX_ICS_SUMMARY_LENGTH);
+        let rendered_uid = render_event_template("{uid}{uid}", &event, "", MAX_ICS_SUMMARY_LENGTH);
         assert_eq!(rendered_uid.len(), MAX_ICS_SUMMARY_LENGTH);
     }
 
@@ -253,7 +273,7 @@ mod tests {
             stop: Some(2),
             description: Some("Description".to_string()),
             location: Some("L".repeat(MAX_ICS_DESCRIPTION_LENGTH / 2)),
-            categories: Some("ä".repeat(MAX_ICS_DESCRIPTION_LENGTH)),
+            categories: vec!["ä".repeat(MAX_ICS_DESCRIPTION_LENGTH)],
             ..IcsEvent::default()
         };
         let config = IcsEpgSourceConfig {

--- a/backend/src/processing/parser/xmltv.rs
+++ b/backend/src/processing/parser/xmltv.rs
@@ -1,8 +1,9 @@
 use crate::{
     model::{
         Epg, EpgSmartMatchConfig, IcsDummyPolicy, IcsEpgSourceConfig, PersistedEpgSource, PersistedEpgSourceKind,
-        TVGuide, XmlTag, XmlTagIcon, EPG_ATTRIB_CHANNEL, EPG_ATTRIB_ID, EPG_TAG_CHANNEL, EPG_TAG_DISPLAY_NAME,
-        EPG_TAG_ICON, EPG_TAG_PROGRAMME, EPG_TAG_TV,
+        TVGuide, XmlTag, XmlTagIcon, EPG_ATTRIB_CHANNEL, EPG_ATTRIB_ID, EPG_ATTRIB_LANG, EPG_TAG_CATEGORY,
+        EPG_TAG_CHANNEL, EPG_TAG_DESC, EPG_TAG_DISPLAY_NAME, EPG_TAG_ICON, EPG_TAG_LIVE, EPG_TAG_NEW,
+        EPG_TAG_PROGRAMME, EPG_TAG_TITLE, EPG_TAG_TV,
     },
     processing::{
         parser::ics,
@@ -18,7 +19,7 @@ use quick_xml::events::{BytesStart, BytesText, Event};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use shared::{
     concat_string,
-    model::{EpgChannel, EpgNamePrefix, EpgProgramme},
+    model::{EpgCategory, EpgChannel, EpgNamePrefix, EpgProgramme},
     utils::{deunicode_string, Internable, CONSTANTS},
 };
 use std::{
@@ -187,8 +188,6 @@ impl TVGuide {
         start_attrib: &Arc<str>,
         stop_attrib: &Arc<str>,
         catchup_id_attrib: &Arc<str>,
-        tag_title: &Arc<str>,
-        tag_desc: &Arc<str>,
     ) -> Option<EpgProgramme> {
         let Some((Some(start), Some(stop))) =
             tag.attributes.as_ref().map(|a| (a.get(start_attrib), a.get(stop_attrib)))
@@ -204,19 +203,40 @@ impl TVGuide {
 
         let mut title = None;
         let mut desc = None;
+        let mut categories = Vec::new();
+        let mut is_live = false;
+        let mut is_new = false;
         if let Some(children) = tag.children.as_ref() {
             for child in children {
-                if child.name == *tag_title {
-                    title.clone_from(&child.value);
-                } else if child.name == *tag_desc {
-                    desc.clone_from(&child.value);
+                match child.name.as_ref() {
+                    EPG_TAG_TITLE => title.clone_from(&child.value),
+                    EPG_TAG_DESC => desc.clone_from(&child.value),
+                    EPG_TAG_CATEGORY => {
+                        if let Some(value) = child.value.as_ref().filter(|value| !value.is_empty()) {
+                            categories.push(EpgCategory {
+                                value: Arc::clone(value),
+                                lang: child
+                                    .attributes
+                                    .as_ref()
+                                    .and_then(|attributes| attributes.get(EPG_ATTRIB_LANG))
+                                    .cloned(),
+                            });
+                        }
+                    }
+                    EPG_TAG_LIVE => is_live = true,
+                    EPG_TAG_NEW => is_new = true,
+                    _ => {}
                 }
             }
         }
 
         let catchup_id = tag.attributes.as_ref().and_then(|attributes| attributes.get(catchup_id_attrib)).cloned();
 
-        Some(EpgProgramme::new_all(start_time, stop_time, Arc::clone(epg_id), title, desc, catchup_id))
+        let mut programme = EpgProgramme::new_all(start_time, stop_time, Arc::clone(epg_id), title, desc, catchup_id);
+        programme.categories = categories;
+        programme.is_live = is_live;
+        programme.is_new = is_new;
+        Some(programme)
     }
 
     /// Finds the best fuzzy match for a channel's normalized EPG ID using phonetic encoding and Jaro-Winkler similarity.
@@ -316,8 +336,6 @@ impl TVGuide {
         let start_attrib = "start".intern();
         let stop_attrib = "stop".intern();
         let catchup_id_attrib = "catchup-id".intern();
-        let tag_title = "title".intern();
-        let tag_desc = "desc".intern();
 
         match CompressedFileReaderAsync::new(&epg_source.file_path).await {
             Ok(mut reader) => {
@@ -370,8 +388,6 @@ impl TVGuide {
                                         &start_attrib,
                                         &stop_attrib,
                                         &catchup_id_attrib,
-                                        &tag_title,
-                                        &tag_desc,
                                     ) {
                                         accumulator.push_programme(epg_source.priority, source_order, programme);
                                     }
@@ -899,6 +915,11 @@ fn backfill_programme_metadata(existing: &mut EpgProgramme, incoming: EpgProgram
     if existing.catchup_id.is_none() {
         existing.catchup_id = incoming.catchup_id;
     }
+    if existing.categories.is_empty() {
+        existing.categories = incoming.categories;
+    }
+    existing.is_live |= incoming.is_live;
+    existing.is_new |= incoming.is_new;
 }
 
 fn normalize_channel_programmes(acc: &mut ChannelMergeAcc) {
@@ -986,7 +1007,7 @@ mod tests {
         },
         utils::FileLockManager,
     };
-    use shared::model::{EpgChannel, EpgProgramme};
+    use shared::model::{EpgCategory, EpgChannel, EpgProgramme};
     use std::{collections::HashSet, fs, path::PathBuf, sync::Arc};
     use tempfile::tempdir;
 
@@ -1120,6 +1141,66 @@ mod tests {
         assert_eq!(merged[0].programmes.len(), 1);
         assert_eq!(merged[0].programmes[0].title.as_deref(), Some("High Title"));
         assert_eq!(merged[0].programmes[0].desc.as_deref(), Some("Recovered desc"));
+    }
+
+    #[test]
+    fn epg_priority_merge_backfills_programme_tags() {
+        let low_priority_categories = vec![
+            EpgCategory { value: "Sports".intern(), lang: None },
+            EpgCategory { value: "Live".intern(), lang: Some("en".intern()) },
+        ];
+        let mut low_programme = epg_programme("demo.channel", 10, 20, None, None);
+        low_programme.categories = low_priority_categories.clone();
+        low_programme.is_live = true;
+        low_programme.is_new = true;
+
+        let merged = merge_epg_channels_by_priority(vec![
+            (
+                0,
+                vec![epg_channel(
+                    "demo.channel",
+                    Some("High"),
+                    None,
+                    vec![epg_programme("demo.channel", 10, 20, Some("High Title"), None)],
+                )],
+            ),
+            (10, vec![epg_channel("demo.channel", None, None, vec![low_programme])]),
+        ]);
+
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].programmes.len(), 1);
+        assert_eq!(merged[0].programmes[0].categories, low_priority_categories);
+        assert!(merged[0].programmes[0].is_live);
+        assert!(merged[0].programmes[0].is_new);
+
+        let high_programme_with_categories = {
+            let mut programme = epg_programme("demo.channel", 30, 40, Some("High Title 2"), None);
+            programme.categories = vec![EpgCategory { value: "Drama".intern(), lang: None }];
+            programme.is_new = true;
+            programme
+        };
+        let low_programme_extra = {
+            let mut programme = epg_programme("demo.channel", 30, 40, None, None);
+            programme.categories = vec![EpgCategory { value: "ShouldNotWin".intern(), lang: None }];
+            programme.is_live = true;
+            programme
+        };
+        let merged = merge_epg_channels_by_priority(vec![
+            (
+                0,
+                vec![epg_channel("demo.channel", None, None, vec![high_programme_with_categories])],
+            ),
+            (10, vec![epg_channel("demo.channel", None, None, vec![low_programme_extra])]),
+        ]);
+
+        assert_eq!(merged.len(), 1);
+        let programme = &merged[0].programmes[0];
+        assert_eq!(
+            programme.categories,
+            vec![EpgCategory { value: "Drama".intern(), lang: None }],
+        );
+        assert!(programme.is_live);
+        assert!(programme.is_new);
     }
 
     #[test]
@@ -1676,5 +1757,43 @@ mod tests {
         println!("{}", metaphone.encode(&normalize_channel_name("ODISEA ᵁᴴᴰ ³⁸⁴⁰ᴾ", &epg_smart_cfg)));
         println!("{}", metaphone.encode(&normalize_channel_name("BU | ODISEA ᵁᴴᴰ ³⁸⁴⁰ᴾ", &epg_smart_cfg)));
         println!("{}", metaphone.encode(&normalize_channel_name("BG | ODISEA ᵁᴴᴰ ³⁸⁴⁰ᴾ", &epg_smart_cfg)));
+    }
+
+    #[test]
+    fn xmltv_programme_tags_are_extracted() {
+        run_async_test(async move {
+            let dir = tempdir().expect("temp dir");
+            let epg_path = dir.path().join("programme-tags.xml");
+            fs::write(
+                &epg_path,
+                r#"<tv>
+  <channel id="ESPN.us"><display-name>ESPN</display-name></channel>
+  <programme start="20260718180000 +0000" stop="20260718200000 +0000" channel="ESPN.us">
+    <title lang="en">Softball</title>
+    <category lang="en">Softball</category>
+    <category>Sports</category>
+    <live/>
+    <new></new>
+  </programme>
+</tv>"#,
+            )
+            .expect("write XMLTV fixture");
+
+            let guide = TVGuide::new(vec![xmltv_source(epg_path, 0, false)]);
+            let mut id_cache = EpgIdCache::new(None);
+            id_cache.insert_channel_epg_id("ESPN.us");
+            let merged = guide.filter_merged(&mut id_cache).await.expect("merged EPG");
+            let programme = &merged.children[0].programmes[0];
+
+            assert_eq!(
+                programme.categories,
+                vec![
+                    EpgCategory { value: "Softball".intern(), lang: Some("en".intern()) },
+                    EpgCategory { value: "Sports".intern(), lang: None },
+                ],
+            );
+            assert!(programme.is_live);
+            assert!(programme.is_new);
+        });
     }
 }

--- a/backend/src/repository/bplustree/migration.rs
+++ b/backend/src/repository/bplustree/migration.rs
@@ -1032,6 +1032,9 @@ mod tests {
         assert_eq!(decoded.title.as_deref(), Some("Programme"));
         assert_eq!(decoded.desc.as_deref(), Some("Description"));
         assert!(decoded.catchup_id.is_none());
+        assert!(decoded.categories.is_empty());
+        assert!(!decoded.is_live);
+        assert!(!decoded.is_new);
     }
 
     fn test_roots_fingerprint(roots: &[PathBuf]) -> String {

--- a/backend/src/repository/epg_repository.rs
+++ b/backend/src/repository/epg_repository.rs
@@ -196,7 +196,7 @@ mod tests {
     use shared::{
         foundation::Filter,
         model::{
-            EpgChannel, EpgProgramme, PlaylistItem, PlaylistItemHeader, ProcessingOrder, XtreamCluster,
+            EpgCategory, EpgChannel, EpgProgramme, PlaylistItem, PlaylistItemHeader, ProcessingOrder, XtreamCluster,
         },
         utils::Internable,
     };
@@ -285,6 +285,7 @@ mod tests {
                 "DTEND:20300101T130000Z\r\n",
                 "SUMMARY:Formula 1 Practice\r\n",
                 "DESCRIPTION:Imported from ICS\r\n",
+                "CATEGORIES:Motorsport,Practice\r\n",
                 "END:VEVENT\r\n",
                 "END:VCALENDAR\r\n",
             ),
@@ -334,6 +335,15 @@ mod tests {
             assert_eq!(stored.title.as_deref(), Some("Formula 1"));
             assert_eq!(stored.programmes.len(), 1);
             assert_eq!(stored.programmes[0].title.as_deref(), Some("Formula 1 Practice"));
+            assert_eq!(
+                stored.programmes[0].categories,
+                vec![
+                    EpgCategory { value: "Motorsport".intern(), lang: None },
+                    EpgCategory { value: "Practice".intern(), lang: None },
+                ],
+            );
+            assert!(!stored.programmes[0].is_live);
+            assert!(!stored.programmes[0].is_new);
         }
     }
 

--- a/shared/src/model/epg.rs
+++ b/shared/src/model/epg.rs
@@ -115,6 +115,13 @@ mod tests {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct EpgCategory {
+    pub value: Arc<str>,
+    #[serde(default)]
+    pub lang: Option<Arc<str>>,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct EpgProgramme {
     pub start: i64,
@@ -123,6 +130,12 @@ pub struct EpgProgramme {
     pub desc: Option<Arc<str>>,
     #[serde(default)]
     pub catchup_id: Option<Arc<str>>,
+    #[serde(default)]
+    pub categories: Vec<EpgCategory>,
+    #[serde(default)]
+    pub is_live: bool,
+    #[serde(default)]
+    pub is_new: bool,
     #[serde(skip)]
     channel: Arc<str>,
 }
@@ -134,7 +147,17 @@ impl EpgProgramme {
 
 impl EpgProgramme {
     pub fn new(start: i64, stop: i64, channel: Arc<str>) -> Self {
-        Self { start, stop, channel, title: None, desc: None, catchup_id: None }
+        Self {
+            start,
+            stop,
+            channel,
+            title: None,
+            desc: None,
+            catchup_id: None,
+            categories: Vec::new(),
+            is_live: false,
+            is_new: false,
+        }
     }
     pub fn new_all(
         start: i64,
@@ -144,7 +167,7 @@ impl EpgProgramme {
         desc: Option<Arc<str>>,
         catchup_id: Option<Arc<str>>,
     ) -> Self {
-        Self { start, stop, channel, title, desc, catchup_id }
+        Self { start, stop, channel, title, desc, catchup_id, categories: Vec::new(), is_live: false, is_new: false }
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * EPG imports and exports now preserve programme categories, including optional language details.
  * XMLTV output and Web UI EPG previews now include categories plus `live`/`new` markers when present.
  * ICS imports now support multiple `CATEGORIES` values, correctly handling escaped commas.
* **Bug Fixes**
  * Programme category metadata and `live`/`new` flags are now correctly merged and retained during persistence.
* **Compatibility**
  * Existing saved EPG data remains readable; missing metadata defaults to empty categories and unset flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->