### PR TITLE
Fix: Mapper counter reset

### DIFF
--- a/backend/src/processing/processor/playlist.rs
+++ b/backend/src/processing/processor/playlist.rs
@@ -323,11 +323,14 @@ fn map_playlist_counter(target: &ConfigTarget, playlist: &mut [PlaylistGroup]) {
         for mapping in mappings {
             if let Some(counter_list) = &mapping.t_counter {
                 for counter in counter_list {
+                    // fresh per target/call. No shared atomic, no cross-refresh carry-over.
+                    let mut current = counter.start;
                     for plg in &mut *playlist {
                         for channel in &mut plg.channels {
                             let provider = ValueProvider { pli: channel, match_as_ascii: mapping.match_as_ascii };
                             if counter.filter.filter(&provider) {
-                                let cntval = counter.value.fetch_add(1, core::sync::atomic::Ordering::AcqRel);
+                                let cntval = current;
+                                current += 1;
                                 let padded_cntval = if counter.padding > 0 {
                                     format!("{:0width$}", cntval, width = counter.padding as usize)
                                 } else {

--- a/frontend/src/app/components/playlist/mapper_counter_view.rs
+++ b/frontend/src/app/components/playlist/mapper_counter_view.rs
@@ -1,6 +1,5 @@
 use crate::i18n::use_translation;
 use shared::model::MappingCounter;
-use std::sync::atomic::Ordering;
 use yew::prelude::*;
 
 #[derive(Properties, PartialEq, Clone)]
@@ -32,7 +31,7 @@ pub fn MapperCounterView(props: &MapperCounterViewProps) -> Html {
         </div>
         <div class="tp__mapper-counter__row">
             <label>{translate.t("LABEL.VALUE")}</label>
-            {props.counter.value.load(Ordering::Relaxed)}
+            {props.counter.start}
         </div>
         <div class="tp__mapper-counter__row">
             <label>{translate.t("LABEL.PADING")}</label>

--- a/shared/src/model/mapping.rs
+++ b/shared/src/model/mapping.rs
@@ -4,7 +4,6 @@ use crate::{
     model::PatternTemplate,
 };
 use log::trace;
-use std::sync::{atomic::AtomicU32, Arc};
 use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
 
 pub const COUNTER_FIELDS: &[&str] = &["name", "title", "caption", "chno"];
@@ -78,7 +77,7 @@ pub struct MappingCounter {
     pub field: String,
     pub concat: String,
     pub modifier: CounterModifier,
-    pub value: Arc<AtomicU32>,
+    pub start: u32,
     pub padding: u8,
 }
 
@@ -88,8 +87,8 @@ impl PartialEq for MappingCounter {
             && self.field == other.field
             && self.concat == other.concat
             && self.modifier == other.modifier
+            && self.start == other.start
             && self.padding == other.padding
-        // value is not compared!
     }
 }
 
@@ -206,7 +205,7 @@ impl MappingDto {
                         field: def.field.clone(),
                         concat: def.concat.clone(),
                         modifier: def.modifier,
-                        value: Arc::new(AtomicU32::new(def.value)),
+                        start: def.value,
                         padding: def.padding,
                     });
                 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed playlist counter assignments so values reset correctly during each refresh.
  * Corrected counter displays to consistently show their configured starting values.
  * Improved counter comparisons to detect changes in starting values accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->