### PR TITLE
QOS compacting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,10 @@
 
 ## 🌟 New Features
 
+- **QoS snapshot compaction**: `qos_aggregation.compaction_interval_secs` now periodically rebuilds
+  `qos_snapshot.db` to reclaim storage from expired snapshots. It defaults to daily; set it to `0` to disable
+  automatic compaction without changing QoS summary windows.
+
 - **STRM metadata naming option**: STRM outputs now accept `use_metadata: true` to prefer media metadata names for
   generated folders and filenames. The default remains the target's processed title, so title rename and mapping rules
   apply to STRM paths without additional configuration.

--- a/backend/src/api/endpoints/stream_history_api.rs
+++ b/backend/src/api/endpoints/stream_history_api.rs
@@ -1188,6 +1188,7 @@ mod tests {
                 qos_aggregation: Some(QosAggregationConfig {
                     enabled: false,
                     interval_secs: 300,
+                    compaction_interval_secs: 86_400,
                 }),
                 hls_cache: None,
             }),
@@ -1200,6 +1201,7 @@ mod tests {
             reverse_proxy.qos_aggregation = Some(QosAggregationConfig {
                 enabled: true,
                 interval_secs: 300,
+                compaction_interval_secs: 86_400,
             });
         }
 

--- a/backend/src/api/model/app_state.rs
+++ b/backend/src/api/model/app_state.rs
@@ -910,7 +910,7 @@ fn qos_aggregation_changed(old_config: &Config, new_config: &Config) -> bool {
         })
     };
     let qos_tuple = |cfg: Option<&crate::model::QosAggregationConfig>| {
-        cfg.map(|qos| (qos.enabled, qos.interval_secs))
+        cfg.map(|qos| (qos.enabled, qos.interval_secs, qos.compaction_interval_secs))
     };
 
     stream_history_tuple(old_stream_history) != stream_history_tuple(new_stream_history)
@@ -1070,7 +1070,7 @@ mod tests {
                     stream_history_retention_days: 7,
                     stream_history_directory: "/tmp/history".to_string(),
                 }),
-                qos_aggregation: Some(QosAggregationConfigDto { enabled: true, interval_secs: 60 }),
+                qos_aggregation: Some(QosAggregationConfigDto { enabled: true, interval_secs: 60, ..Default::default() }),
                 ..Default::default()
             })),
             ..Config::default()
@@ -1081,6 +1081,27 @@ mod tests {
             if let Some(history) = reverse_proxy.stream_history.as_mut() {
                 history.stream_history_batch_size = 128;
             }
+        }
+
+        assert!(qos_aggregation_changed(&old_config, &new_config));
+    }
+
+    #[test]
+    fn qos_aggregation_changed_detects_compaction_interval_changes() {
+        let old_config = Config {
+            reverse_proxy: Some(crate::model::ReverseProxyConfig::from(&ReverseProxyConfigDto {
+                qos_aggregation: Some(QosAggregationConfigDto {
+                    enabled: true,
+                    interval_secs: 60,
+                    compaction_interval_secs: 86_400,
+                }),
+                ..Default::default()
+            })),
+            ..Config::default()
+        };
+        let mut new_config = old_config.clone();
+        if let Some(qos) = new_config.reverse_proxy.as_mut().and_then(|proxy| proxy.qos_aggregation.as_mut()) {
+            qos.compaction_interval_secs = 3_600;
         }
 
         assert!(qos_aggregation_changed(&old_config, &new_config));

--- a/backend/src/api/model/qos_aggregation_manager.rs
+++ b/backend/src/api/model/qos_aggregation_manager.rs
@@ -13,7 +13,7 @@ use crate::api::model::AppState;
 use crate::model::{Config, StreamHistoryRecord};
 use crate::repository::{
     extract_day_from_filename,
-    QosSnapshotDailyBucket, QosSnapshotRecord, QosSnapshotRepository, QosSnapshotWindow,
+    QosAggregationCheckpoint, QosSnapshotDailyBucket, QosSnapshotRecord, QosSnapshotRepository, QosSnapshotWindow,
     StreamHistoryFileReader,
 };
 use crate::utils::{current_utc_day, now_utc_secs};
@@ -66,6 +66,7 @@ pub(in crate::api) fn exec_qos_aggregation(app_state: &Arc<AppState>, cancel_tok
     let history_dir = PathBuf::from(history.stream_history_directory.clone());
     let storage_dir = PathBuf::from(config.storage_dir.clone());
     let interval = Duration::from_secs(qos.interval_secs.max(1));
+    let compaction_interval_secs = qos.compaction_interval_secs;
     let cancel = cancel_token.clone();
 
     tokio::spawn(async move {
@@ -82,7 +83,7 @@ pub(in crate::api) fn exec_qos_aggregation(app_state: &Arc<AppState>, cancel_tok
             let repo_clone = repo.clone();
             let history_dir_clone = history_dir.clone();
             if let Err(err) = tokio::task::spawn_blocking(move || {
-                run_aggregation_once(&repo_clone, &history_dir_clone, &today)
+                run_aggregation_once(&repo_clone, &history_dir_clone, &today, compaction_interval_secs)
             }).await.unwrap_or_else(|e| Err(std::io::Error::other(e.to_string()))) {
                 warn!("QoS aggregation run failed: {err}");
             }
@@ -102,6 +103,17 @@ pub(crate) fn run_aggregation_once(
     repo: &QosSnapshotRepository,
     history_dir: &Path,
     today_utc: &str,
+    compaction_interval_secs: u64,
+) -> io::Result<()> {
+    run_aggregation_once_at(repo, history_dir, today_utc, compaction_interval_secs, now_utc_secs())
+}
+
+fn run_aggregation_once_at(
+    repo: &QosSnapshotRepository,
+    history_dir: &Path,
+    today_utc: &str,
+    compaction_interval_secs: u64,
+    now_utc_secs: u64,
 ) -> io::Result<()> {
     let mut checkpoint = repo.load_checkpoint()?;
     let days = discover_history_days(history_dir)?;
@@ -128,13 +140,38 @@ pub(crate) fn run_aggregation_once(
     {
         checkpoint.last_completed_day_utc = Some(last_completed_day_utc);
     }
-    checkpoint.last_successful_run_ts_utc = now_utc_secs();
+    checkpoint.last_successful_run_ts_utc = now_utc_secs;
     checkpoint.current_day_utc = Some(today_utc.to_string());
     checkpoint.current_day_revision_secs = current_day_revision.map(|revision| revision.0);
     checkpoint.current_day_revision_len = current_day_revision.map(|revision| revision.1);
     repo.store_checkpoint(&checkpoint)?;
+    if compact_if_due(&mut checkpoint, compaction_interval_secs, now_utc_secs, || repo.compact_snapshots())? {
+        repo.store_checkpoint(&checkpoint)?;
+    }
 
     Ok(())
+}
+
+fn compaction_is_due(last_compaction_at_utc: u64, interval_secs: u64, now_utc_secs: u64) -> bool {
+    interval_secs != 0
+        && (last_compaction_at_utc == 0 || now_utc_secs.saturating_sub(last_compaction_at_utc) >= interval_secs)
+}
+
+fn compact_if_due<F>(
+    checkpoint: &mut QosAggregationCheckpoint,
+    compaction_interval_secs: u64,
+    now_utc_secs: u64,
+    compact: F,
+) -> io::Result<bool>
+where
+    F: FnOnce() -> io::Result<()>,
+{
+    if !compaction_is_due(checkpoint.last_compaction_at_utc, compaction_interval_secs, now_utc_secs) {
+        return Ok(false);
+    }
+    compact()?;
+    checkpoint.last_compaction_at_utc = now_utc_secs;
+    Ok(true)
 }
 
 pub(crate) fn fold_record_into_bucket(bucket: &mut QosSnapshotDailyBucket, record: &StreamHistoryRecord) {
@@ -544,12 +581,13 @@ struct HistoryDayFile {
 mod tests {
     use std::collections::BTreeMap;
 
-    use super::{fold_record_into_bucket, history_day_revision, qos_aggregation_is_enabled, rebuild_windows, run_aggregation_once};
+    use super::{compact_if_due, compaction_is_due, fold_record_into_bucket, history_day_revision, qos_aggregation_is_enabled, rebuild_windows, run_aggregation_once};
     use crate::model::{Config, QosAggregationConfig, ResourceRetryConfig, ReverseProxyConfig, StreamHistoryConfig, StreamHistoryRecord, RECORD_SCHEMA_VERSION};
     use crate::repository::{
         serialize_named, write_block_magic, write_file_magic, write_framed, BlockHeaderBody,
         CompressionKind, FileHeaderBody,
-        QosSnapshotDailyBucket, QosSnapshotRecord, QosSnapshotRepository, QosSnapshotWindow, RecordEncodingKind,
+        QosAggregationCheckpoint, QosSnapshotDailyBucket, QosSnapshotRecord, QosSnapshotRepository, QosSnapshotWindow,
+        RecordEncodingKind,
         CONTAINER_FORMAT_VERSION, SOURCE_KIND_STREAM_HISTORY,
     };
     use crate::utils::current_utc_day;
@@ -810,6 +848,7 @@ mod tests {
                 qos_aggregation: Some(QosAggregationConfig {
                     enabled: true,
                     interval_secs: 300,
+                    compaction_interval_secs: 86_400,
                 }),
             }),
             ..Config::default()
@@ -823,6 +862,25 @@ mod tests {
             }
         }
         assert!(qos_aggregation_is_enabled(&config));
+    }
+
+    #[test]
+    fn compaction_due_respects_the_configured_interval() {
+        assert!(!compaction_is_due(0, 0, 100));
+        assert!(compaction_is_due(0, 60, 100));
+        assert!(!compaction_is_due(41, 60, 100));
+        assert!(compaction_is_due(40, 60, 100));
+        assert!(!compaction_is_due(101, 60, 100));
+    }
+
+    #[test]
+    fn failed_compaction_keeps_the_timestamp_due_for_retry() {
+        let mut checkpoint = QosAggregationCheckpoint::default();
+        assert!(compact_if_due(&mut checkpoint, 60, 100, || Err(std::io::Error::other("test failure"))).is_err());
+        assert_eq!(checkpoint.last_compaction_at_utc, 0);
+
+        assert!(compact_if_due(&mut checkpoint, 60, 100, || Ok(())).expect("retry should succeed"));
+        assert_eq!(checkpoint.last_compaction_at_utc, 100);
     }
 
     #[tokio::test]
@@ -847,7 +905,7 @@ mod tests {
         let repo_c = repo.clone();
         let h_dir = history_dir.clone();
         let now = today.clone();
-        tokio::task::spawn_blocking(move || run_aggregation_once(&repo_c, &h_dir, &now))
+        tokio::task::spawn_blocking(move || run_aggregation_once(&repo_c, &h_dir, &now, 0))
             .await.unwrap().expect("aggregation should succeed");
 
         let snapshot = repo
@@ -881,13 +939,13 @@ mod tests {
         let repo_c1 = repo.clone();
         let h_dir1 = history_dir.clone();
         let t_day1 = today.clone();
-        tokio::task::spawn_blocking(move || run_aggregation_once(&repo_c1, &h_dir1, &t_day1))
+        tokio::task::spawn_blocking(move || run_aggregation_once(&repo_c1, &h_dir1, &t_day1, 0))
             .await.unwrap().expect("first aggregation should succeed");
 
         let repo_c2 = repo.clone();
         let h_dir2 = history_dir.clone();
         let t_day2 = today.clone();
-        tokio::task::spawn_blocking(move || run_aggregation_once(&repo_c2, &h_dir2, &t_day2))
+        tokio::task::spawn_blocking(move || run_aggregation_once(&repo_c2, &h_dir2, &t_day2, 0))
             .await.unwrap().expect("second aggregation should succeed");
 
         let snapshot = repo
@@ -928,7 +986,7 @@ mod tests {
 
         let repo_c1 = repo.clone();
         let h_dir1 = history_dir.clone();
-        tokio::task::spawn_blocking(move || run_aggregation_once(&repo_c1, &h_dir1, "2036-04-05"))
+        tokio::task::spawn_blocking(move || run_aggregation_once(&repo_c1, &h_dir1, "2036-04-05", 0))
             .await.unwrap().expect("first aggregation should succeed");
 
         let checkpoint = repo.load_checkpoint().expect("checkpoint should load");
@@ -943,7 +1001,7 @@ mod tests {
 
         let repo_c2 = repo.clone();
         let h_dir2 = history_dir.clone();
-        tokio::task::spawn_blocking(move || run_aggregation_once(&repo_c2, &h_dir2, "2036-04-05"))
+        tokio::task::spawn_blocking(move || run_aggregation_once(&repo_c2, &h_dir2, "2036-04-05", 0))
             .await.unwrap().expect("second aggregation should succeed");
 
         let checkpoint = repo.load_checkpoint().expect("checkpoint should load");

--- a/backend/src/model/config/qos_aggregation.rs
+++ b/backend/src/model/config/qos_aggregation.rs
@@ -4,6 +4,7 @@ use shared::model::QosAggregationConfigDto;
 pub struct QosAggregationConfig {
     pub enabled: bool,
     pub interval_secs: u64,
+    pub compaction_interval_secs: u64,
 }
 
 impl From<&QosAggregationConfigDto> for QosAggregationConfig {
@@ -11,6 +12,7 @@ impl From<&QosAggregationConfigDto> for QosAggregationConfig {
         Self {
             enabled: dto.enabled,
             interval_secs: dto.interval_secs,
+            compaction_interval_secs: dto.compaction_interval_secs,
         }
     }
 }
@@ -20,6 +22,7 @@ impl From<&QosAggregationConfig> for QosAggregationConfigDto {
         Self {
             enabled: config.enabled,
             interval_secs: config.interval_secs,
+            compaction_interval_secs: config.compaction_interval_secs,
         }
     }
 }

--- a/backend/src/model/config/reverse_proxy.rs
+++ b/backend/src/model/config/reverse_proxy.rs
@@ -457,6 +457,7 @@ mod tests {
             qos_aggregation: Some(QosAggregationConfigDto {
                 enabled: true,
                 interval_secs: 300,
+                ..Default::default()
             }),
             ..Default::default()
         };

--- a/backend/src/repository/qos_snapshot_repository.rs
+++ b/backend/src/repository/qos_snapshot_repository.rs
@@ -236,6 +236,8 @@ pub struct QosAggregationCheckpoint {
     pub current_day_utc: Option<String>,
     pub current_day_revision_secs: Option<u64>,
     pub current_day_revision_len: Option<u64>,
+    #[serde(default)]
+    pub last_compaction_at_utc: u64,
 }
 
 pub struct QosSnapshotRepository {
@@ -294,6 +296,8 @@ impl QosSnapshotRepository {
         tree.commit()?;
         Ok(deleted)
     }
+
+    pub fn compact_snapshots(&self) -> io::Result<()> { self.snapshot_tree.lock().compact() }
 
     pub fn for_each_snapshot<F>(&self, mut visit: F) -> io::Result<()>
     where
@@ -360,6 +364,7 @@ fn load_snapshot_tree(path: &Path) -> io::Result<BPlusTree<String, QosSnapshotRe
 
 #[cfg(test)]
 mod tests {
+    use serde::{Deserialize, Serialize};
     use std::collections::BTreeMap;
     use std::path::Path;
 
@@ -415,10 +420,58 @@ mod tests {
             current_day_utc: Some("2026-04-02".to_string()),
             current_day_revision_secs: Some(1_700_001_000),
             current_day_revision_len: Some(4_096),
+            last_compaction_at_utc: 1_700_001_001,
         };
         repo.store_checkpoint(&checkpoint).expect("store checkpoint should succeed");
         let loaded_checkpoint = repo.load_checkpoint().expect("load checkpoint should succeed");
         assert_eq!(loaded_checkpoint, checkpoint);
+    }
+
+    #[derive(Serialize, Deserialize)]
+    struct LegacyQosAggregationCheckpoint {
+        last_completed_day_utc: Option<String>,
+        last_successful_run_ts_utc: u64,
+        current_day_utc: Option<String>,
+        current_day_revision_secs: Option<u64>,
+        current_day_revision_len: Option<u64>,
+    }
+
+    #[test]
+    fn qos_aggregation_checkpoint_defaults_missing_compaction_timestamp() {
+        let legacy = LegacyQosAggregationCheckpoint {
+            last_completed_day_utc: Some("2026-04-01".to_string()),
+            last_successful_run_ts_utc: 1_700_000_999,
+            current_day_utc: Some("2026-04-02".to_string()),
+            current_day_revision_secs: Some(1_700_001_000),
+            current_day_revision_len: Some(4_096),
+        };
+        let bytes = crate::repository::serialize_named(&legacy).expect("legacy checkpoint should serialize");
+        let checkpoint: QosAggregationCheckpoint =
+            crate::repository::deserialize_named(&bytes).expect("legacy checkpoint should deserialize");
+
+        assert_eq!(checkpoint.last_completed_day_utc, legacy.last_completed_day_utc);
+        assert_eq!(checkpoint.last_successful_run_ts_utc, legacy.last_successful_run_ts_utc);
+        assert_eq!(checkpoint.last_compaction_at_utc, 0);
+    }
+
+    #[test]
+    fn qos_snapshot_repository_compaction_reclaims_deleted_snapshot_storage() {
+        let temp = tempdir().expect("tempdir should succeed");
+        let repo = QosSnapshotRepository::open(temp.path()).expect("repo should open");
+        for index in 0..128 {
+            let snapshot = make_test_snapshot(&format!("stream-{index:03}"), 81);
+            repo.put_snapshot(&snapshot).expect("put snapshot should succeed");
+        }
+        for index in 0..127 {
+            assert!(repo.delete_snapshot(&format!("stream-{index:03}")).expect("delete should succeed"));
+        }
+        let size_before = std::fs::metadata(repo.snapshot_path()).expect("snapshot metadata should load").len();
+
+        repo.compact_snapshots().expect("compaction should succeed");
+
+        assert!(repo.get_snapshot("stream-127").expect("get should succeed").is_some());
+        let size_after = std::fs::metadata(repo.snapshot_path()).expect("snapshot metadata should load").len();
+        assert!(size_after < size_before, "compaction must reclaim snapshot storage");
     }
 
     #[test]

--- a/config/config.yml
+++ b/config/config.yml
@@ -102,6 +102,7 @@ reverse_proxy:
   # qos_aggregation:
   #   enabled: true
   #   interval_secs: 300
+  #   compaction_interval_secs: 86400
   rewrite_secret: ${env:TULIPROX_PROXY_REWRITE_SECRET} # use openssl rand -hex 16
 
 library:

--- a/docs/src/configuration/reverse-proxy.md
+++ b/docs/src/configuration/reverse-proxy.md
@@ -510,6 +510,7 @@ reverse_proxy:
   qos_aggregation:
     enabled: true
     interval_secs: 300
+    compaction_interval_secs: 86400
 ```
 
 ### QoS Aggregation Parameters
@@ -518,6 +519,7 @@ reverse_proxy:
 | :--- | :--- | :--- | :--- |
 | `enabled` | Bool | `false` | Enables the background QoS worker. Only effective if `stream_history.stream_history_enabled` is also `true`. |
 | `interval_secs` | Int | `300` | Polling interval for the aggregation loop. Lower values update snapshots faster but increase background disk and CPU work. |
+| `compaction_interval_secs` | Int | `86400` | Rebuilds `qos_snapshot.db` at this interval to reclaim B+Tree storage from expired snapshots. Set to `0` to disable automatic compaction; this does not change the rolling 30-day QoS summaries. |
 
 ### Technical Background
 

--- a/shared/src/defaults/mod.rs
+++ b/shared/src/defaults/mod.rs
@@ -84,13 +84,14 @@ mod monitoring;
 mod network;
 mod paths;
 mod primitives;
+mod qos;
 mod stream_history;
 mod tmdb;
 mod trakt;
 
 pub use self::{
     auth::*, epg::*, hdhomerun::*, hls::*, library::*, media_server::*, metadata::*, monitoring::*, network::*,
-    paths::*, primitives::*, stream_history::*, tmdb::*, trakt::*,
+    paths::*, primitives::*, qos::*, stream_history::*, tmdb::*, trakt::*,
 };
 
 /// Streaming-side defaults (auth, hls, hdhomerun, library, media_server).
@@ -105,7 +106,7 @@ pub mod integrations {
     pub use super::{epg::*, metadata::*, tmdb::*, trakt::*};
 }
 
-/// Runtime/infrastructure defaults (monitoring, network, paths, primitives, stream_history).
+/// Runtime/infrastructure defaults (monitoring, network, paths, primitives, QoS, stream history).
 pub mod runtime {
-    pub use super::{monitoring::*, network::*, paths::*, primitives::*, stream_history::*};
+    pub use super::{monitoring::*, network::*, paths::*, primitives::*, qos::*, stream_history::*};
 }

--- a/shared/src/defaults/qos.rs
+++ b/shared/src/defaults/qos.rs
@@ -1,0 +1,6 @@
+//! QoS aggregation defaults.
+
+default_eq_fns!(
+    default_qos_aggregation_interval_secs, is_default_qos_aggregation_interval_secs, u64, 300;
+    default_qos_aggregation_compaction_interval_secs, is_default_qos_aggregation_compaction_interval_secs, u64, 86_400;
+);

--- a/shared/src/model/config/qos_aggregation.rs
+++ b/shared/src/model/config/qos_aggregation.rs
@@ -1,9 +1,10 @@
-use crate::{defaults::is_false, error::TuliproxError};
-
-const fn default_qos_aggregation_interval_secs() -> u64 { 300 }
-const fn is_default_qos_aggregation_interval_secs(value: &u64) -> bool {
-    *value == default_qos_aggregation_interval_secs()
-}
+use crate::{
+    defaults::{
+        default_qos_aggregation_compaction_interval_secs, default_qos_aggregation_interval_secs,
+        is_default_qos_aggregation_compaction_interval_secs, is_default_qos_aggregation_interval_secs, is_false,
+    },
+    error::TuliproxError,
+};
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
@@ -15,14 +16,29 @@ pub struct QosAggregationConfigDto {
         skip_serializing_if = "is_default_qos_aggregation_interval_secs"
     )]
     pub interval_secs: u64,
+    #[serde(
+        default = "default_qos_aggregation_compaction_interval_secs",
+        skip_serializing_if = "is_default_qos_aggregation_compaction_interval_secs"
+    )]
+    pub compaction_interval_secs: u64,
 }
 
 impl Default for QosAggregationConfigDto {
-    fn default() -> Self { Self { enabled: false, interval_secs: default_qos_aggregation_interval_secs() } }
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            interval_secs: default_qos_aggregation_interval_secs(),
+            compaction_interval_secs: default_qos_aggregation_compaction_interval_secs(),
+        }
+    }
 }
 
 impl QosAggregationConfigDto {
-    pub fn is_empty(&self) -> bool { !self.enabled && self.interval_secs == default_qos_aggregation_interval_secs() }
+    pub fn is_empty(&self) -> bool {
+        !self.enabled
+            && self.interval_secs == default_qos_aggregation_interval_secs()
+            && self.compaction_interval_secs == default_qos_aggregation_compaction_interval_secs()
+    }
 
     pub(crate) fn prepare(&mut self, stream_history_enabled: bool) -> Result<(), TuliproxError> {
         if !stream_history_enabled {
@@ -35,5 +51,24 @@ impl QosAggregationConfigDto {
             ));
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::QosAggregationConfigDto;
+
+    #[test]
+    fn qos_aggregation_defaults_to_daily_snapshot_compaction() {
+        assert_eq!(QosAggregationConfigDto::default().compaction_interval_secs, 86_400);
+    }
+
+    #[test]
+    fn qos_aggregation_allows_disabling_automatic_snapshot_compaction() {
+        let config: QosAggregationConfigDto =
+            serde_json::from_str(r#"{"enabled":true,"interval_secs":300,"compaction_interval_secs":0}"#)
+                .expect("configuration should deserialize");
+
+        assert_eq!(config.compaction_interval_secs, 0);
     }
 }

--- a/shared/src/model/config/reverse_proxy.rs
+++ b/shared/src/model/config/reverse_proxy.rs
@@ -315,7 +315,7 @@ qos_aggregation:
     fn prepare_disables_qos_aggregation_when_stream_history_is_disabled() {
         let mut cfg = ReverseProxyConfigDto {
             rewrite_secret: "00112233445566778899aabbccddeeff".to_string(),
-            qos_aggregation: Some(QosAggregationConfigDto { enabled: true, interval_secs: 300 }),
+            qos_aggregation: Some(QosAggregationConfigDto { enabled: true, interval_secs: 300, ..Default::default() }),
             ..Default::default()
         };
 
@@ -329,7 +329,7 @@ qos_aggregation:
         let mut cfg = ReverseProxyConfigDto {
             rewrite_secret: "00112233445566778899aabbccddeeff".to_string(),
             stream_history: Some(StreamHistoryConfigDto { stream_history_enabled: true, ..Default::default() }),
-            qos_aggregation: Some(QosAggregationConfigDto { enabled: true, interval_secs: 0 }),
+            qos_aggregation: Some(QosAggregationConfigDto { enabled: true, interval_secs: 0, ..Default::default() }),
             ..Default::default()
         };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable QoS snapshot compaction to periodically reclaim storage from expired snapshots.
  - Compaction runs daily by default and can be disabled by setting the interval to `0`.
  - QoS config hot-reload now recognizes compaction interval changes.
  - Older saved snapshot checkpoints remain compatible with the new setting.
- **Documentation**
  - Updated configuration examples and reverse-proxy QoS documentation to include `compaction_interval_secs`, its default, and disable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->