### PR TITLE
Fixed input form state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@
 
 ## 🌟 New Features
 
+- **Mapper Read-Only Metadata Fields**:
+  - Mapper scripts can read `@Input` and `@Type` directly and use them as regex sources or map keys.
+  - Assignments to these immutable fields are rejected while all existing read-write fields remain assignable.
+
 - **Dependency-aware parallel playlist updates**:
   - `process_parallel: true` now downloads independent inputs concurrently and starts each source's targets as soon as
     its required inputs are ready.
@@ -433,6 +437,12 @@
   - Added smarter HLS playback access/admission handling for consistent manifest responses.
 
 ## 🐛 Fixes
+
+- **Mapper Regex Capture Results**:
+  - Regex expressions now evaluate one complete match instead of flattening later matches into duplicate,
+    unreachable capture keys.
+  - Every capture group from that match remains accessible by index (`.1` through `.n`), and named groups remain
+    accessible by both index and name. A single unnamed capture also supports `.1` without losing scalar use.
 
 - **Media servers no longer show a duplicate movie for every extra provider listing (STRM `flat` mode)**: under
   `flat: true` the movie folder is deduplicated by TMDB id, but each file was still named after *its own*

--- a/docs/src/configuration/mapping-dsl.md
+++ b/docs/src/configuration/mapping-dsl.md
@@ -106,6 +106,9 @@ the `@` prefix.
 `@time_shift`,  
 `@rec`, `@url`, `@epg_channel_id`, `@epg_id`, `@genre`.
 
+**Read-only `@Fields`:** `@input`, `@type`. They can be used as values, regex sources, and map keys, but assignments
+such as `@Input = "provider"` or `@Type = "vod"` are rejected.
+
 *(Special note on `@Caption`: Acts as an alias for Title/Name. If you write to `@Caption`,
 Tuliprox updates both the `Title` AND the `Name` to the same value).*
 
@@ -131,7 +134,9 @@ Tuliprox updates both the `Title` AND the `Name` to the same value).*
 ### 2. RegEx Captures & Extraction
 
 Regular expressions are executed using the tilde `~` operator. The results are placed in a
-capture object. You can access them via index (`.1`, `.2`) or via "Named Captures".
+capture object. Only the first complete regex match is evaluated, while every participating capture group from that
+match remains available by index (`.1` through `.n`). Named groups are available both by index and by name. A single
+unnamed capture can be used directly as a scalar and through `.1`.
 
 ```dsl
 # Extract the year from the title using named captures

--- a/frontend/src/app/components/source_editor/input_form.rs
+++ b/frontend/src/app/components/source_editor/input_form.rs
@@ -1486,3 +1486,78 @@ mod tests {
         assert_eq!(libraries, vec![detailed, MediaServerLibrarySelector::Name("Kids".to_string())]);
     }
 }
+
+#[cfg(all(test, target_arch = "wasm32"))]
+mod browser_tests {
+    use super::*;
+    use crate::{hooks::IconContext, i18n::I18nProvider, provider::DialogProvider};
+    use gloo_timers::future::TimeoutFuture;
+    use std::{rc::Rc, sync::Arc};
+    use wasm_bindgen::JsCast;
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+    use web_sys::{HtmlElement, HtmlInputElement};
+    use yew::{component, html, use_state, Callback, Html, Renderer};
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    fn m3u_input(name: &str) -> ConfigInputDto {
+        ConfigInputDto { name: Arc::<str>::from(name), input_type: shared::model::InputType::M3u, ..Default::default() }
+    }
+
+    #[component]
+    fn M3uRefreshHarness() -> Html {
+        let input = use_state(|| m3u_input("first"));
+        let icons = use_state(|| IconContext::new(&vec![]));
+        let on_switch = {
+            let input = input.clone();
+            Callback::from(move |_| input.set(m3u_input("second")))
+        };
+
+        html! {
+            <yew::ContextProvider<yew::UseStateHandle<IconContext>> context={icons}>
+                <DialogProvider>
+                    <I18nProvider>
+                        <button id="switch-m3u-input" onclick={on_switch}>{"switch"}</button>
+                        <ConfigInputView input={Some(Rc::new((*input).clone()))} />
+                    </I18nProvider>
+                </DialogProvider>
+            </yew::ContextProvider<yew::UseStateHandle<IconContext>>>
+        }
+    }
+
+    async fn settle_render() {
+        TimeoutFuture::new(0).await;
+        TimeoutFuture::new(0).await;
+    }
+
+    fn rendered_name(root: &web_sys::Element) -> Option<String> {
+        root.query_selector("input[name=\"name\"]")
+            .ok()
+            .flatten()
+            .and_then(|element| element.dyn_into::<HtmlInputElement>().ok())
+            .map(|input| input.value())
+    }
+
+    #[wasm_bindgen_test(async)]
+    async fn m3u_form_refreshes_when_selected_input_changes() -> Result<(), wasm_bindgen::JsValue> {
+        let document = gloo_utils::document();
+        let body = document.body().ok_or_else(|| wasm_bindgen::JsValue::from_str("test document has no body"))?;
+        let root = document.create_element("div")?;
+        body.append_child(&root)?;
+        Renderer::<M3uRefreshHarness>::with_root(root.clone()).render();
+        settle_render().await;
+        assert_eq!(rendered_name(&root).as_deref(), Some("first"));
+
+        let switch = root
+            .query_selector("#switch-m3u-input")?
+            .ok_or_else(|| wasm_bindgen::JsValue::from_str("switch button was not rendered"))?
+            .dyn_into::<HtmlElement>()
+            .map_err(|_| wasm_bindgen::JsValue::from_str("switch button has the wrong element type"))?;
+        switch.click();
+        settle_render().await;
+
+        assert_eq!(rendered_name(&root).as_deref(), Some("second"));
+        root.remove();
+        Ok(())
+    }
+}

--- a/frontend/src/app/components/source_editor/input_form/common.rs
+++ b/frontend/src/app/components/source_editor/input_form/common.rs
@@ -20,7 +20,7 @@ use shared::{model::InputFetchMethod, utils::BATCH_SCHEME_PREFIX};
 use std::{collections::HashMap, rc::Rc};
 use yew::{component, html, use_memo, Callback, Html, Properties, UseReducerHandle, UseStateHandle};
 
-#[derive(Properties, Clone, PartialEq)]
+#[derive(Properties, Clone)]
 pub(super) struct CommonInputFormProps {
     pub state: UseReducerHandle<ConfigInputFormState>,
     pub allow_write: bool,
@@ -42,6 +42,10 @@ pub(super) struct CommonInputFormProps {
     pub extra: Html,
     #[prop_or_default]
     pub exp_date_tool_action: Option<ToolAction>,
+}
+
+impl PartialEq for CommonInputFormProps {
+    fn eq(&self, _other: &Self) -> bool { false }
 }
 
 #[component]
@@ -169,7 +173,7 @@ pub(super) enum OptionsKind {
     Stalker,
 }
 
-#[derive(Properties, Clone, PartialEq)]
+#[derive(Properties, Clone)]
 pub(super) struct InputOptionsFormProps {
     pub state: UseReducerHandle<ConfigInputOptionsDtoFormState>,
     pub headers: UseStateHandle<HashMap<String, String>>,
@@ -177,6 +181,10 @@ pub(super) struct InputOptionsFormProps {
     pub kind: OptionsKind,
     #[prop_or_default]
     pub extra: Html,
+}
+
+impl PartialEq for InputOptionsFormProps {
+    fn eq(&self, _other: &Self) -> bool { false }
 }
 
 #[component]

--- a/frontend/src/app/components/source_editor/input_form/library.rs
+++ b/frontend/src/app/components/source_editor/input_form/library.rs
@@ -1,10 +1,14 @@
 use super::{common::CommonInputForm, ConfigInputFormState};
 use yew::{component, html, Html, Properties, UseReducerHandle};
 
-#[derive(Properties, Clone, PartialEq)]
+#[derive(Properties, Clone)]
 pub(super) struct LibraryInputFormProps {
     pub state: UseReducerHandle<ConfigInputFormState>,
     pub allow_write: bool,
+}
+
+impl PartialEq for LibraryInputFormProps {
+    fn eq(&self, _other: &Self) -> bool { false }
 }
 
 #[component]

--- a/frontend/src/app/components/source_editor/input_form/m3u.rs
+++ b/frontend/src/app/components/source_editor/input_form/m3u.rs
@@ -1,10 +1,14 @@
 use super::{common::CommonInputForm, ConfigInputFormState};
 use yew::{component, html, Html, Properties, UseReducerHandle};
 
-#[derive(Properties, Clone, PartialEq)]
+#[derive(Properties, Clone)]
 pub(super) struct M3uInputFormProps {
     pub state: UseReducerHandle<ConfigInputFormState>,
     pub allow_write: bool,
+}
+
+impl PartialEq for M3uInputFormProps {
+    fn eq(&self, _other: &Self) -> bool { false }
 }
 
 #[component]

--- a/frontend/src/app/components/source_editor/input_form/media_server.rs
+++ b/frontend/src/app/components/source_editor/input_form/media_server.rs
@@ -11,10 +11,14 @@ use crate::{
 use shared::model::MediaServerInputConfigDto;
 use yew::{component, html, Callback, Html, Properties, UseReducerHandle};
 
-#[derive(Properties, Clone, PartialEq)]
+#[derive(Properties, Clone)]
 pub(super) struct MediaServerInputFormProps {
     pub state: UseReducerHandle<ConfigInputFormState>,
     pub allow_write: bool,
+}
+
+impl PartialEq for MediaServerInputFormProps {
+    fn eq(&self, _other: &Self) -> bool { false }
 }
 
 #[component]
@@ -25,10 +29,14 @@ pub(super) fn MediaServerInputForm(props: &MediaServerInputFormProps) -> Html {
     }
 }
 
-#[derive(Properties, Clone, PartialEq)]
+#[derive(Properties, Clone)]
 pub(super) struct MediaServerSettingsFormProps {
     pub state: UseReducerHandle<ConfigInputFormState>,
     pub allow_write: bool,
+}
+
+impl PartialEq for MediaServerSettingsFormProps {
+    fn eq(&self, _other: &Self) -> bool { false }
 }
 
 #[component]

--- a/frontend/src/app/components/source_editor/input_form/staged.rs
+++ b/frontend/src/app/components/source_editor/input_form/staged.rs
@@ -11,10 +11,14 @@ use shared::model::{ClusterFlags, StagedInputType};
 use std::rc::Rc;
 use yew::{component, html, Callback, Html, Properties, UseReducerHandle};
 
-#[derive(Properties, Clone, PartialEq)]
+#[derive(Properties, Clone)]
 pub(super) struct StagedInputFormProps {
     pub state: UseReducerHandle<ConfigInputFormState>,
     pub allow_write: bool,
+}
+
+impl PartialEq for StagedInputFormProps {
+    fn eq(&self, _other: &Self) -> bool { false }
 }
 
 #[component]

--- a/frontend/src/app/components/source_editor/input_form/stalker.rs
+++ b/frontend/src/app/components/source_editor/input_form/stalker.rs
@@ -182,10 +182,14 @@ where
     })
 }
 
-#[derive(Properties, Clone, PartialEq)]
+#[derive(Properties, Clone)]
 pub(super) struct StalkerDeviceInputFormProps {
     pub state: UseReducerHandle<StalkerDeviceFormState>,
     pub allow_write: bool,
+}
+
+impl PartialEq for StalkerDeviceInputFormProps {
+    fn eq(&self, _other: &Self) -> bool { false }
 }
 
 #[component]

--- a/frontend/src/app/components/source_editor/input_form/xtream.rs
+++ b/frontend/src/app/components/source_editor/input_form/xtream.rs
@@ -6,11 +6,15 @@ use yew::{
     component, html, platform::spawn_local, use_mut_ref, use_state, Callback, Html, Properties, UseReducerHandle,
 };
 
-#[derive(Properties, Clone, PartialEq)]
+#[derive(Properties, Clone)]
 pub(super) struct XtreamInputFormProps {
     pub state: UseReducerHandle<ConfigInputFormState>,
     pub providers: Vec<ConfigProviderDto>,
     pub allow_write: bool,
+}
+
+impl PartialEq for XtreamInputFormProps {
+    fn eq(&self, _other: &Self) -> bool { false }
 }
 
 #[component]

--- a/frontend/src/utils/format.rs
+++ b/frontend/src/utils/format.rs
@@ -98,6 +98,8 @@ mod tests {
     #[cfg(target_arch = "wasm32")]
     use super::format_local_day_boundary_utc;
     use super::{format_bandwidth, format_transferred};
+    #[cfg(target_arch = "wasm32")]
+    use chrono::TimeZone;
 
     fn format_local_with_offset(ts: i64, js_offset_minutes_west: i32, fmt: &str) -> String {
         let utc = match chrono::DateTime::from_timestamp(ts, 0) {

--- a/shared/src/foundation/filter.rs
+++ b/shared/src/foundation/filter.rs
@@ -4,13 +4,14 @@ pub use crate::model::{ItemField, PatternTemplate, PlaylistItemType, TemplateVal
 use crate::{
     error::TuliproxError,
     foundation::value_provider::ValueProvider,
-    utils::{DirectedGraph, Internable, CONSTANTS},
+    utils::{DirectedGraph, CONSTANTS},
 };
 use indexmap::IndexSet;
 use log::{error, log_enabled, trace, Level};
 use pest::{iterators::Pair, Parser};
 use pest_derive::Parser;
 use std::{
+    borrow::Cow,
     cmp::Ordering,
     collections::{HashMap, HashSet},
     sync::Arc,
@@ -100,19 +101,19 @@ impl Default for Filter {
     }
 }
 
-fn get_caption<'a>(provider: &'a ValueProvider<'a>, rewc: &'a CompiledRegex) -> (bool, Arc<str>) {
-    if let Some(value) = provider.get("title") {
+fn get_caption<'a>(provider: &'a ValueProvider<'_>, rewc: &CompiledRegex) -> (bool, Cow<'a, str>) {
+    if let Some(value) = provider.get_filter_value(ItemField::Title) {
         if rewc.re.is_match(&value) {
             return (true, value);
         }
     }
 
-    if let Some(value) = provider.get("name") {
+    if let Some(value) = provider.get_filter_value(ItemField::Name) {
         if rewc.re.is_match(&value) {
             return (true, value);
         }
     }
-    (false, "".intern())
+    (false, Cow::Borrowed(""))
 }
 
 impl Filter {
@@ -121,10 +122,10 @@ impl Filter {
             Self::FieldComparison(field, rewc) => {
                 let (is_match, value) = if field == &ItemField::Caption {
                     get_caption(provider, rewc)
-                } else if let Some(value) = provider.get(field.as_ref()) {
+                } else if let Some(value) = provider.get_filter_value(*field) {
                     (rewc.re.is_match(&value), value)
                 } else {
-                    (false, "".intern())
+                    (false, Cow::Borrowed(""))
                 };
                 if log_enabled!(Level::Trace) {
                     if is_match {
@@ -136,25 +137,24 @@ impl Filter {
                 is_match
             }
             Self::TypeComparison(field, item_type) => {
-                if let Some(value) = provider.get(field.as_ref()) {
-                    get_filter_item_type(&value).is_some_and(|pli_type| {
-                        let is_match = match item_type {
-                            PlaylistItemType::Video => pli_type.is_video(),
-                            PlaylistItemType::Series => pli_type.is_series(),
-                            _ => pli_type.eq(item_type),
-                        };
-                        if log_enabled!(Level::Trace) {
-                            if is_match {
-                                trace!("Match found: {field:?} {value}");
-                            } else {
-                                trace!("Match failed: {self}: {field:?} {value}");
-                            }
-                        }
-                        is_match
-                    })
-                } else {
-                    false
+                let actual = provider.pli.header.item_type;
+                let is_match = match item_type {
+                    PlaylistItemType::Live => actual.is_live(),
+                    PlaylistItemType::Video => actual.is_video(),
+                    PlaylistItemType::Series => {
+                        actual.is_series()
+                            || matches!(actual, PlaylistItemType::SeriesInfo | PlaylistItemType::LocalSeriesInfo)
+                    }
+                    _ => actual == *item_type,
+                };
+                if log_enabled!(Level::Trace) {
+                    if is_match {
+                        trace!("Match found: {field:?} {}", actual.as_str());
+                    } else {
+                        trace!("Match failed: {self}: {field:?} {}", actual.as_str());
+                    }
                 }
+                is_match
             }
             Self::Group(expr) => expr.filter(provider),
             Self::UnaryExpression(op, expr) => match op {
@@ -312,7 +312,7 @@ fn get_parser_expression(
     templates: Option<&[PatternTemplate]>,
     errors: &mut Vec<String>,
 ) -> Result<Filter, String> {
-    let mut stmts = Vec::with_capacity(128);
+    let mut stmts = Vec::new();
     let pairs = expr.into_inner();
     let mut bop: Option<BinaryOperator> = None;
     let mut uop: Option<UnaryOperator> = None;
@@ -640,9 +640,10 @@ mod tests {
             filter::{get_filter, ValueProvider},
             prepare_templates,
         },
-        model::{PatternTemplate, PlaylistItem, PlaylistItemHeader, TemplateValue},
+        model::{ItemField, PatternTemplate, PlaylistItem, PlaylistItemHeader, PlaylistItemType, TemplateValue},
         utils::{Internable, CONSTANTS},
     };
+    use std::borrow::Cow;
 
     fn create_mock_pli(name: &str, group: &str) -> PlaylistItem {
         PlaylistItem { header: PlaylistItemHeader { name: name.into(), group: group.intern(), ..Default::default() } }
@@ -831,6 +832,46 @@ mod tests {
             }
             Err(e) => panic!("{e}"),
         }
+    }
+
+    #[test]
+    fn filter_value_borrows_stored_field() {
+        let channel = create_mock_pli("Channel", "Group");
+        let provider = ValueProvider { pli: &channel, match_as_ascii: false };
+
+        assert!(matches!(provider.get_filter_value(ItemField::Name), Some(Cow::Borrowed("Channel"))));
+    }
+
+    #[test]
+    fn missing_genre_does_not_match_empty_pattern() {
+        let filter = get_filter(r#"Genre ~ "^$""#, None).expect("filter should parse");
+        let channel = create_mock_pli("Channel", "Group");
+        let provider = ValueProvider { pli: &channel, match_as_ascii: false };
+
+        assert!(!filter.filter(&provider));
+    }
+
+    #[test]
+    fn caption_checks_name_when_title_does_not_match() {
+        let filter = get_filter(r#"Caption ~ "Channel""#, None).expect("filter should parse");
+        let mut channel = create_mock_pli("Channel", "Group");
+        channel.header.title = "Different title".intern();
+        let provider = ValueProvider { pli: &channel, match_as_ascii: false };
+
+        assert!(filter.filter(&provider));
+    }
+
+    #[test]
+    fn type_filter_matches_normalized_type_families() {
+        let live_filter = get_filter("Type = live", None).expect("live filter should parse");
+        let series_filter = get_filter("Type = series", None).expect("series filter should parse");
+        let mut channel = create_mock_pli("Channel", "Group");
+
+        channel.header.item_type = PlaylistItemType::LiveHls;
+        assert!(live_filter.filter(&ValueProvider { pli: &channel, match_as_ascii: false }));
+
+        channel.header.item_type = PlaylistItemType::LocalSeriesInfo;
+        assert!(series_filter.filter(&ValueProvider { pli: &channel, match_as_ascii: false }));
     }
 
     #[test]

--- a/shared/src/foundation/mapper.pest
+++ b/shared/src/foundation/mapper.pest
@@ -10,13 +10,16 @@ number_range_to = { ".." ~ number }
 number_range_full = { number ~ ".." ~ number }
 number_range_eq = { number }
 number_range = _{ number_range_full | number_range_from | number_range_to | number_range_eq}
-field = { ^"name" | ^"title" | ^"caption" | ^"group" | ^"id" | ^"chno" | ^"logo" | ^"logo_small" | ^"parent_code" | ^"audio_track" | ^"time_shift" | ^"rec" | ^"url" | ^"epg_channel_id" | ^"epg_id" | ^"genre" }
+read_write_field = _{ ^"name" | ^"title" | ^"caption" | ^"group" | ^"id" | ^"chno" | ^"logo" | ^"logo_small" | ^"parent_code" | ^"audio_track" | ^"time_shift" | ^"rec" | ^"url" | ^"epg_channel_id" | ^"epg_id" | ^"genre" }
+read_only_field = _{ ^"input" | ^"type" }
+field = { read_write_field | read_only_field }
+assignment_field = { read_write_field }
 field_access = _{ "@" ~ field }
 regex_source = _{ field_access | identifier }
 regex_expr = { regex_source ~ regex_op ~ string_literal }
 block_expr = { "{" ~ statements ~ "}" }
 condition = { function_call | var_access | field_access }
-assignment = { (field_access | identifier) ~ "=" ~ expression }
+assignment = { (("@" ~ assignment_field) | identifier) ~ "=" ~ expression }
 expression = { assignment | map_block | match_block | for_each_block | function_call | regex_expr | string_literal | number | var_access | field_access | null | block_expr }
 function_name = { "concat" | "uppercase" | "lowercase" | "capitalize" | "split" | "trim" | "print" | "number" | "first" | "template" | "replace" | "pad" | "format" | "add_favourite" }
 function_call = { function_name ~ "(" ~ (expression ~ ("," ~ expression)*)? ~ ")" }

--- a/shared/src/foundation/mapper.rs
+++ b/shared/src/foundation/mapper.rs
@@ -1614,6 +1614,9 @@ impl Expression {
                     Failure(_) => return key_value,
                     _ => Vec::new(),
                 };
+                let previous_key_var = expr.key_var.as_ref().and_then(|key_var| ctx.variables.get(key_var).cloned());
+                let previous_value_var =
+                    expr.value_var.as_ref().and_then(|value_var| ctx.variables.get(value_var).cloned());
                 for (k, val) in values {
                     if let Some(key_var) = &expr.key_var {
                         ctx.set_var(key_var, EvalResult::Value(k));
@@ -1624,10 +1627,18 @@ impl Expression {
                     expr.expression.eval(ctx, accessor);
                 }
                 if let Some(key_var) = &expr.key_var {
-                    ctx.variables.remove(key_var);
+                    if let Some(previous) = previous_key_var {
+                        ctx.set_var(key_var, previous);
+                    } else {
+                        ctx.variables.remove(key_var);
+                    }
                 }
                 if let Some(value_var) = &expr.value_var {
-                    ctx.variables.remove(value_var);
+                    if let Some(previous) = previous_value_var {
+                        ctx.set_var(value_var, previous);
+                    } else {
+                        ctx.variables.remove(value_var);
+                    }
                 }
                 Undefined
             }
@@ -2043,5 +2054,30 @@ mod tests {
         let mut accessor = ValueAccessor { pli: &mut series_info, virtual_items: vec![], match_as_ascii: false };
         mapper.eval(&mut accessor, None);
         assert_eq!(accessor.virtual_items.len(), 3);
+    }
+
+    #[test]
+    fn for_each_restores_existing_loop_variables() {
+        let expressions = vec![
+            Expression::Identifier("value".to_string()),
+            Expression::ForEachBlock {
+                key: ForEachKey::Identifier("items".to_string()),
+                expr: ForEachExpr {
+                    key_var: Some("key".to_string()),
+                    value_var: Some("value".to_string()),
+                    expression: ExprId(0),
+                },
+            },
+        ];
+        let mut ctx = MapperContext::new(&expressions, None);
+        ctx.set_var("items", Named(vec![("first".to_string(), "current".to_string())]));
+        ctx.set_var("value", Value("outer".to_string()));
+        let mut item = PlaylistItem { header: PlaylistItemHeader::default() };
+        let mut accessor = ValueAccessor { pli: &mut item, virtual_items: vec![], match_as_ascii: false };
+
+        ExprId(1).eval(&mut ctx, &mut accessor);
+
+        assert!(matches!(ctx.get_var("value"), Value(value) if value == "outer"));
+        assert!(matches!(ctx.get_var("key"), Undefined));
     }
 }

--- a/shared/src/foundation/mapper.rs
+++ b/shared/src/foundation/mapper.rs
@@ -37,13 +37,16 @@ number_range_to = { ".." ~ number }
 number_range_full = { number ~ ".." ~ number }
 number_range_eq = { number }
 number_range = _{ number_range_full | number_range_from | number_range_to | number_range_eq}
-field = { ^"name" | ^"title" | ^"caption" | ^"group" | ^"id" | ^"chno" | ^"logo" | ^"logo_small" | ^"parent_code" | ^"audio_track" | ^"time_shift" | ^"rec" | ^"url" | ^"epg_channel_id" | ^"epg_id" | ^"genre" }
+read_write_field = _{ ^"name" | ^"title" | ^"caption" | ^"group" | ^"id" | ^"chno" | ^"logo" | ^"logo_small" | ^"parent_code" | ^"audio_track" | ^"time_shift" | ^"rec" | ^"url" | ^"epg_channel_id" | ^"epg_id" | ^"genre" }
+read_only_field = _{ ^"input" | ^"type" }
+field = { read_write_field | read_only_field }
+assignment_field = { read_write_field }
 field_access = _{ "@" ~ field }
 regex_source = _{ field_access | identifier }
 regex_expr = { regex_source ~ regex_op ~ string_literal }
 block_expr = { "{" ~ statements ~ "}" }
 condition = { function_call | var_access | field_access }
-assignment = { (field_access | identifier) ~ "=" ~ expression }
+assignment = { (("@" ~ assignment_field) | identifier) ~ "=" ~ expression }
 expression = { assignment | map_block | match_block | for_each_block | function_call | regex_expr | string_literal | number | var_access | field_access | null | block_expr }
 function_name = { "concat" | "uppercase" | "lowercase" | "capitalize" | "split" | "trim" | "print" | "number" | "first" | "template" | "replace" | "pad" | "format" | "add_favourite" }
 function_call = { function_name ~ "(" ~ (expression ~ ("," ~ expression)*)? ~ ")" }
@@ -384,7 +387,7 @@ impl MapperScript {
         let name = inner.next().unwrap();
         let target = match name.as_rule() {
             Rule::identifier => AssignmentTarget::Identifier(name.as_str().to_string()),
-            Rule::field => AssignmentTarget::Field(name.as_str().to_string()),
+            Rule::assignment_field => AssignmentTarget::Field(name.as_str().to_string()),
             _ => return Err(TuliproxError::Mapper(format!("Assignment target isn't supported {}", name.as_str()))),
         };
         let next = inner.next().unwrap();
@@ -1086,17 +1089,19 @@ fn eval_regex(source: &str, re_pattern: &Regex, match_as_ascii: bool) -> EvalRes
     let source = if match_as_ascii { deunicode_string(source) } else { Cow::Borrowed(source) };
     let mut values = vec![];
 
-    for caps in re_pattern.captures_iter(&source) {
-        for i in 1..caps.len() {
-            if let Some(value) = caps.get(i) {
-                values.push((i.to_string(), value.as_str().to_string()));
-            }
-        }
+    let Some(caps) = re_pattern.captures(&source) else {
+        return Undefined;
+    };
 
-        for name in re_pattern.capture_names().flatten() {
-            if let Some(value) = caps.name(name) {
-                values.push((name.to_string(), value.as_str().to_string()));
-            }
+    for i in 1..caps.len() {
+        if let Some(value) = caps.get(i) {
+            values.push((i.to_string(), value.as_str().to_string()));
+        }
+    }
+
+    for name in re_pattern.capture_names().flatten() {
+        if let Some(value) = caps.name(name) {
+            values.push((name.to_string(), value.as_str().to_string()));
         }
     }
 
@@ -1164,6 +1169,7 @@ impl Expression {
                 None => Failure(format!("Variable with name {name} not found.")),
                 Some(value) => match value {
                     Undefined => Undefined,
+                    Value(value) if field == "1" => Value(value.clone()),
                     Number(_) | Value(_) => Failure(format!("Variable with name {name} has no fields.")),
                     Named(values) => {
                         for (key, val) in values {
@@ -1488,6 +1494,14 @@ impl Expression {
                         None => Failure(format!("Variable with name {name} not found.")),
                         Some(value) => match value {
                             Undefined => Undefined,
+                            Value(value) if field == "1" => {
+                                let value = if accessor.match_as_ascii {
+                                    deunicode_string(value).into_owned()
+                                } else {
+                                    value.clone()
+                                };
+                                Value(value)
+                            }
                             Number(_) | Value(_) => Failure(format!("Variable with name {name} has no fields.")),
                             Named(values) => {
                                 for (key, val) in values {
@@ -1802,6 +1816,110 @@ mod tests {
         mapper.eval(&mut accessor, None);
 
         assert_eq!(accessor.pli.header.group.as_ref(), "matched");
+    }
+
+    #[test]
+    fn regex_evaluation_keeps_all_groups_from_only_the_first_match() -> Result<(), Box<dyn std::error::Error>> {
+        let regex = Regex::new(r"(?P<one>[A-Z])([A-Z])(?P<three>[A-Z])([A-Z])(?P<five>[A-Z])([A-Z])")?;
+
+        let Named(values) = eval_regex("ABCDEFUVWXYZ", &regex, false) else {
+            return Err("regex captures should produce a named result".into());
+        };
+
+        assert_eq!(
+            values,
+            [
+                ("1", "A"),
+                ("2", "B"),
+                ("3", "C"),
+                ("4", "D"),
+                ("5", "E"),
+                ("6", "F"),
+                ("one", "A"),
+                ("three", "C"),
+                ("five", "E"),
+            ]
+            .map(|(key, value)| (key.to_string(), value.to_string()))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn regex_capture_groups_are_available_by_index_and_name() -> Result<(), Box<dyn std::error::Error>> {
+        let dsl = r#"
+            captures = @Name ~ "(?P<one>[A-Z])([A-Z])(?P<three>[A-Z])([A-Z])(?P<five>[A-Z])([A-Z])"
+            @Title = concat(captures.1, captures.2, captures.3, captures.4, captures.5, captures.6)
+            @Group = concat(captures.one, captures.three, captures.five)
+        "#;
+        let mapper = MapperScript::parse(dsl, None)?;
+        let mut channel = PlaylistItem { header: PlaylistItemHeader { name: "ABCDEF".intern(), ..Default::default() } };
+        let mut accessor = ValueAccessor { pli: &mut channel, virtual_items: vec![], match_as_ascii: false };
+
+        mapper.eval(&mut accessor, None);
+
+        assert_eq!(accessor.pli.header.title.as_ref(), "ABCDEF");
+        assert_eq!(accessor.pli.header.group.as_ref(), "ACE");
+        Ok(())
+    }
+
+    #[test]
+    fn single_regex_capture_is_available_as_scalar_and_by_index() -> Result<(), Box<dyn std::error::Error>> {
+        let dsl = r#"
+            capture = @Name ~ "([A-Z]+)"
+            @Group = map capture.1 {
+                "ABC" => concat(capture, ":", capture.1),
+                _ => "missed",
+            }
+        "#;
+        let mapper = MapperScript::parse(dsl, None)?;
+        let mut channel = PlaylistItem { header: PlaylistItemHeader { name: "ABC".intern(), ..Default::default() } };
+        let mut accessor = ValueAccessor { pli: &mut channel, virtual_items: vec![], match_as_ascii: false };
+
+        mapper.eval(&mut accessor, None);
+
+        assert_eq!(accessor.pli.header.group.as_ref(), "ABC:ABC");
+        Ok(())
+    }
+
+    #[test]
+    fn read_only_fields_work_in_direct_regex_and_map_expressions() -> Result<(), Box<dyn std::error::Error>> {
+        let dsl = r#"
+            input_match = @Input ~ "(source)"
+            type_match = @Type ~ "(live)"
+            @Title = concat(@Input, ":", @Type, ":", input_match, ":", type_match)
+            @Group = map @Input {
+                "source" => "input-map",
+                _ => "missed",
+            }
+            @Name = map @Type {
+                "live" => concat(@Group, ":type-map"),
+                _ => "missed",
+            }
+        "#;
+        let mapper = MapperScript::parse(dsl, None)?;
+        let mut channel = PlaylistItem {
+            header: PlaylistItemHeader {
+                input_name: "source".intern(),
+                item_type: PlaylistItemType::Live,
+                ..Default::default()
+            },
+        };
+        let mut accessor = ValueAccessor { pli: &mut channel, virtual_items: vec![], match_as_ascii: false };
+
+        mapper.eval(&mut accessor, None);
+
+        assert_eq!(accessor.pli.header.title.as_ref(), "source:live:source:live");
+        assert_eq!(accessor.pli.header.group.as_ref(), "input-map");
+        assert_eq!(accessor.pli.header.name.as_ref(), "input-map:type-map");
+        Ok(())
+    }
+
+    #[test]
+    fn read_only_field_assignments_are_rejected() {
+        for script in [r#"@Input = "changed""#, r#"@Type = "movie""#] {
+            assert!(MapperScript::parse(script, None).is_err());
+        }
+        assert!(MapperScript::parse(r#"@Group = "changed""#, None).is_ok());
     }
 
     #[test]

--- a/shared/src/foundation/mapper.rs
+++ b/shared/src/foundation/mapper.rs
@@ -17,7 +17,7 @@ use std::{
     borrow::Cow,
     cmp::Ordering,
     collections::{HashMap, HashSet},
-    fmt::{Display, Write},
+    fmt::Display,
     ops::Deref,
     str::FromStr,
     sync::Arc,
@@ -197,7 +197,7 @@ impl FromStr for BuiltInFunction {
 
 impl Display for BuiltInFunction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let str = match &self {
+        f.write_str(match self {
             Self::Concat => "concat",
             Self::Capitalize => "capitalize",
             Self::Lowercase => "lowercase",
@@ -212,9 +212,7 @@ impl Display for BuiltInFunction {
             Self::Pad => "pad",
             Self::Format => "format",
             Self::AddFavourite => "add_favourite",
-        }
-        .to_owned();
-        write!(f, "{str}")
+        })
     }
 }
 
@@ -323,8 +321,8 @@ impl Statement {
 
 impl MapperScript {
     fn validate(
-        expressions: &Vec<Expression>,
-        statements: &Vec<Statement>,
+        expressions: &[Expression],
+        statements: &[Statement],
         templates: Option<&[PatternTemplate]>,
     ) -> Result<(), TuliproxError> {
         let ctx = &mut MapperContext::new(expressions, templates);
@@ -723,41 +721,30 @@ impl MapperScript {
 }
 
 pub struct MapperContext<'a> {
-    expressions: &'a Vec<Expression>,
+    expressions: &'a [Expression],
     variables: HashMap<String, EvalResult>,
-    templates: Option<HashMap<String, &'a PatternTemplate>>,
+    templates: Option<&'a [PatternTemplate]>,
 }
 
 impl<'a> MapperContext<'a> {
-    fn new(expressions: &'a Vec<Expression>, templates: Option<&'a [PatternTemplate]>) -> Self {
-        Self {
-            expressions,
-            variables: HashMap::new(),
-            templates: templates.and_then(|vec_templates| {
-                if vec_templates.is_empty() {
-                    None
-                } else {
-                    let mut hash_map = HashMap::new();
-                    for template in vec_templates {
-                        hash_map.insert(template.name.to_string(), template);
-                    }
-                    Some(hash_map)
-                }
-            }),
-        }
+    fn new(expressions: &'a [Expression], templates: Option<&'a [PatternTemplate]>) -> Self {
+        Self { expressions, variables: HashMap::new(), templates: templates.filter(|templates| !templates.is_empty()) }
     }
 
     fn get_template(&self, name: &str) -> Option<&str> {
-        match self.templates.as_ref() {
-            None => None,
-            Some(templates) => templates.get(name).and_then(|&template| match &template.value {
-                TemplateValue::Single(v) => Some(v.as_str()),
-                TemplateValue::Multi(_) => None,
-            }),
-        }
+        self.templates?.iter().rev().find(|template| template.name == name).and_then(|template| match &template.value {
+            TemplateValue::Single(v) => Some(v.as_str()),
+            TemplateValue::Multi(_) => None,
+        })
     }
 
-    fn set_var(&mut self, name: &str, value: EvalResult) { self.variables.insert(name.to_string(), value); }
+    fn set_var(&mut self, name: &str, value: EvalResult) {
+        if let Some(current) = self.variables.get_mut(name) {
+            *current = value;
+        } else {
+            self.variables.insert(name.to_string(), value);
+        }
+    }
 
     fn has_var(&self, name: &str) -> bool { self.variables.contains_key(name) }
 
@@ -1043,18 +1030,6 @@ fn cmp_number(num: f64, s: &str) -> Option<Ordering> {
 }
 
 impl EvalResult {
-    fn matches(&self, other: &EvalResult) -> bool {
-        match (self, other) {
-            (AnyValue, _) | (_, AnyValue) => true,
-            (Value(a), Value(b)) => a == b,
-            (Number(a), Value(b)) => match_number(*a, b),
-            (Value(a), Number(b)) => match_number(*b, a),
-            (Number(a), Number(b)) => compare_number(*a, *b) == Ordering::Equal,
-            (Named(a), Named(b)) => compare_tuple_vec(a, b),
-            _ => false,
-        }
-    }
-
     fn compare(&self, other: &EvalResult) -> Option<Ordering> {
         match (self, other) {
             (AnyValue, _) | (_, AnyValue) => Some(Ordering::Equal),
@@ -1105,6 +1080,40 @@ fn concat_args(args: &Vec<EvalResult>) -> Vec<Cow<'_, str>> {
     }
 
     result
+}
+
+fn eval_regex(source: &str, re_pattern: &Regex, match_as_ascii: bool) -> EvalResult {
+    let source = if match_as_ascii { deunicode_string(source) } else { Cow::Borrowed(source) };
+    let mut values = vec![];
+
+    for caps in re_pattern.captures_iter(&source) {
+        for i in 1..caps.len() {
+            if let Some(value) = caps.get(i) {
+                values.push((i.to_string(), value.as_str().to_string()));
+            }
+        }
+
+        for name in re_pattern.capture_names().flatten() {
+            if let Some(value) = caps.name(name) {
+                values.push((name.to_string(), value.as_str().to_string()));
+            }
+        }
+    }
+
+    match values.len() {
+        0 => Undefined,
+        1 => values.pop().map_or(Undefined, |(_, value)| Value(value)),
+        _ => Named(values),
+    }
+}
+
+fn matches_text(value: &EvalResult, expected: &str) -> bool {
+    match value {
+        AnyValue => true,
+        Value(actual) => actual == expected,
+        Number(actual) => match_number(*actual, expected),
+        Undefined | Named(_) | Failure(_) => false,
+    }
 }
 
 macro_rules! extract_evaluated_arg_value {
@@ -1169,43 +1178,15 @@ impl Expression {
             },
             Expression::StringLiteral(s) => Value(s.clone()),
             Expression::NumberLiteral(num) => Number(*num),
-            Expression::RegexExpr { field, pattern: _pattern, re_pattern } => {
-                let source = match field {
-                    RegexSource::Identifier(ident) => match ctx.get_var(ident) {
-                        Value(text) => Some(text.as_str().into()),
-                        _ => None,
-                    },
-                    RegexSource::Field(field) => accessor.get(field),
-                };
-                if let Some(mut val) = source {
-                    if accessor.match_as_ascii {
-                        val = deunicode_string(&val).into_owned().into();
-                    }
-                    let mut values = vec![];
-                    for caps in re_pattern.captures_iter(&val) {
-                        // Positional groups
-                        for i in 1..caps.len() {
-                            if let Some(m) = caps.get(i) {
-                                values.push((i.to_string(), m.as_str().to_string()));
-                            }
-                        }
-
-                        // named groups
-                        for name in re_pattern.capture_names().flatten() {
-                            if let Some(m) = caps.name(name) {
-                                values.push((name.to_string(), m.as_str().to_string()));
-                            }
-                        }
-                    }
-                    if values.is_empty() {
-                        return Undefined;
-                    } else if values.len() == 1 {
-                        return Value(values[0].1.to_string());
-                    }
-                    return Named(values);
-                }
-                Undefined
-            }
+            Expression::RegexExpr { field, pattern: _pattern, re_pattern } => match field {
+                RegexSource::Identifier(ident) => match ctx.get_var(ident) {
+                    Value(text) => eval_regex(text, re_pattern, accessor.match_as_ascii),
+                    _ => Undefined,
+                },
+                RegexSource::Field(field) => accessor
+                    .get(field)
+                    .map_or(Undefined, |value| eval_regex(&value, re_pattern, accessor.match_as_ascii)),
+            },
             Expression::Assignment { target, expr } => {
                 let val = expr.eval(ctx, accessor);
                 match target {
@@ -1418,7 +1399,7 @@ impl Expression {
                                     if ch == '{' && chars.peek() == Some(&'}') {
                                         chars.next();
                                         if let Some(Some(arg)) = arg_iter.next() {
-                                            write!(formatted, "{arg}").unwrap();
+                                            formatted.push_str(arg);
                                         } else {
                                             formatted.push_str("{}");
                                         }
@@ -1529,7 +1510,7 @@ impl Expression {
                     let mut matches = false;
                     for key in &map_case.keys {
                         if match key {
-                            MapCaseKey::Text(value) => key_value.matches(&Value(value.to_string())),
+                            MapCaseKey::Text(value) => matches_text(&key_value, value),
                             MapCaseKey::AnyMatch => true,
                             MapCaseKey::RangeFrom(num) => match key_value.compare(&Number(*num)) {
                                 None => false,
@@ -1801,6 +1782,50 @@ mod tests {
             mapper.eval(&mut accessor, None);
             println!("Result: {pli:?}");
         }
+    }
+
+    #[test]
+    fn regex_identifier_ascii_normalization_preserves_map_selection() {
+        let dsl = r#"
+            source = @Name
+            capture = source ~ "(Cinema)"
+            @Group = map capture {
+                "Cinema" => "matched",
+                _ => "missed",
+            }
+        "#;
+        let mapper = MapperScript::parse(dsl, None).expect("mapper should parse");
+        let mut channel =
+            PlaylistItem { header: PlaylistItemHeader { name: "Cinéma".intern(), ..Default::default() } };
+        let mut accessor = ValueAccessor { pli: &mut channel, virtual_items: vec![], match_as_ascii: true };
+
+        mapper.eval(&mut accessor, None);
+
+        assert_eq!(accessor.pli.header.group.as_ref(), "matched");
+    }
+
+    #[test]
+    fn template_lookup_keeps_last_duplicate_value() {
+        let dsl = r#"@Group = template("label")"#;
+        let templates = vec![
+            PatternTemplate {
+                name: "label".to_string(),
+                value: TemplateValue::Single("first".to_string()),
+                placeholder: "!label!".to_string(),
+            },
+            PatternTemplate {
+                name: "label".to_string(),
+                value: TemplateValue::Single("second".to_string()),
+                placeholder: "!label!".to_string(),
+            },
+        ];
+        let mapper = MapperScript::parse(dsl, Some(&templates)).expect("mapper should parse");
+        let mut channel = PlaylistItem { header: PlaylistItemHeader::default() };
+        let mut accessor = ValueAccessor { pli: &mut channel, virtual_items: vec![], match_as_ascii: false };
+
+        mapper.eval(&mut accessor, Some(&templates));
+
+        assert_eq!(accessor.pli.header.group.as_ref(), "second");
     }
 
     #[test]

--- a/shared/src/foundation/value_provider.rs
+++ b/shared/src/foundation/value_provider.rs
@@ -1,8 +1,8 @@
 use crate::{
-    model::{FieldGetAccessor, ItemField, PlaylistItem},
+    model::{FieldGetAccessor, ItemField, PlaylistItem, StreamProperties},
     utils::{deunicode_string, Internable},
 };
-use std::sync::Arc;
+use std::{borrow::Cow, sync::Arc};
 
 #[macro_export]
 macro_rules! set_genre {
@@ -173,6 +173,32 @@ pub struct ValueProvider<'a> {
 }
 
 impl ValueProvider<'_> {
+    pub(crate) fn get_filter_value(&self, field: ItemField) -> Option<Cow<'_, str>> {
+        let header = &self.pli.header;
+        let value = match field {
+            ItemField::Group => header.group.as_ref(),
+            ItemField::Name => header.name.as_ref(),
+            ItemField::Title => header.title.as_ref(),
+            ItemField::Genre => match header.additional_properties.as_ref()? {
+                StreamProperties::Video(video) => video.details.as_ref()?.genre.as_deref()?,
+                StreamProperties::Series(series) => series.genre.as_deref()?,
+                StreamProperties::Live(_) | StreamProperties::Episode(_) => return None,
+            },
+            ItemField::Url => header.url.as_ref(),
+            ItemField::Input => header.input_name.as_ref(),
+            ItemField::Type => header.item_type.as_str(),
+            ItemField::Caption => {
+                if header.title.is_empty() {
+                    header.name.as_ref()
+                } else {
+                    header.title.as_ref()
+                }
+            }
+        };
+
+        Some(if self.match_as_ascii { deunicode_string(value) } else { Cow::Borrowed(value) })
+    }
+
     pub fn get(&self, field: &str) -> Option<Arc<str>> {
         let val = self.pli.header.get_field(field)?;
         if self.match_as_ascii {


### PR DESCRIPTION
fixed: input form state 
optimized filter and mapping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Input forms now consistently update when switching between configured sources.
  - Improved filter matching for captions/titles and more accurate type handling for live/video/series (including series-info variants).
- **New Features**
  - Mapping DSL now supports reading `@input` and `@type` as metadata sources, while rejecting assignments to them.
  - Regex capture results are now more consistently exposed across captures (by index and name).
- **Tests**
  - Added WASM browser coverage for input switching and updated coverage for filter/mapping behavior.
- **Documentation**
  - Updated mapping DSL documentation and changelog to reflect `@input`/`@type` read-only behavior and capture access rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->