### PR TITLE
fix: Flussonic/BitTV archive Streams sticky panel and catchup routing

### DIFF
--- a/backend/src/api/api_utils.rs
+++ b/backend/src/api/api_utils.rs
@@ -2535,9 +2535,9 @@ pub async fn force_provider_stream_response(
     let item_type = stream_channel.item_type;
 
     // Forced reopens must clear stale provider slots before reacquiring. For adaptive HLS/DASH
-    // sessions we only target old active stream sockets of the same session, never manifest-only
-    // session addresses, otherwise the controlling playlist request gets torn down.
-    let cleanup_addrs = if item_type.is_live_adaptive() {
+    // and Catchup sessions we only target old active stream sockets of the same session, never
+    // manifest-only session addresses, otherwise the controlling playlist request gets torn down.
+    let cleanup_addrs = if item_type.is_live_adaptive() || item_type == PlaylistItemType::Catchup {
         app_state
             .active_users
             .adaptive_session_stream_cleanup_addrs(&ctx.user.username, &user_session.token, &fingerprint.addr)
@@ -3381,7 +3381,7 @@ async fn cleanup_forced_reopen_addrs(
     item_type: PlaylistItemType,
     cleanup_addrs: &[SocketAddr],
 ) {
-    let close_client_socket = !item_type.is_live_adaptive();
+    let close_client_socket = !(item_type.is_live_adaptive() || item_type == PlaylistItemType::Catchup);
     for addr in cleanup_addrs {
         app_state.connection_manager.release_provider_connection(addr).await;
         if close_client_socket {

--- a/backend/src/api/endpoints/hls_api.rs
+++ b/backend/src/api/endpoints/hls_api.rs
@@ -103,6 +103,123 @@ fn is_m3u_catchup_session_token(session_token: &str) -> bool {
     session_token.starts_with("m3u-catchup|") || session_token.starts_with("catchup|")
 }
 
+/// Recover archive EPG reference from `m3u-catchup|╤В╨Р╨╢|archive|{start}|{duration}` session keys.
+///
+/// BitTV archive media URLs look like `╤В╨Р╨╢/2026/07/24/14/13/38-06800.ts` and lose Flussonic
+/// path markers after HLS rewrite, so the panel would otherwise keep showing Live + live EPG.
+pub(in crate::api) fn m3u_catchup_epg_reference_from_session_token(session_token: &str) -> Option<i64> {
+    let rest = session_token.strip_prefix("m3u-catchup|")?;
+    for marker in ["|archive|", "|timeshift_abs|"] {
+        if let Some(idx) = rest.rfind(marker) {
+            let after = &rest[idx + marker.len()..];
+            let start = after.split('|').next()?.trim();
+            if let Ok(ts) = start.parse::<i64>() {
+                return Some(ts);
+            }
+        }
+    }
+    None
+}
+
+fn resolve_m3u_archive_reference(stream_url: &str, session_token: Option<&str>) -> Option<i64> {
+    m3u_archive_epg_reference_ts(stream_url)
+        .or_else(|| epg_reference_ts_from_date_tree_path(stream_url))
+        .or_else(|| session_token.and_then(m3u_catchup_epg_reference_from_session_token))
+}
+
+fn looks_like_archive_media_path(path: &str) -> bool {
+    let rel = path.trim_start_matches('/');
+    if rel.is_empty() {
+        return false;
+    }
+    rel.starts_with("dvr-")
+        || rel.contains("/dvr-")
+        || rel.starts_with("202")
+        || (rel.len() >= 10 && rel.as_bytes().get(4) == Some(&b'/') && rel.starts_with('2'))
+}
+
+/// BitTV / Flussonic date-tree segments: `YYYY/MM/DD/HH/MM/SS-╤В╨Р╨╢.ts` or `dvr-YYYY/╤В╨Р╨╢`.
+pub(in crate::api) fn epg_reference_ts_from_date_tree_path(path: &str) -> Option<i64> {
+    let owned_path;
+    let mut rel = path.trim_start_matches('/');
+    if let Some(idx) = rel.find('?') {
+        rel = &rel[..idx];
+    }
+    if rel.contains("://") {
+        let parsed = Url::parse(rel).ok()?;
+        owned_path = parsed.path().trim_start_matches('/').to_string();
+        rel = owned_path.as_str();
+    }
+    if let Some(rest) = rel.strip_prefix("dvr-") {
+        rel = rest;
+    }
+    let parts: Vec<&str> = rel.split('/').collect();
+    if parts.len() < 6 {
+        return None;
+    }
+    let year: i32 = parts[0].parse().ok()?;
+    if !(2000..=2100).contains(&year) {
+        return None;
+    }
+    let month: u32 = parts[1].parse().ok()?;
+    let day: u32 = parts[2].parse().ok()?;
+    let hour: u32 = parts[3].parse().ok()?;
+    let minute: u32 = parts[4].parse().ok()?;
+    let sec_token = parts[5]
+        .split('-')
+        .next()?
+        .trim_end_matches(".ts")
+        .trim_end_matches(".m3u8");
+    let second: u32 = sec_token.parse().ok()?;
+    let naive = chrono::NaiveDate::from_ymd_opt(year, month, day)?
+        .and_hms_opt(hour, minute, second)?;
+    Some(naive.and_utc().timestamp())
+}
+
+/// Join a client-leaked relative DVR/media path against the session's origin URL.
+///
+/// When an origin `.m3u8` is force-piped without `rewrite_hls`, players resolve
+/// `dvr-2026/╤В╨Р╨╢ts?token=` against the proxy playlist URL (`/hls/╤В╨Р╨╢/{token}.m3u8`).
+fn resolve_leaked_hls_relative_origin(
+    session_stream_url: &str,
+    relative_path: &str,
+    request_query: Option<&str>,
+) -> Option<String> {
+    let rel = relative_path.trim_start_matches('/');
+    if rel.is_empty() || rel.contains("://") {
+        return None;
+    }
+    // Only recover archive-style relative paths (BitTV/Flussonic DVR or date trees).
+    let looks_like_archive_rel = rel.starts_with("dvr-")
+        || rel.starts_with("202")
+        || rel.contains("/dvr-")
+        || (rel.len() >= 10 && rel.as_bytes().get(4) == Some(&b'/') && rel.starts_with('2'));
+    if !looks_like_archive_rel {
+        return None;
+    }
+
+    // If the session URL is already inside a DVR/date tree, strip back to the stream root
+    // so sibling relative segments do not nest under the previous segment directory.
+    let joined = if rel.starts_with("dvr-") {
+        if let Some(idx) = session_stream_url.find("/dvr-") {
+            format!("{}{rel}", &session_stream_url[..idx + 1])
+        } else {
+            url::Url::parse(session_stream_url).ok()?.join(rel).ok()?.into()
+        }
+    } else if let Some(idx) = session_stream_url.find("/202") {
+        let root = &session_stream_url[..idx];
+        format!("{root}/{rel}")
+    } else {
+        url::Url::parse(session_stream_url).ok()?.join(rel).ok()?.into()
+    };
+
+    if let Some(query) = request_query.filter(|q| !q.is_empty()) {
+        Some(format!("{joined}?{query}"))
+    } else {
+        Some(joined)
+    }
+}
+
 fn legacy_hls_route_allowed_with_cache(
     cache_enabled: bool,
     decoded_session_token: Option<&str>,
@@ -128,19 +245,21 @@ fn query_flag_marks_start_context(key: &str) -> bool {
 }
 
 pub(in crate::api) fn m3u_archive_epg_reference_ts(stream_url: &str) -> Option<i64> {
+    use crate::iptv::m3u::parse_flussonic_archive_file;
+
     let parsed = Url::parse(stream_url).ok()?;
-    let path = parsed.path();
-    if let Some(rest) = path.split("/archive-").nth(1) {
-        let start = rest.split('-').next()?;
-        if let Ok(ts) = start.parse::<i64>() {
-            return Some(ts);
+    // Flussonic / TiviMate path forms: archive|index|video|mono-{utc}-{duration}.m3u8
+    // and timeshift_abs / timeshift_rel. Without this, HLS sessions stay LiveHls in the panel.
+    if let Some(file) = parsed.path_segments().and_then(|mut segments| segments.next_back()) {
+        if let Some(archive) = parse_flussonic_archive_file(file) {
+            if let Some(ts) = archive.epg_reference_ts() {
+                return Some(ts);
+            }
         }
     }
-    if let Some(rest) = path.split("/timeshift_abs-").nth(1) {
-        let start = rest.trim_end_matches(".ts").trim_end_matches(".m3u8");
-        if let Ok(ts) = start.parse::<i64>() {
-            return Some(ts);
-        }
+    // BitTV date-tree: /╤В╨Р╨╢/YYYY/MM/DD/HH/MM/SS-╤В╨Р╨╢.ts
+    if let Some(ts) = epg_reference_ts_from_date_tree_path(parsed.path()) {
+        return Some(ts);
     }
     let mut start_ts = None;
     let mut has_start_context = false;
@@ -166,6 +285,7 @@ struct HlsApiPathParams {
     target_id: u16,
     input_id: u16,
     stream_id: u32,
+    /// Single obfuscated token, or a leaked relative origin path (`dvr-YYYY/...ts`).
     token: String,
 }
 
@@ -1274,8 +1394,28 @@ async fn ensure_hls_cache_stream_registered(
         .map_or_else(|| Cow::Borrowed(""), |value| String::from_utf8_lossy(value.as_bytes()));
 
     stream_channel.url = Arc::from(hls_cache_stream_stats_url(&proxy_session_id));
-    stream_channel.item_type = PlaylistItemType::LiveHls;
-    stream_channel.cluster = XtreamCluster::try_from(PlaylistItemType::LiveHls).unwrap_or(stream_channel.cluster);
+    // Panel Streams/History read this item_type. Shared HLS transport is still HLS, but
+    // archive/catchup leases must never be published as Live/LiveHls.
+    let panel_archive_reference = origin_source
+        .archive_reference
+        .or(access.epg_reference_ts)
+        .or_else(|| access.archive_origin_url.as_deref().and_then(m3u_archive_epg_reference_ts))
+        .or_else(|| m3u_catchup_epg_reference_from_session_token(&access.user_session_token))
+        .or(stream_channel.epg_reference_ts);
+    let is_archive_playback = panel_archive_reference.is_some()
+        || access.archive_origin_url.is_some()
+        || origin_source.archive_reference.is_some()
+        || is_m3u_catchup_session_token(&access.user_session_token)
+        || stream_channel.item_type == PlaylistItemType::Catchup;
+    if is_archive_playback {
+        stream_channel.item_type = PlaylistItemType::Catchup;
+        stream_channel.cluster = XtreamCluster::Video;
+        stream_channel.epg_reference_ts = panel_archive_reference;
+    } else {
+        stream_channel.item_type = PlaylistItemType::LiveHls;
+        stream_channel.cluster =
+            XtreamCluster::try_from(PlaylistItemType::LiveHls).unwrap_or(stream_channel.cluster);
+    }
     let shared_stream_id = hls_cache_shared_stream_id(&proxy_session_id);
     stream_channel.shared = true;
     stream_channel.shared_stream_id = Some(shared_stream_id);
@@ -1359,13 +1499,15 @@ async fn build_hls_cache_stream_channel(
         fallback_hls_cache_stream_channel(0, access.virtual_id, origin_source, proxy_session_id)
     };
 
-    if access.epg_reference_ts.is_some()
-        || access.archive_origin_url.is_some()
-        || is_m3u_catchup_session_token(&access.user_session_token)
-    {
+    let archive_reference = access
+        .epg_reference_ts
+        .or_else(|| access.archive_origin_url.as_deref().and_then(m3u_archive_epg_reference_ts))
+        .or_else(|| m3u_catchup_epg_reference_from_session_token(&access.user_session_token));
+
+    if archive_reference.is_some() || access.archive_origin_url.is_some() || is_m3u_catchup_session_token(&access.user_session_token) {
         channel.item_type = PlaylistItemType::Catchup;
         channel.cluster = XtreamCluster::Video;
-        channel.epg_reference_ts = access.epg_reference_ts;
+        channel.epg_reference_ts = archive_reference;
     } else {
         channel.item_type = PlaylistItemType::LiveHls;
         channel.cluster = XtreamCluster::try_from(PlaylistItemType::LiveHls).unwrap_or(channel.cluster);
@@ -3716,6 +3858,7 @@ async fn try_hls_cache_entry_redirect(
     origin_source: HlsOriginSource,
     virtual_id: u32,
     existing_user_session: Option<&UserSession>,
+    session_token_hint: Option<&str>,
     request_url: &str,
     input: &ConfigInput,
     connection_permission: UserConnectionPermission,
@@ -3732,11 +3875,14 @@ async fn try_hls_cache_entry_redirect(
     let now_ms = current_time_millis();
     let origin_connection_kind = hls_entry_origin_connection_kind(connection_permission, connection_kind);
     let access_lease_id = new_hls_access_lease_id();
+    let existing_token = existing_user_session
+        .map(|session| session.token.as_str())
+        .or(session_token_hint);
     let session_token = create_hls_cache_user_session_token(
         fingerprint,
         &user.username,
         virtual_id,
-        existing_user_session.map(|session| session.token.as_str()),
+        existing_token,
         origin_source.archive_reference,
     );
     let session_token = prepare_hls_cache_user_session(
@@ -5244,6 +5390,7 @@ pub(in crate::api) async fn handle_hls_stream_request(
     user: &ProxyUserCredentials,
     target: &ConfigTarget,
     user_session: Option<&UserSession>,
+    session_token_hint: Option<&str>,
     hls_url: &str,
     archive_reference: Option<i64>,
     stream_identity: HlsEntryStreamIdentity,
@@ -5268,6 +5415,16 @@ pub(in crate::api) async fn handle_hls_stream_request(
         );
     }
     let url = ensure_hls_manifest_extension(&normalized_hls_url);
+    // Recover archive context when callers (esp. Xtream timeshift) pass None but the
+    // resolved provider URL / catchup session still carries Flussonic archive markers.
+    let archive_reference = archive_reference
+        .or_else(|| m3u_archive_epg_reference_ts(&url))
+        .or_else(|| {
+            user_session
+                .map(|session| session.token.as_str())
+                .or(session_token_hint)
+                .and_then(m3u_catchup_epg_reference_from_session_token)
+        });
     let hls_cache_origin = build_hls_origin_resolution(input, &url);
     let hls_origin_source = hls_cache_origin
         .as_ref()
@@ -5298,6 +5455,7 @@ pub(in crate::api) async fn handle_hls_stream_request(
             origin_source,
             virtual_id,
             user_session,
+            session_token_hint,
             if archive_reference.is_some() {
                 url.as_str()
             } else {
@@ -5386,12 +5544,14 @@ pub(in crate::api) async fn handle_hls_stream_request(
             None => (url, None, None, None),
         }
     } else {
-        let user_session_token = create_playback_session_fingerprint(
+        // Append/shift catchup must keep an m3u-catchup session token even when shared HLS
+        // cache is off; otherwise rewritten segments register as LiveHls in the panel.
+        let user_session_token = hls_entry_user_session_token(
             fingerprint,
             &user.username,
             virtual_id,
-            PlaylistItemType::LiveHls,
-            None,
+            session_token_hint,
+            archive_reference,
         );
         let hls_session_owner = if hls_cache_enabled_for_target(app_state, target) {
             let session_key = HlsSessionKey::new(input.id, stream_identity.stream_ref());
@@ -5571,6 +5731,7 @@ async fn resolve_stream_channel(
     virtual_id: u32,
     hls_url: &str,
     archive_reference: Option<i64>,
+    session_token: Option<&str>,
 ) -> StreamChannel {
     let unknown = "Unknown".intern();
     let mut channel = match get_stream_channel(app_state, target, virtual_id).await {
@@ -5598,7 +5759,13 @@ async fn resolve_stream_channel(
         },
     };
 
-    if archive_reference.is_some() {
+    let archive_reference = archive_reference.or_else(|| epg_reference_ts_from_date_tree_path(hls_url));
+    // Append/shift catchup often loses utc/utcstart on rewritten segment URLs; the session
+    // token still identifies archive playback for Streams/History (Catchup, not Live/HLS).
+    let is_archive_playback = archive_reference.is_some()
+        || looks_like_archive_media_path(hls_url)
+        || session_token.is_some_and(is_m3u_catchup_session_token);
+    if is_archive_playback {
         channel.item_type = PlaylistItemType::Catchup;
         channel.cluster = XtreamCluster::Video;
         channel.epg_reference_ts = archive_reference;
@@ -5607,6 +5774,27 @@ async fn resolve_stream_channel(
         channel.epg_reference_ts = None;
     }
     channel
+}
+
+fn hls_entry_user_session_token(
+    fingerprint: &Fingerprint,
+    username: &str,
+    virtual_id: u32,
+    session_token_hint: Option<&str>,
+    archive_reference: Option<i64>,
+) -> String {
+    if let Some(hint) = session_token_hint.filter(|token| is_m3u_catchup_session_token(token)) {
+        return hint.to_string();
+    }
+    if let Some(timestamp) = archive_reference {
+        return create_m3u_catchup_session_key(
+            fingerprint,
+            username,
+            virtual_id,
+            &format!("archive|{timestamp}|0"),
+        );
+    }
+    create_playback_session_fingerprint(fingerprint, username, virtual_id, PlaylistItemType::LiveHls, None)
 }
 
 struct HlsAccessManifestRequestContext {
@@ -5747,6 +5935,7 @@ async fn hls_proxy_manifest(
 async fn hls_api_stream(
     fingerprint: Fingerprint,
     req_headers: HeaderMap,
+    axum::extract::RawQuery(raw_query): axum::extract::RawQuery,
     axum::extract::Path(params): axum::extract::Path<HlsApiPathParams>,
     axum::extract::State(app_state): axum::extract::State<Arc<AppState>>,
 ) -> impl IntoResponse + Send {
@@ -5765,6 +5954,23 @@ async fn hls_api_stream(
         }
         (user, target)
     };
+
+    // Nested path = relative origin segment that leaked past rewrite_hls (e.g. dvr-YYYY/╤В╨Р╨╢).
+    if params.token.contains('/') {
+        return hls_api_stream_leaked_relative(
+            fingerprint,
+            req_headers,
+            app_state,
+            user,
+            target,
+            params.input_id,
+            params.stream_id,
+            params.token,
+            raw_query.as_deref(),
+        )
+        .await;
+    }
+
     hls_api_stream_resolved(
         fingerprint,
         req_headers,
@@ -5776,6 +5982,79 @@ async fn hls_api_stream(
         params.token,
     )
     .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn hls_api_stream_leaked_relative(
+    fingerprint: Fingerprint,
+    req_headers: HeaderMap,
+    app_state: Arc<AppState>,
+    user: Arc<ProxyUserCredentials>,
+    target: Arc<ConfigTarget>,
+    input_id: u16,
+    stream_id: u32,
+    relative_path: String,
+    request_query: Option<&str>,
+) -> axum::response::Response {
+    if let Err(e) = check_network_access_only(&user, &fingerprint, &app_state) {
+        return e.into_player_response(app_state.app_config.get_auth_error_status());
+    }
+    let Some(mut session) = app_state
+        .active_users
+        .find_latest_session_for_virtual_id(&user.username, stream_id)
+        .await
+    else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    let Some(origin_url) =
+        resolve_leaked_hls_relative_origin(&session.stream_url, &relative_path, request_query)
+    else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    let Some(input) = app_state.app_config.get_input_by_id(input_id) else {
+        return StatusCode::BAD_REQUEST.into_response();
+    };
+    let archive_reference = resolve_m3u_archive_reference(&origin_url, Some(session.token.as_str()))
+        .or_else(|| epg_reference_ts_from_date_tree_path(&relative_path))
+        .or_else(|| epg_reference_ts_from_date_tree_path(&origin_url));
+    let is_archive_media =
+        looks_like_archive_media_path(&relative_path) || looks_like_archive_media_path(&origin_url);
+    session.stream_url = origin_url.intern();
+    let mut stream_channel = resolve_stream_channel(
+        &app_state,
+        &target,
+        &input,
+        stream_id,
+        &session.stream_url,
+        archive_reference,
+        Some(session.token.as_str()),
+    )
+    .await;
+    // Leaked DVR/date-tree segments are always archive playback for the panel, even when the
+    // prior session was live and the date-tree timestamp could not be parsed.
+    if is_archive_media {
+        stream_channel.item_type = PlaylistItemType::Catchup;
+        stream_channel.cluster = XtreamCluster::Video;
+        if stream_channel.epg_reference_ts.is_none() {
+            stream_channel.epg_reference_ts = archive_reference;
+        }
+    }
+    force_provider_stream_response(
+        &fingerprint,
+        &app_state,
+        &session,
+        stream_channel,
+        crate::api::api_utils::ForceStreamRequestContext {
+            req_headers: &req_headers,
+            input: &input,
+            user: &user,
+            session_reservation_ttl_secs: get_hls_session_ttl_secs(&app_state),
+            content_representation: crate::api::model::ProviderContentRepresentationMode::Identity,
+        },
+        None,
+    )
+    .await
+    .into_response()
 }
 
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
@@ -5802,7 +6081,7 @@ async fn hls_api_stream_resolved(
     );
 
     if user.permission_denied(&app_state) {
-        let stream_channel = resolve_stream_channel(&app_state, &target, &input, virtual_id, "", None).await;
+        let stream_channel = resolve_stream_channel(&app_state, &target, &input, virtual_id, "", None, None).await;
         return hls_admission_failure_manifest_response(
             &app_state,
             &fingerprint,
@@ -5839,7 +6118,8 @@ async fn hls_api_stream_resolved(
     }
 
     if let Some(session) = &mut user_session {
-        let decoded_archive_reference = m3u_archive_epg_reference_ts(&decoded_hls_token.1);
+        let decoded_archive_reference =
+            resolve_m3u_archive_reference(&decoded_hls_token.1, Some(lookup_session_token.as_str()));
         if session.permission == UserConnectionPermission::Exhausted {
             let stream_channel = resolve_stream_channel(
                 &app_state,
@@ -5848,6 +6128,7 @@ async fn hls_api_stream_resolved(
                 virtual_id,
                 &decoded_hls_token.1,
                 decoded_archive_reference,
+                Some(session.token.as_str()),
             )
             .await;
             return hls_admission_failure_manifest_response(
@@ -5869,6 +6150,7 @@ async fn hls_api_stream_resolved(
                 virtual_id,
                 &decoded_hls_token.1,
                 decoded_archive_reference,
+                Some(session.token.as_str()),
             )
             .await;
             return hls_admission_failure_manifest_response(
@@ -5888,12 +6170,23 @@ async fn hls_api_stream_resolved(
             _ => return axum::http::StatusCode::BAD_REQUEST.into_response(),
         };
         let hls_url = hls_url.intern();
-        let archive_reference = m3u_archive_epg_reference_ts(&hls_url);
+        // Recover utc/utcstart from the prior playlist URL before overwriting with a segment URL
+        // that usually drops append/shift query params.
+        let archive_reference = resolve_m3u_archive_reference(&hls_url, Some(session.token.as_str()))
+            .or_else(|| m3u_archive_epg_reference_ts(session.stream_url.as_ref()));
         session.stream_url = hls_url.clone();
         if session.virtual_id == virtual_id {
             app_state.connection_manager.touch_http_activity(&user.username, &session.token, &fingerprint.addr).await;
-            let stream_channel =
-                resolve_stream_channel(&app_state, &target, &input, virtual_id, &hls_url, archive_reference).await;
+            let stream_channel = resolve_stream_channel(
+                &app_state,
+                &target,
+                &input,
+                virtual_id,
+                &hls_url,
+                archive_reference,
+                Some(session.token.as_str()),
+            )
+            .await;
             if is_seekable_media_request(
                 stream_channel.cluster,
                 &req_headers,
@@ -5953,8 +6246,16 @@ async fn hls_api_stream_resolved(
         {
             let provider = if session.provider.is_empty() { input.name.clone() } else { session.provider.clone() };
             let stream_channel =
-                resolve_stream_channel(&app_state, &target, &input, virtual_id, &session.stream_url, archive_reference)
-                    .await;
+                resolve_stream_channel(
+                    &app_state,
+                    &target,
+                    &input,
+                    virtual_id,
+                    &session.stream_url,
+                    archive_reference,
+                    Some(session.token.as_str()),
+                )
+                .await;
             return hls_admission_failure_manifest_response(
                 &app_state,
                 &fingerprint,
@@ -5986,6 +6287,7 @@ async fn hls_api_stream_resolved(
                 &user,
                 &target,
                 Some(session),
+                None,
                 &session.stream_url,
                 archive_reference,
                 source.stream_identity,
@@ -6001,7 +6303,16 @@ async fn hls_api_stream_resolved(
 
         if is_file_url(&session.stream_url) {
             let stream_channel =
-                resolve_stream_channel(&app_state, &target, &input, virtual_id, &hls_url, archive_reference).await;
+                resolve_stream_channel(
+                    &app_state,
+                    &target,
+                    &input,
+                    virtual_id,
+                    &hls_url,
+                    archive_reference,
+                    Some(session.token.as_str()),
+                )
+                .await;
             return local_stream_response(
                 &fingerprint,
                 &app_state,
@@ -6021,7 +6332,16 @@ async fn hls_api_stream_resolved(
         }
 
         let stream_channel =
-            resolve_stream_channel(&app_state, &target, &input, virtual_id, &hls_url, archive_reference).await;
+            resolve_stream_channel(
+                &app_state,
+                &target,
+                &input,
+                virtual_id,
+                &hls_url,
+                archive_reference,
+                Some(session.token.as_str()),
+            )
+            .await;
         force_provider_stream_response(
             &fingerprint,
             &app_state,
@@ -6062,7 +6382,7 @@ pub fn hls_api_register() -> axum::Router<Arc<AppState>> {
             axum::routing::get(hls_proxy_resource),
         )
         .route(
-            "/hls/{username}/{password}/{target_id}/{input_id}/{stream_id}/{token}",
+            "/hls/{username}/{password}/{target_id}/{input_id}/{stream_id}/{*token}",
             axum::routing::get(hls_api_stream),
         )
     //cfg.service(web::resource("/hls/{token}/{stream}").route(web::get().to(xtream_player_api_hls_stream)));
@@ -6073,7 +6393,8 @@ pub fn hls_api_register() -> axum::Router<Arc<AppState>> {
 mod tests {
     use super::{
         build_hls_manifest_request_headers, extract_hls_provider_session_headers, hls_api_register,
-        m3u_archive_epg_reference_ts, MAX_HLS_MANIFEST_BYTES,
+        m3u_archive_epg_reference_ts, m3u_catchup_epg_reference_from_session_token, resolve_leaked_hls_relative_origin,
+        MAX_HLS_MANIFEST_BYTES,
     };
     use crate::{
         api::model::{
@@ -6154,6 +6475,82 @@ mod tests {
     #[test]
     fn archive_epg_reference_rejects_plain_start_queries() {
         assert_eq!(m3u_archive_epg_reference_ts("http://provider/live/42.m3u8?start=1700000000"), None);
+    }
+
+    #[test]
+    fn date_tree_path_recovers_bittv_archive_epg_reference() {
+        assert_eq!(
+            super::epg_reference_ts_from_date_tree_path("2026/07/24/14/13/38-06800.ts"),
+            Some(
+                chrono::NaiveDate::from_ymd_opt(2026, 7, 24)
+                    .unwrap()
+                    .and_hms_opt(14, 13, 38)
+                    .unwrap()
+                    .and_utc()
+                    .timestamp()
+            )
+        );
+        assert_eq!(
+            super::epg_reference_ts_from_date_tree_path("dvr-2026/07/24/14/13/38-06800.ts"),
+            super::epg_reference_ts_from_date_tree_path("2026/07/24/14/13/38-06800.ts")
+        );
+        assert!(super::looks_like_archive_media_path("2026/07/24/14/13/38-06800.ts"));
+    }
+
+    #[test]
+    fn session_token_recovers_archive_epg_reference_when_media_url_lost_markers() {
+        assert_eq!(
+            m3u_catchup_epg_reference_from_session_token(
+                "m3u-catchup|user|42|archive|1717200000|3600"
+            ),
+            Some(1_717_200_000)
+        );
+        assert_eq!(
+            m3u_catchup_epg_reference_from_session_token("m3u-catchup|user|42|live"),
+            None
+        );
+    }
+
+    #[test]
+    fn append_catchup_session_hint_keeps_m3u_catchup_token_without_shared_hls_cache() {
+        let fingerprint = test_fingerprint();
+        let hint = "m3u-catchup|fp|alice|42|deadbeef";
+        let token = super::hls_entry_user_session_token(&fingerprint, "alice", 42, Some(hint), Some(1_717_200_000));
+        assert_eq!(token, hint);
+        assert!(super::is_m3u_catchup_session_token(&token));
+
+        let from_archive =
+            super::hls_entry_user_session_token(&fingerprint, "alice", 42, None, Some(1_717_200_000));
+        assert!(from_archive.contains("|archive|1717200000|0"));
+        assert!(super::is_m3u_catchup_session_token(&from_archive));
+    }
+
+    #[test]
+    fn leaked_dvr_relative_joins_against_media_playlist_and_dvr_session_root() {
+        assert_eq!(
+            resolve_leaked_hls_relative_origin(
+                "http://cdn.example/big/aa_1/media.m3u8",
+                "dvr-2026/07/26/15/30/59-06000.ts",
+                Some("token=abc"),
+            ),
+            Some("http://cdn.example/big/aa_1/dvr-2026/07/26/15/30/59-06000.ts?token=abc".to_string())
+        );
+        assert_eq!(
+            resolve_leaked_hls_relative_origin(
+                "http://cdn.example/big/aa_1/dvr-2026/07/26/15/30/59-06000.ts?token=old",
+                "dvr-2026/07/26/15/31/05-06000.ts",
+                Some("token=new"),
+            ),
+            Some("http://cdn.example/big/aa_1/dvr-2026/07/26/15/31/05-06000.ts?token=new".to_string())
+        );
+        assert_eq!(
+            resolve_leaked_hls_relative_origin(
+                "http://cdn.example/big/aa_1/media.m3u8",
+                "segment001.ts",
+                None,
+            ),
+            None
+        );
     }
 
     #[test]
@@ -9664,6 +10061,7 @@ mod tests {
             origin_source,
             12345,
             None,
+            None,
             request_url,
             &input,
             UserConnectionPermission::Allowed,
@@ -9706,6 +10104,7 @@ mod tests {
             &app_state,
             &user,
             &target,
+            None,
             None,
             archive_url,
             Some(1_784_898_000),
@@ -9770,6 +10169,7 @@ mod tests {
             origin_source,
             12345,
             None,
+            None,
             request_url,
             &input,
             UserConnectionPermission::GracePeriod,
@@ -9829,6 +10229,7 @@ mod tests {
             &user,
             &target,
             None,
+            None,
             "http://origin.example.com/live/user/pass/1001.m3u8",
             None,
             super::HlsEntryStreamIdentity::new(1001, "80510").expect("valid input stream identity"),
@@ -9886,6 +10287,7 @@ mod tests {
             &user,
             &first_target,
             None,
+            None,
             "http://origin.example.com/live/user/pass/1001.m3u8",
             None,
             super::HlsEntryStreamIdentity::new(1001, "80510").expect("first input stream identity"),
@@ -9902,6 +10304,7 @@ mod tests {
             &app_state,
             &user,
             &second_target,
+            None,
             None,
             "http://origin.example.com/live/user/pass/9007.m3u8",
             None,
@@ -9988,6 +10391,7 @@ mod tests {
             &app_state,
             &user,
             &target,
+            None,
             None,
             "http://origin.example.com/live/user/pass/12345.m3u8",
             None,
@@ -10162,6 +10566,7 @@ mod tests {
             origin_source.clone(),
             12345,
             None,
+            None,
             request_url,
             &input,
             UserConnectionPermission::Allowed,
@@ -10185,6 +10590,7 @@ mod tests {
             &normal_user,
             origin_source,
             12345,
+            None,
             None,
             request_url,
             &input,
@@ -10376,6 +10782,7 @@ mod tests {
             origin_source.clone(),
             12345,
             None,
+            None,
             request_url,
             &input,
             UserConnectionPermission::Allowed,
@@ -10401,6 +10808,7 @@ mod tests {
             &user,
             origin_source,
             12345,
+            None,
             None,
             request_url,
             &input,
@@ -10442,6 +10850,7 @@ mod tests {
             &user,
             origin_source.clone(),
             12345,
+            None,
             None,
             request_url,
             &input,
@@ -10485,6 +10894,7 @@ mod tests {
             origin_source,
             12345,
             None,
+            None,
             request_url,
             &input,
             UserConnectionPermission::Allowed,
@@ -10525,6 +10935,7 @@ mod tests {
             origin_source.clone(),
             12345,
             None,
+            None,
             request_url,
             &input,
             UserConnectionPermission::Allowed,
@@ -10561,6 +10972,7 @@ mod tests {
             &user,
             origin_source,
             12345,
+            None,
             None,
             request_url,
             &input,
@@ -10632,6 +11044,7 @@ mod tests {
             origin_source,
             12345,
             None,
+            None,
             request_url,
             &input,
             UserConnectionPermission::Allowed,
@@ -10667,6 +11080,7 @@ mod tests {
             origin_source.clone(),
             12345,
             None,
+            None,
             request_url,
             &input,
             UserConnectionPermission::Allowed,
@@ -10694,6 +11108,7 @@ mod tests {
             &user,
             origin_source,
             12345,
+            None,
             None,
             request_url,
             &input,
@@ -10759,6 +11174,7 @@ mod tests {
             origin_source,
             80510,
             None,
+            None,
             "http://origin.example.com/live/user/pass/80510.m3u8",
             &input,
             UserConnectionPermission::Allowed,
@@ -10795,6 +11211,7 @@ mod tests {
             &user,
             origin_source,
             70001,
+            None,
             None,
             "http://media.example.com/channel/playlist.m3u8",
             &input,

--- a/backend/src/api/endpoints/m3u_api.rs
+++ b/backend/src/api/endpoints/m3u_api.rs
@@ -425,7 +425,10 @@ pub(in crate::api) async fn m3u_api_stream_loaded(
     };
 
     if let Some(response) = redirect_response(app_state, &redirect_params).await {
-        return response.into_response();
+        // Archive/catchup must keep the resolved provider archive URL — do not redirect to live.
+        if archive_discriminator.is_none() && pli.item_type != PlaylistItemType::Catchup {
+            return response.into_response();
+        }
     }
 
     let is_session_request = is_session_based_playback(pli.item_type, Some(extension));
@@ -435,7 +438,14 @@ pub(in crate::api) async fn m3u_api_stream_loaded(
     // branch attaches it to the StreamChannel so the frontend's stream_epg
     // request can centre its EPG window on the archive timestamp instead of
     // falling back to `now`.
-    let archive_reference = m3u_archive_epg_reference_ts(&pli.url);
+    let archive_reference = m3u_archive_epg_reference_ts(&pli.url).or_else(|| {
+        archive_discriminator.and_then(|disc| {
+            disc.strip_prefix("archive|")
+                .or_else(|| disc.strip_prefix("timeshift_abs|"))
+                .and_then(|rest| rest.split('|').next())
+                .and_then(|start| start.parse::<i64>().ok())
+        })
+    });
     // Reverse proxy mode — only route genuine HLS into the HLS handler, not DASH
     if is_session_request && extension == shared::defaults::HLS_EXT {
         let Some(stream_identity) = HlsEntryStreamIdentity::from_playlist_item(&pli) else {
@@ -452,6 +462,7 @@ pub(in crate::api) async fn m3u_api_stream_loaded(
             &user,
             &target,
             user_session.as_ref(),
+            Some(session_key.as_str()),
             &pli.url,
             archive_reference,
             stream_identity,
@@ -524,6 +535,30 @@ fn playlist_item_native_flussonic_mode(item: &shared::model::M3uPlaylistItem) ->
         StreamProperties::Live(live) => live.catchup.as_ref()?.native_flussonic_player_mode(),
         _ => None,
     }
+}
+
+/// Accept Flussonic archive routes when catchup-type is Flussonic OR when BitTV-style
+/// rows only have timeshift / catchup-days (v3.3.81 fallback).
+fn playlist_item_allows_flussonic_archive(item: &shared::model::M3uPlaylistItem) -> bool {
+    if playlist_item_native_flussonic_mode(item).is_some() {
+        return true;
+    }
+    if !item.time_shift.trim().is_empty() {
+        return true;
+    }
+    match item.additional_properties.as_ref() {
+        Some(StreamProperties::Live(live)) => live
+            .catchup
+            .as_ref()
+            .is_some_and(|c| c.days.as_ref().is_some_and(|d| !d.is_empty())),
+        _ => false,
+    }
+}
+
+fn playlist_item_flussonic_mode_or_default(item: &shared::model::M3uPlaylistItem) -> Option<&'static str> {
+    playlist_item_native_flussonic_mode(item).or_else(|| {
+        playlist_item_allows_flussonic_archive(item).then_some("flussonic")
+    })
 }
 
 fn native_live_file_matches_mode(mode: &str, file: &str) -> bool {
@@ -608,7 +643,7 @@ async fn m3u_api_stream(
                 return axum::http::StatusCode::NOT_FOUND.into_response();
             }
         };
-        let Some(mode) = playlist_item_native_flussonic_mode(&pli) else {
+        let Some(mode) = playlist_item_flussonic_mode_or_default(&pli) else {
             return axum::http::StatusCode::BAD_REQUEST.into_response();
         };
         if !native_archive_matches_mode(mode, &archive) {
@@ -720,7 +755,7 @@ async fn m3u_api_stream_nested(
     );
     let stream_ext = extract_extension_from_url(file);
     let resolved = if let Some(archive) = parse_flussonic_archive_file(file) {
-        let Some(mode) = playlist_item_native_flussonic_mode(&pli) else {
+        let Some(mode) = playlist_item_flussonic_mode_or_default(&pli) else {
             return axum::http::StatusCode::BAD_REQUEST.into_response();
         };
         if !native_archive_matches_mode(mode, &archive) {
@@ -730,7 +765,7 @@ async fn m3u_api_stream_nested(
             (item, Some(discriminator))
         })
     } else if is_flussonic_live_file(file) {
-        let Some(mode) = playlist_item_native_flussonic_mode(&pli) else {
+        let Some(mode) = playlist_item_flussonic_mode_or_default(&pli) else {
             return axum::http::StatusCode::BAD_REQUEST.into_response();
         };
         if !native_live_file_matches_mode(mode, file) {

--- a/backend/src/api/endpoints/v1_api.rs
+++ b/backend/src/api/endpoints/v1_api.rs
@@ -48,7 +48,7 @@ pub async fn create_status_check(app_state: &Arc<AppState>) -> StatusCheck {
     let (active_users, active_user_connections, active_user_streams) = {
         let active_user = &app_state.active_users;
         let (user_count, connection_count) = active_user.active_users_and_connections().await;
-        (user_count, connection_count, active_user.active_streams().await)
+        (user_count, connection_count, active_user.panel_streams().await)
     };
 
     let active_provider_connections =
@@ -81,7 +81,7 @@ async fn streams(
     ExtractAcceptHeader(accept): ExtractAcceptHeader,
     axum::extract::State(app_state): axum::extract::State<Arc<AppState>>,
 ) -> axum::response::Response {
-    let streams = app_state.active_users.active_streams().await;
+    let streams = app_state.active_users.panel_streams().await;
     json_or_bin_response(accept.as_deref(), &streams).into_response()
 }
 

--- a/backend/src/api/endpoints/xtream_api.rs
+++ b/backend/src/api/endpoints/xtream_api.rs
@@ -17,7 +17,8 @@ use crate::{
         endpoints::{
             hls_api::{
                 build_virtual_hls_entry_path, handle_hls_stream_request, hls_admission_failure_manifest_response,
-                hls_custom_video_manifest_response, HlsEntryStreamIdentity,
+                hls_custom_video_manifest_response, m3u_archive_epg_reference_ts,
+                m3u_catchup_epg_reference_from_session_token, HlsEntryStreamIdentity,
             },
             xmltv_api::{get_empty_epg_response, get_epg_path_for_target_by_type, serve_short_epg},
         },
@@ -636,14 +637,18 @@ async fn xtream_player_api_stream(
             return axum::http::StatusCode::SERVICE_UNAVAILABLE.into_response();
         };
         let original_hls_entry_path = build_virtual_hls_entry_path(&target, &input, &user, pli.virtual_id);
+        let archive_reference = m3u_archive_epg_reference_ts(stream_url.as_ref())
+            .or_else(|| m3u_archive_epg_reference_ts(pli.url.as_ref()))
+            .or_else(|| m3u_catchup_epg_reference_from_session_token(&session_key));
         return handle_hls_stream_request(
             fingerprint,
             app_state,
             &user,
             &target,
             user_session.as_ref(),
+            Some(session_key.as_str()),
             &stream_url,
-            None,
+            archive_reference,
             stream_identity,
             &input,
             req_headers,
@@ -655,7 +660,11 @@ async fn xtream_player_api_stream(
         .into_response();
     }
 
-    let stream_channel = create_stream_channel_with_type(target.id, &pli, item_type);
+    let archive_reference = m3u_archive_epg_reference_ts(stream_url.as_ref())
+        .or_else(|| m3u_archive_epg_reference_ts(pli.url.as_ref()))
+        .or_else(|| m3u_catchup_epg_reference_from_session_token(&session_key));
+    let stream_channel = create_stream_channel_with_type(target.id, &pli, item_type)
+        .with_epg_reference_ts(archive_reference);
 
     let pinned_provider =
         user_session.as_ref().filter(|_| item_type.requires_provider_affinity()).map(|session| &session.provider);
@@ -927,8 +936,9 @@ pub(in crate::api) async fn xtream_player_api_stream_with_token(
                 &user,
                 &target,
                 None,
+                Some(session_key.as_str()),
                 &pli.url,
-                None,
+                m3u_archive_epg_reference_ts(pli.url.as_ref()),
                 stream_identity,
                 &input,
                 req_headers,

--- a/backend/src/api/model/active_user_manager.rs
+++ b/backend/src/api/model/active_user_manager.rs
@@ -385,9 +385,19 @@ fn create_socket_reentry_guard_key(username: &str, client_ip: &str, virtual_id: 
     shared::concat_string!(username, "|", client_ip, "|", &virtual_id.to_string())
 }
 
+fn is_catchup_session_token(session_token: &str) -> bool {
+    session_token.starts_with("m3u-catchup|")
+        || session_token.starts_with("catchup|")
+        || session_token.contains("|archive|")
+        || session_token.contains("|timeshift_abs|")
+}
+
 fn is_stable_session_stream(stream: &StreamInfo) -> bool {
+    // Catchup-token Live/.ts segment sockets must preserve too ╤В╨Р╨д otherwise archive panel rows
+    // hard-remove every HLS chunk and Streams blinks even when frontend soft-preserve is present.
     stream.channel.item_type == PlaylistItemType::Catchup
         || stream.channel.item_type.is_live_adaptive()
+        || stream.session_token.as_deref().is_some_and(is_catchup_session_token)
         || matches!(
             extract_extension_from_url(stream.channel.url.as_ref()),
             Some(ext) if ext == HLS_EXT || ext == DASH_EXT
@@ -1667,10 +1677,16 @@ impl ActiveUserManager {
         sessions: &[UserSession],
     ) -> Option<AdaptiveExpiryEntry> {
         let session_token = stream.session_token.as_deref()?;
-        let session = sessions.iter().find(|session| session.token == session_token)?;
+        // Catchup segment gaps can briefly lose the UserSession row; still preserve the panel
+        // row using the stream timestamp so Streams does not blink between archive chunks.
+        let session_ts = sessions
+            .iter()
+            .find(|session| session.token == session_token)
+            .map(|session| session.ts)
+            .unwrap_or(stream.ts);
 
         let ttl_secs = self.adaptive_session_ttl_secs.load(Ordering::Relaxed);
-        let expires_at = session.ts.saturating_add(ttl_secs);
+        let expires_at = session_ts.saturating_add(ttl_secs);
         Some(AdaptiveExpiryEntry {
             expires_at,
             username: username.to_string(),
@@ -2873,6 +2889,18 @@ impl ActiveUserManager {
         self.update_user_session(username, token).await
     }
 
+    /// Latest session for `virtual_id` (used to recover leaked relative DVR segment paths).
+    pub async fn find_latest_session_for_virtual_id(&self, username: &str, virtual_id: u32) -> Option<UserSession> {
+        let user_connections = self.connections.read().await;
+        let connection_data = user_connections.by_key.get(username)?;
+        connection_data
+            .sessions
+            .iter()
+            .filter(|session| session.virtual_id == virtual_id)
+            .max_by_key(|session| session.ts)
+            .cloned()
+    }
+
     pub async fn update_session_provider_headers(
         &self,
         username: &str,
@@ -2933,7 +2961,27 @@ impl ActiveUserManager {
         let mut streams = Vec::new();
         for connection_data in user_connections.by_key.values() {
             for stream in &connection_data.streams {
+                // Keep active_streams free of preserved rows — shared-HLS join detection and
+                // connection accounting must not see stale archive segment leases (v3.3.81).
                 if !stream.preserved {
+                    streams.push(stream.clone());
+                }
+            }
+        }
+        streams
+    }
+
+    /// Streams for the WebUI / StatusCheck snapshot.
+    ///
+    /// Includes preserved Catchup/HLS/DASH session rows so the panel keeps showing archive
+    /// playback between short segment sockets. Do not use this for shared-HLS accounting.
+    pub async fn panel_streams(&self) -> Vec<StreamInfo> {
+        self.gc();
+        let user_connections = self.connections.read().await;
+        let mut streams = Vec::new();
+        for connection_data in user_connections.by_key.values() {
+            for stream in &connection_data.streams {
+                if !stream.preserved || Self::should_preserve_session_stream(stream) {
                     streams.push(stream.clone());
                 }
             }
@@ -3138,11 +3186,13 @@ impl ActiveUserManager {
             return true;
         };
 
-        let Some(session) = sessions.iter().find(|session| session.token == session_token) else {
-            return true;
-        };
+        let session_ts = sessions
+            .iter()
+            .find(|session| session.token == session_token)
+            .map(|session| session.ts)
+            .unwrap_or(stream.ts);
 
-        now.saturating_sub(session.ts) >= ttl_secs
+        now.saturating_sub(session_ts) >= ttl_secs
     }
 
     fn collect_divergence_snapshot(
@@ -7092,7 +7142,14 @@ mod tests {
         assert!(released.addr_removed);
         assert!(released.removed_streams.is_empty(), "adaptive close should preserve without history removal");
         assert_eq!(manager.user_connections(&user.username).await, 0);
-        assert!(manager.active_streams().await.is_empty(), "preserved adaptive streams are hidden from active snapshots");
+        assert!(
+            manager.active_streams().await.is_empty(),
+            "preserved rows stay out of active_streams (use panel_streams for StatusCheck)"
+        );
+        let panel = manager.panel_streams().await;
+        assert_eq!(panel.len(), 1, "preserved adaptive/catchup session rows stay in panel snapshots");
+        assert!(panel[0].preserved);
+        assert_eq!(panel[0].session_token.as_deref(), Some("tok-hls-manifest-touch"));
 
         let connections = manager.connections.read().await;
         let data = connections.by_key.get(&user.username).expect("user should remain for preserved session");

--- a/backend/src/iptv/m3u/archive.rs
+++ b/backend/src/iptv/m3u/archive.rs
@@ -28,6 +28,13 @@ impl FlussonicArchiveKind {
             | Self::TimeshiftRel { extension, .. } => extension,
         }
     }
+
+    pub fn epg_reference_ts(&self) -> Option<i64> {
+        match self {
+            Self::Archive { start, .. } | Self::TimeshiftAbs { start, .. } => start.parse().ok(),
+            Self::TimeshiftRel { .. } => None,
+        }
+    }
 }
 
 fn strip_media_suffix(value: &str) -> &str {

--- a/backend/src/iptv/m3u/catchup.rs
+++ b/backend/src/iptv/m3u/catchup.rs
@@ -12,6 +12,9 @@ pub const M3U_CATCHUP_ROUTE_PREFIX: &str = "m3u-catchup";
 pub const M3U_CATCHUP_MARKER: &str = "tuliprox-catchup";
 const COLLECTOR_PREFIX: &str = "v";
 const M3U_APPEND_TEMPLATE: &str = "?utc={utc}&lutc={lutc}";
+/// Default when source declares append (`catchup=` / `catchup-type=`) without `catchup-source`.
+/// Matches the usual Wink/Zabava query shape; an explicit `catchup-source` always wins.
+const M3U_APPEND_MODE_DEFAULT_TEMPLATE: &str = "?offset=-${offset}&utcstart=${timestamp}";
 const M3U_CATCHUP_PARAM_UTC: &str = "utc";
 const M3U_CATCHUP_PARAM_LUTC: &str = "lutc";
 const XC_START_TEMPLATE: &str = "{Y}-{m}-{d}:{H}-{M}-{S}";
@@ -164,6 +167,16 @@ fn append_siptv_template(source_url: &str) -> String {
     }
 }
 
+fn append_mode_default_template(source_url: &str) -> String {
+    append_query_template(source_url, M3U_APPEND_MODE_DEFAULT_TEMPLATE).unwrap_or_else(|| {
+        if source_url.contains('?') {
+            format!("{source_url}&{}", M3U_APPEND_MODE_DEFAULT_TEMPLATE.trim_start_matches('?'))
+        } else {
+            format!("{source_url}{M3U_APPEND_MODE_DEFAULT_TEMPLATE}")
+        }
+    })
+}
+
 fn derive_xc_template(source_url: &str) -> Option<String> {
     let parsed = Url::parse(source_url).ok()?;
     let mut segments = parsed
@@ -229,6 +242,38 @@ fn is_append_like_query_source(mode: &str, source: &str) -> bool {
     mode_alias(mode) == "append" || source.starts_with('?')
 }
 
+/// Build `archive|{utc}|{duration}` when the resolved provider URL still carries append/shift
+/// query markers. Session tokens keep this discriminator so the panel can show Catchup/EPG
+/// after HLS rewrite drops `utc`/`utcstart` from segment URLs.
+fn archive_discriminator_from_resolved_url(url: &str) -> Option<String> {
+    let parsed = Url::parse(url).ok()?;
+    let mut start_ts = None;
+    let mut end_ts = None;
+    let mut duration_secs = None;
+    for (key, value) in parsed.query_pairs() {
+        if key.eq_ignore_ascii_case("utc")
+            || key.eq_ignore_ascii_case("utcstart")
+            || key.eq_ignore_ascii_case("timestamp")
+        {
+            start_ts = value.parse::<i64>().ok().or(start_ts);
+        } else if key.eq_ignore_ascii_case("lutc") {
+            end_ts = value.parse::<i64>().ok().or(end_ts);
+        } else if key.eq_ignore_ascii_case("offset") || key.eq_ignore_ascii_case("duration") {
+            duration_secs = value
+                .parse::<i64>()
+                .ok()
+                .map(i64::abs)
+                .or(duration_secs);
+        }
+    }
+    let start = start_ts?;
+    let duration = end_ts
+        .map(|end| end.saturating_sub(start).max(0))
+        .or(duration_secs)
+        .unwrap_or(0);
+    Some(format!("archive|{start}|{duration}"))
+}
+
 fn derived_template_for_mode<'a>(source_url: &'a str, catchup: &'a CatchupProperties) -> Option<Cow<'a, str>> {
     let mode = effective_catchup_mode(catchup);
     if let Some(source) = catchup.source.as_deref().filter(|source| !source.is_empty()) {
@@ -241,6 +286,9 @@ fn derived_template_for_mode<'a>(source_url: &'a str, catchup: &'a CatchupProper
 
     match mode_alias(mode) {
         "shift" => Some(Cow::Owned(format!("{source_url}{}", append_siptv_template(source_url)))),
+        // Append without catchup-source: Wink-style offset/utcstart template.
+        // Explicit catchup-source is handled above and always wins.
+        "append" => Some(Cow::Owned(append_mode_default_template(source_url))),
         "xc" => derive_xc_template(source_url).map(Cow::Owned),
         "fs" => derive_flussonic_template(source_url).map(Cow::Owned),
         "vod" => Some(Cow::Borrowed("{catchup-id}")),
@@ -542,13 +590,17 @@ pub fn resolve_m3u_catchup_url(
     }
 
     let url = render_template(&segments, &collectors)?;
-    let mut discriminator = url::form_urlencoded::Serializer::new(String::new());
-    let mode = effective_catchup_mode(catchup);
-    discriminator.append_pair("mode", if mode.is_empty() { "default" } else { mode });
-    for (idx, value) in collectors {
-        discriminator.append_pair(&format!("{COLLECTOR_PREFIX}{idx}"), &value);
-    }
-    let discriminator = short_hash(&discriminator.finish());
+    // Prefer archive|{utc}|{duration} so Streams/History can recover EPG from the session token
+    // after append/shift query params are stripped from rewritten HLS segment URLs.
+    let discriminator = archive_discriminator_from_resolved_url(&url).unwrap_or_else(|| {
+        let mut discriminator = url::form_urlencoded::Serializer::new(String::new());
+        let mode = effective_catchup_mode(catchup);
+        discriminator.append_pair("mode", if mode.is_empty() { "default" } else { mode });
+        for (idx, value) in &collectors {
+            discriminator.append_pair(&format!("{COLLECTOR_PREFIX}{idx}"), value);
+        }
+        short_hash(&discriminator.finish())
+    });
     Ok(Some(ResolvedM3uCatchup { url, discriminator }))
 }
 
@@ -626,7 +678,25 @@ mod tests {
             resolved.url,
             "http://provider.example/live/42.m3u8?offset=-120&utcstart=1717200000"
         );
-        assert!(!resolved.discriminator.is_empty());
+        assert_eq!(resolved.discriminator, "archive|1717200000|120");
+    }
+
+    #[test]
+    fn append_discriminator_embeds_archive_start_for_panel_epg() {
+        assert_eq!(
+            super::archive_discriminator_from_resolved_url(
+                "http://provider.example/live/42.m3u8?offset=-3600&utcstart=1717200000"
+            )
+            .as_deref(),
+            Some("archive|1717200000|3600")
+        );
+        assert_eq!(
+            super::archive_discriminator_from_resolved_url(
+                "http://provider.example/live/42.ts?utc=1717200000&lutc=1717203600"
+            )
+            .as_deref(),
+            Some("archive|1717200000|3600")
+        );
     }
 
     #[test]

--- a/backend/src/repository/m3u_playlist_iterator.rs
+++ b/backend/src/repository/m3u_playlist_iterator.rs
@@ -163,14 +163,31 @@ fn apply_rewrite(
     };
 
     if should_rewrite_urls {
-        let flussonic_live_file = m3u_pli.additional_properties.as_ref().and_then(|properties| match properties {
-            StreamProperties::Live(live) => live
-                .catchup
-                .as_ref()
-                .and_then(shared::model::CatchupProperties::native_flussonic_player_mode)
-                .map(flussonic_proxy_live_file),
-            _ => None,
-        });
+        let flussonic_live_file = m3u_pli
+            .additional_properties
+            .as_ref()
+            .and_then(|properties| match properties {
+                StreamProperties::Live(live) => live
+                    .catchup
+                    .as_ref()
+                    .and_then(shared::model::CatchupProperties::native_flussonic_player_mode)
+                    .map(flussonic_proxy_live_file),
+                _ => None,
+            })
+            .or_else(|| {
+                // BitTV rows often have timeshift/catchup-days without a Flussonic mode on
+                // catchup=; nested live file is required so TiviMate can rewrite the last
+                // path segment for archive (v3.3.81).
+                let has_timeshift = !m3u_pli.time_shift.trim().is_empty();
+                let has_days = m3u_pli.additional_properties.as_ref().and_then(|props| match props {
+                    StreamProperties::Live(live) => live
+                        .catchup
+                        .as_ref()
+                        .and_then(|c| c.days.as_ref().filter(|d| !d.is_empty())),
+                    _ => None,
+                });
+                (has_timeshift || has_days.is_some()).then_some(flussonic_proxy_live_file("flussonic"))
+            });
         let stream_url = flussonic_live_file.map_or_else(
             || {
                 build_rewritten_url(

--- a/frontend/scss/app/components/dashboard/_streams_view.scss
+++ b/frontend/scss/app/components/dashboard/_streams_view.scss
@@ -90,6 +90,7 @@
     flex: 1 1 auto;
     min-height: 0;
     padding: var(--padding-default);
+    overflow: hidden;
   }
 
   &__list {
@@ -98,6 +99,10 @@
     flex-flow: column;
     gap: var(--gap-small);
     min-height: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+    pointer-events: auto;
+    -webkit-overflow-scrolling: touch;
     overscroll-behavior: contain;
     padding-right: var(--padding-small);
     z-index: 1;

--- a/frontend/src/app/components/dashboard/stream_display/helpers.rs
+++ b/frontend/src/app/components/dashboard/stream_display/helpers.rs
@@ -54,8 +54,28 @@ pub fn get_adaptive_session_ttl_secs(config_ctx: &ConfigContext) -> u64 {
         .map_or_else(default_hls_session_ttl_secs, |stream| stream.hls_session_ttl_secs)
 }
 
+fn is_catchup_session_token(session_token: &str) -> bool {
+    session_token.starts_with("m3u-catchup|")
+        || session_token.starts_with("catchup|")
+        || session_token.contains("|archive|")
+        || session_token.contains("|timeshift_abs|")
+}
+
 pub fn is_adaptive_session_stream(stream: &StreamInfo) -> bool {
-    stream.session_token.is_some() && stream.channel.item_type.is_live_adaptive()
+    // Soft-preserve keeps archive/HLS rows between short segment sockets; this TTL path is what
+    // eventually hides them after the session ends (without a full page reload).
+    if stream.channel.item_type == PlaylistItemType::Catchup {
+        return true;
+    }
+    if stream.session_token.as_deref().is_some_and(is_catchup_session_token) {
+        return true;
+    }
+    let url = stream.channel.url.as_ref().to_ascii_lowercase();
+    if url.contains(".m3u8") || url.contains(".mpd") {
+        return true;
+    }
+    stream.session_token.is_some()
+        && (stream.channel.item_type.is_live_adaptive() || is_shared_hls_stream(stream))
 }
 
 pub fn is_background_transfer_stream(stream: &StreamInfo) -> bool {
@@ -106,7 +126,8 @@ fn compute_adaptive_last_seen(
 
         for stream in streams {
             if is_adaptive_session_stream(stream) {
-                if !stream.preserved || is_shared_hls_stream(stream) || !next.contains_key(&stream.uid) {
+                // Freeze last_seen for all preserved rows (including shared) so TTL can hide ended sessions.
+                if !stream.preserved || !next.contains_key(&stream.uid) {
                     next.insert(stream.uid, now);
                 }
             } else {
@@ -140,11 +161,17 @@ pub fn build_technical_chips(
         return chips;
     };
 
-    if let Some(label) = adaptive_tech_label(item_type) {
+    let type_label = adaptive_tech_label(item_type);
+    if let Some(label) = type_label {
         chips.push((label.to_string(), "tp__stream-display__chip--container"));
     }
     if !tech.container.is_empty() {
-        chips.push((tech.container.to_ascii_uppercase(), "tp__stream-display__chip--container"));
+        let container = tech.container.to_ascii_uppercase();
+        // LiveHls/Dash already add HLS/DASH from item_type; metrics often repeat the same container.
+        let duplicate_type_label = type_label.is_some_and(|label| label.eq_ignore_ascii_case(&container));
+        if !duplicate_type_label {
+            chips.push((container, "tp__stream-display__chip--container"));
+        }
     }
     if !tech.video_codec.is_empty() {
         chips.push((tech.video_codec.clone(), "tp__stream-display__chip--video-codec"));
@@ -280,12 +307,101 @@ mod tests {
     }
 
     #[test]
-    fn compute_adaptive_last_seen_refreshes_preserved_shared_hls() {
+    fn compute_adaptive_last_seen_freezes_preserved_shared_hls() {
         let existing = HashMap::from([(2, 200)]);
         let streams = Some(vec![test_shared_hls_stream(2, true, true)]);
 
         let refreshed = compute_adaptive_last_seen(existing, &streams, 999);
 
-        assert_eq!(refreshed.get(&2), Some(&999));
+        assert_eq!(refreshed.get(&2), Some(&200));
+    }
+
+    #[test]
+    fn compute_adaptive_last_seen_tracks_catchup_session_streams() {
+        let existing = HashMap::from([(5, 100)]);
+        let streams = Some(vec![
+            test_stream(5, PlaylistItemType::Catchup, true, true),
+            test_stream(6, PlaylistItemType::Catchup, false, true),
+        ]);
+
+        let refreshed = compute_adaptive_last_seen(existing, &streams, 999);
+
+        // Preserved catchup keeps prior last_seen (sticky between segments).
+        assert_eq!(refreshed.get(&5), Some(&100));
+        assert_eq!(refreshed.get(&6), Some(&999));
+    }
+
+    #[test]
+    fn filter_visible_streams_keeps_preserved_catchup_within_adaptive_ttl() {
+        use super::filter_visible_streams;
+
+        let streams = Some(vec![
+            test_stream(1, PlaylistItemType::Catchup, true, true),
+            test_stream(2, PlaylistItemType::Video, false, true),
+        ]);
+        let last_seen = HashMap::from([(1, 1_000u64)]);
+        let ttl = 30u64;
+        let visible = filter_visible_streams(streams, &last_seen, 1_000 + ttl, ttl).unwrap();
+        assert_eq!(visible.len(), 2);
+        assert!(visible.iter().any(|stream| stream.channel.item_type == PlaylistItemType::Catchup));
+    }
+
+    #[test]
+    fn filter_visible_streams_hides_preserved_catchup_past_adaptive_ttl() {
+        use super::{filter_visible_streams, ADAPTIVE_STREAM_CLEANUP_BUFFER_SECS};
+
+        let streams = Some(vec![
+            test_stream(1, PlaylistItemType::Catchup, true, true),
+            test_stream(2, PlaylistItemType::Video, false, true),
+        ]);
+        let last_seen = HashMap::from([(1, 1_000u64)]);
+        let ttl = 30u64;
+        let visible = filter_visible_streams(
+            streams,
+            &last_seen,
+            1_000 + ttl + ADAPTIVE_STREAM_CLEANUP_BUFFER_SECS + 1,
+            ttl,
+        )
+        .unwrap();
+        // Soft-preserve is for segment gaps only; past TTL the row must leave Streams without reload.
+        assert_eq!(visible.len(), 1);
+        assert_eq!(visible[0].channel.item_type, PlaylistItemType::Video);
+    }
+
+    #[test]
+    fn filter_visible_streams_hides_stale_active_catchup_past_adaptive_ttl() {
+        use super::{filter_visible_streams, ADAPTIVE_STREAM_CLEANUP_BUFFER_SECS};
+
+        let streams = Some(vec![
+            test_stream(1, PlaylistItemType::Catchup, false, true),
+            test_stream(2, PlaylistItemType::Video, false, true),
+        ]);
+        let last_seen = HashMap::from([(1, 1_000u64)]);
+        let ttl = 30u64;
+        let visible = filter_visible_streams(
+            streams,
+            &last_seen,
+            1_000 + ttl + ADAPTIVE_STREAM_CLEANUP_BUFFER_SECS + 1,
+            ttl,
+        )
+        .unwrap();
+        // Active rows refresh last_seen in the UI; a frozen last_seen past TTL must hide.
+        assert_eq!(visible.len(), 1);
+        assert_eq!(visible[0].channel.item_type, PlaylistItemType::Video);
+    }
+
+    #[test]
+    fn build_technical_chips_dedupes_hls_type_and_container() {
+        use super::build_technical_chips;
+        use shared::model::StreamTechnicalInfo;
+
+        let tech = StreamTechnicalInfo {
+            container: "hls".to_string(),
+            video_codec: "h264".to_string(),
+            ..Default::default()
+        };
+        let chips = build_technical_chips(PlaylistItemType::LiveHls, Some(&tech));
+        let labels: Vec<_> = chips.iter().map(|(label, _)| label.as_str()).collect();
+        assert_eq!(labels, vec!["HLS", "h264"]);
     }
 }

--- a/frontend/src/app/components/dashboard/stream_display/mod.rs
+++ b/frontend/src/app/components/dashboard/stream_display/mod.rs
@@ -26,7 +26,8 @@ use shared::{
     defaults::default_kick_secs,
     error::TuliproxError,
     model::{
-        PlaylistRequest, PlaylistUrlResolveRequest, ProtocolMessage, StreamInfo, StreamInfoConfigDto, UserCommand,
+        PlaylistItemType, PlaylistRequest, PlaylistUrlResolveRequest, ProtocolMessage, StreamInfo,
+        StreamInfoConfigDto, UserCommand,
     },
 };
 use std::{collections::HashMap, fmt::Display, rc::Rc, str::FromStr};
@@ -37,6 +38,17 @@ const KICK: &str = "kick";
 const COPY_LINK_TULIPROX_VIRTUAL_ID: &str = "copy_link_tuliprox_virtual_id";
 const COPY_LINK_TULIPROX_WEBPLAYER_URL: &str = "copy_link_tuliprox_webplayer_url";
 const COPY_LINK_PROVIDER_URL: &str = "copy_link_provider_url";
+
+fn stream_display_key(stream: &StreamInfo) -> String {
+    // Prefer a stable session identity so archive HLS segment addr/uid churn does not remount the row.
+    if let Some(token) = stream.session_token.as_deref().filter(|token| !token.is_empty()) {
+        return format!("session-{token}");
+    }
+    if stream.channel.item_type == PlaylistItemType::Catchup {
+        return format!("catchup-{}-{}", stream.username, stream.channel.virtual_id);
+    }
+    format!("{}-{}", stream.addr, stream.uid)
+}
 
 #[derive(Properties, PartialEq, Clone)]
 pub struct StreamDisplayProps {
@@ -315,7 +327,7 @@ pub fn StreamDisplay(props: &StreamDisplayProps) -> Html {
                             <>
                                 <div class="tp__stream-display__list">
                                     { for streams.iter().cloned().map(|stream| {
-                                        let key = format!("{}-{}", stream.addr, stream.uid);
+                                        let key = stream_display_key(&stream);
                                         let user_comment = user_comments.get(stream.username.as_str()).cloned().flatten();
                                         html! {
                                             <StreamDisplayItem

--- a/frontend/src/hooks/use_server_status.rs
+++ b/frontend/src/hooks/use_server_status.rs
@@ -25,19 +25,58 @@ type ServerStatusState =
 
 fn stream_identity_key(stream: &StreamInfo) -> (SocketAddr, u32) { (stream.addr, stream.uid) }
 
+fn is_catchup_session_token(session_token: &str) -> bool {
+    session_token.starts_with("m3u-catchup|")
+        || session_token.starts_with("catchup|")
+        || session_token.contains("|archive|")
+        || session_token.contains("|timeshift_abs|")
+}
+
+fn stream_url_looks_adaptive(url: &str) -> bool {
+    let lower = url.to_ascii_lowercase();
+    lower.contains(".m3u8") || lower.contains(".mpd")
+}
+
+fn is_sticky_session_stream(stream: &StreamInfo) -> bool {
+    // Match backend `is_stable_session_stream`, plus Catchup without a token so soft-preserve
+    // still wins when archive segments briefly lose session metadata.
+    if stream.channel.item_type == PlaylistItemType::Catchup {
+        return true;
+    }
+    if stream.channel.item_type.is_live_adaptive() || is_shared_hls_stream(stream) {
+        return true;
+    }
+    if stream_url_looks_adaptive(stream.channel.url.as_ref()) {
+        return true;
+    }
+    stream.session_token.as_deref().is_some_and(is_catchup_session_token)
+}
+
 fn find_stream_update_index(streams: &[StreamInfo], updated_stream: &StreamInfo) -> Option<usize> {
     let updated_key = stream_identity_key(updated_stream);
     if let Some(index) = streams.iter().position(|stream| stream_identity_key(stream) == updated_key) {
         return Some(index);
     }
 
-    if updated_stream.session_token.is_some() && updated_stream.channel.item_type.requires_provider_affinity() {
-        if let Some(session_token) = updated_stream.session_token.as_deref() {
+    if let Some(session_token) = updated_stream.session_token.as_deref() {
+        if is_sticky_session_stream(updated_stream) {
             if let Some(index) =
                 streams.iter().position(|stream| stream.session_token.as_deref() == Some(session_token))
             {
                 return Some(index);
             }
+        }
+    }
+
+    // Catchup without a stable token still remaps by channel identity so Streams does not accumulate
+    // one row per HLS segment addr/uid churn.
+    if updated_stream.channel.item_type == PlaylistItemType::Catchup {
+        if let Some(index) = streams.iter().position(|stream| {
+            stream.channel.item_type == PlaylistItemType::Catchup
+                && stream.username == updated_stream.username
+                && stream.channel.virtual_id == updated_stream.channel.virtual_id
+        }) {
+            return Some(index);
         }
     }
 
@@ -53,10 +92,56 @@ fn dedupe_streams_by_identity(streams: &mut Vec<StreamInfo>) {
     streams.retain(|stream| seen.insert(stream_identity_key(stream)));
 }
 
-fn should_keep_preserved_stream_visible(stream: &StreamInfo) -> bool {
-    stream.session_token.is_some() && (stream.channel.item_type.is_live_adaptive() || is_shared_hls_stream(stream))
+/// Drop preserved sticky rows for channels the same user+IP is no longer watching.
+/// Keeps soft-preserve during HLS segment gaps (no active row yet); clears zapped channels immediately
+/// instead of waiting for hls_session_ttl (~15s).
+fn prune_zapped_preserved_streams(streams: &mut Vec<StreamInfo>) {
+    let active_channels: HashSet<(String, String, u32)> = streams
+        .iter()
+        .filter(|stream| !stream.preserved && stream.client_ip != BACKGROUND_TRANSFER_CLIENT_IP)
+        .map(|stream| (stream.username.clone(), stream.client_ip.clone(), stream.channel.virtual_id))
+        .collect();
+    if active_channels.is_empty() {
+        return;
+    }
+    let users_with_active: HashSet<(String, String)> =
+        active_channels.iter().map(|(username, client_ip, _)| (username.clone(), client_ip.clone())).collect();
+
+    streams.retain(|stream| {
+        if stream.client_ip == BACKGROUND_TRANSFER_CLIENT_IP {
+            return true;
+        }
+        if !stream.preserved || !is_sticky_session_stream(stream) {
+            return true;
+        }
+        let user_ip = (stream.username.clone(), stream.client_ip.clone());
+        if !users_with_active.contains(&user_ip) {
+            return true;
+        }
+        active_channels.contains(&(stream.username.clone(), stream.client_ip.clone(), stream.channel.virtual_id))
+    });
 }
 
+fn should_keep_preserved_stream_visible(stream: &StreamInfo) -> bool {
+    // Match backend `is_stable_session_stream`: Catchup/HLS/DASH (and shared HLS) stay visible
+    // while preserved between short segment requests — otherwise archive playback vanishes from Streams.
+    is_sticky_session_stream(stream)
+}
+
+/// Soft-preserve safety net for partial StatusCheck snapshots. Must not resurrect ended sessions.
+#[allow(dead_code)] // kept as documentation of the old merge TTL; snapshot merge was removed
+const STICKY_SNAPSHOT_MERGE_TTL_SECS: u64 = 20;
+
+fn mark_sticky_session_preserved(stream: &mut StreamInfo) -> bool {
+    if is_sticky_session_stream(stream) {
+        stream.preserved = true;
+        true
+    } else {
+        false
+    }
+}
+
+#[allow(dead_code)] // retained for documentation of the old Connections(0) wipe predicate
 fn should_keep_stream_when_connections_drop_to_zero(stream: &StreamInfo) -> bool {
     stream.preserved && should_keep_preserved_stream_visible(stream)
 }
@@ -138,7 +223,10 @@ fn replace_server_status_snapshot(
     mut server_status: StatusCheck,
     download_streams: &[StreamInfo],
 ) -> Rc<StatusCheck> {
+    // Trust backend `panel_streams` as authoritative. Re-merging sticky FE ghosts resurrected
+    // ended archive/HLS rows until a full page reload.
     dedupe_streams_by_identity(&mut server_status.active_user_streams);
+    prune_zapped_preserved_streams(&mut server_status.active_user_streams);
     merge_aux_streams(&mut server_status, download_streams);
     let server_status = Rc::new(server_status);
     *status_holder = Some(Rc::clone(&server_status));
@@ -199,6 +287,9 @@ fn apply_active_user_change(server_status: &mut StatusCheck, event: ActiveUserCo
     match event {
         ActiveUserConnectionChange::Updated(stream_info) => {
             if stream_info.preserved {
+                // Never drop on Updated(preserved): backend already decided the session row should
+                // linger between HLS segments. Removing here blanked archive Streams when sticky
+                // detection lagged behind backend `is_stable_session_stream`.
                 if should_keep_preserved_stream_visible(&stream_info) {
                     if let Some(pos) = find_stream_update_index(&server_status.active_user_streams, &stream_info) {
                         server_status.active_user_streams[pos] = stream_info;
@@ -206,8 +297,7 @@ fn apply_active_user_change(server_status: &mut StatusCheck, event: ActiveUserCo
                         server_status.active_user_streams.push(stream_info);
                     }
                     dedupe_streams_by_identity(&mut server_status.active_user_streams);
-                } else if let Some(pos) = find_stream_update_index(&server_status.active_user_streams, &stream_info) {
-                    server_status.active_user_streams.remove(pos);
+                    prune_zapped_preserved_streams(&mut server_status.active_user_streams);
                 }
                 return;
             }
@@ -217,18 +307,70 @@ fn apply_active_user_change(server_status: &mut StatusCheck, event: ActiveUserCo
                 server_status.active_user_streams.push(stream_info);
             }
             dedupe_streams_by_identity(&mut server_status.active_user_streams);
+            // Channel zap: new active channel replaces preserved soft-kept previous channel immediately.
+            prune_zapped_preserved_streams(&mut server_status.active_user_streams);
         }
         ActiveUserConnectionChange::Disconnected(addr) => {
-            server_status.active_user_streams.retain(|stream_info| stream_info.addr != addr);
+            // Active sticky rows: soft-preserve across short HLS segment teardown.
+            // Already-preserved rows: this is backend expiry (AdaptiveSessionExpired) — hard remove.
+            let mut expired = false;
+            for stream in &server_status.active_user_streams {
+                if stream.addr == addr && stream.preserved && is_sticky_session_stream(stream) {
+                    expired = true;
+                    break;
+                }
+            }
+            if expired {
+                server_status.active_user_streams.retain(|stream_info| stream_info.addr != addr);
+            } else {
+                for stream in &mut server_status.active_user_streams {
+                    if stream.addr == addr {
+                        mark_sticky_session_preserved(stream);
+                    }
+                }
+                server_status
+                    .active_user_streams
+                    .retain(|stream_info| stream_info.addr != addr || should_keep_preserved_stream_visible(stream_info));
+            }
         }
         ActiveUserConnectionChange::DisconnectedStream { addr, uid } => {
-            server_status.active_user_streams.retain(|stream_info| stream_info.addr != addr || stream_info.uid != uid);
+            let already_preserved = server_status.active_user_streams.iter().any(|stream_info| {
+                stream_info.addr == addr && stream_info.uid == uid && stream_info.preserved
+            });
+            if already_preserved {
+                // Backend session TTL expiry — do not soft-preserve again (that left ghosts until reload).
+                server_status
+                    .active_user_streams
+                    .retain(|stream_info| stream_info.addr != addr || stream_info.uid != uid);
+                return;
+            }
+            if let Some(stream) = server_status
+                .active_user_streams
+                .iter_mut()
+                .find(|stream_info| stream_info.addr == addr && stream_info.uid == uid)
+            {
+                if mark_sticky_session_preserved(stream) {
+                    return;
+                }
+            }
+            server_status
+                .active_user_streams
+                .retain(|stream_info| stream_info.addr != addr || stream_info.uid != uid);
         }
         ActiveUserConnectionChange::Connections(user_count, connections) => {
             server_status.active_users = user_count;
             server_status.active_user_connections = connections;
+            // Connections(0) often arrives before Disconnected* between HLS segments. If we leave
+            // sticky rows as active (preserved=false), adaptive last_seen keeps refreshing and the
+            // Streams TTL never hides them — ghosts until page reload.
             if connections == 0 {
-                server_status.active_user_streams.retain(should_keep_stream_when_connections_drop_to_zero);
+                for stream in &mut server_status.active_user_streams {
+                    mark_sticky_session_preserved(stream);
+                }
+                server_status.active_user_streams.retain(|stream| {
+                    stream.client_ip == BACKGROUND_TRANSFER_CLIENT_IP
+                        || (stream.preserved && should_keep_preserved_stream_visible(stream))
+                });
             }
         }
     }
@@ -461,14 +603,16 @@ mod tests {
     }
 
     #[test]
-    fn test_connections_zero_clears_stale_stream_rows() {
+    fn test_connections_zero_drops_plain_rows_and_soft_preserves_sticky() {
+        let mut plain_a = test_stream(1, "127.0.0.1:1234", Some("tok-a"), PlaylistItemType::Video);
+        plain_a.channel.url = "http://localhost/movie.ts".intern();
+        let mut plain_b = test_stream(2, "127.0.0.1:5678", Some("tok-b"), PlaylistItemType::Series);
+        plain_b.channel.url = "http://localhost/series.ts".intern();
+        let sticky = test_stream(3, "127.0.0.1:9999", Some("tok-catchup"), PlaylistItemType::Catchup);
         let mut status = shared::model::StatusCheck {
             active_users: 1,
             active_user_connections: 1,
-            active_user_streams: vec![
-                test_stream(1, "127.0.0.1:1234", Some("tok-a"), PlaylistItemType::Video),
-                test_stream(2, "127.0.0.1:5678", Some("tok-b"), PlaylistItemType::Series),
-            ],
+            active_user_streams: vec![plain_a, plain_b, sticky.clone()],
             ..Default::default()
         };
 
@@ -476,18 +620,22 @@ mod tests {
 
         assert_eq!(status.active_users, 0);
         assert_eq!(status.active_user_connections, 0);
-        assert!(status.active_user_streams.is_empty());
+        assert_eq!(status.active_user_streams.len(), 1);
+        assert_eq!(status.active_user_streams[0].uid, sticky.uid);
+        assert!(status.active_user_streams[0].preserved);
     }
 
     #[test]
-    fn test_connections_zero_keeps_preserved_adaptive_rows_for_ttl_cleanup() {
+    fn test_connections_zero_soft_preserves_sticky_and_drops_plain_rows() {
         let mut preserved = test_stream(1, "127.0.0.1:1234", Some("tok-hls"), PlaylistItemType::LiveHls);
         preserved.preserved = true;
-        let non_adaptive = test_stream(2, "127.0.0.1:5678", Some("tok-vod"), PlaylistItemType::Video);
+        let mut plain = test_stream(2, "127.0.0.1:5678", Some("tok-vod"), PlaylistItemType::Video);
+        plain.channel.url = "http://localhost/movie.ts".intern();
+        let active_catchup = test_stream(3, "127.0.0.1:9999", Some("tok-catchup"), PlaylistItemType::Catchup);
         let mut status = shared::model::StatusCheck {
             active_users: 1,
             active_user_connections: 1,
-            active_user_streams: vec![preserved.clone(), non_adaptive],
+            active_user_streams: vec![preserved.clone(), plain, active_catchup.clone()],
             ..Default::default()
         };
 
@@ -495,7 +643,10 @@ mod tests {
 
         assert_eq!(status.active_users, 1);
         assert_eq!(status.active_user_connections, 0);
-        assert_eq!(status.active_user_streams, vec![preserved]);
+        assert_eq!(status.active_user_streams.len(), 2);
+        assert!(status.active_user_streams.iter().all(|stream| stream.preserved));
+        assert!(status.active_user_streams.iter().any(|stream| stream.uid == preserved.uid));
+        assert!(status.active_user_streams.iter().any(|stream| stream.uid == active_catchup.uid));
     }
 
     #[test]
@@ -527,7 +678,7 @@ mod tests {
     }
 
     #[test]
-    fn test_preserved_non_adaptive_update_removes_active_stream_without_clearing_other_rows() {
+    fn test_preserved_non_adaptive_update_is_ignored_without_clearing_other_rows() {
         let mut preserved = test_stream(1, "127.0.0.1:1234", Some("tok-vod"), PlaylistItemType::Video);
         preserved.preserved = true;
         let other = test_stream(2, "127.0.0.1:5678", Some("tok-other"), PlaylistItemType::LiveHls);
@@ -540,10 +691,12 @@ mod tests {
             ],
             ..Default::default()
         };
+        let before = status.active_user_streams.clone();
 
         apply_active_user_change(&mut status, ActiveUserConnectionChange::Updated(preserved));
 
-        assert_eq!(status.active_user_streams, vec![other]);
+        // Non-sticky preserved updates must not delete panel rows (that path blanked archive Streams).
+        assert_eq!(status.active_user_streams, before);
         assert_eq!(status.active_users, 2);
         assert_eq!(status.active_user_connections, 2);
     }
@@ -562,6 +715,277 @@ mod tests {
         apply_active_user_change(&mut status, ActiveUserConnectionChange::Updated(preserved.clone()));
 
         assert_eq!(status.active_user_streams, vec![preserved]);
+    }
+
+    #[test]
+    fn test_preserved_catchup_update_stays_visible_between_archive_segments() {
+        let mut preserved = test_stream(1, "127.0.0.1:1234", Some("tok-catchup"), PlaylistItemType::Catchup);
+        preserved.preserved = true;
+        let other = test_stream(2, "127.0.0.1:5678", Some("tok-live"), PlaylistItemType::LiveHls);
+        let mut status = shared::model::StatusCheck {
+            active_users: 2,
+            active_user_connections: 2,
+            active_user_streams: vec![
+                test_stream(1, "127.0.0.1:1234", Some("tok-catchup"), PlaylistItemType::Catchup),
+                other.clone(),
+            ],
+            ..Default::default()
+        };
+
+        apply_active_user_change(&mut status, ActiveUserConnectionChange::Updated(preserved.clone()));
+
+        assert_eq!(status.active_user_streams.len(), 2);
+        assert!(status
+            .active_user_streams
+            .iter()
+            .any(|stream| stream.uid == preserved.uid && stream.preserved && stream.channel.item_type == PlaylistItemType::Catchup));
+        assert!(status.active_user_streams.iter().any(|stream| stream == &other));
+    }
+
+    #[test]
+    fn test_connections_zero_keeps_preserved_catchup_rows_for_ttl_cleanup() {
+        let mut preserved = test_stream(1, "127.0.0.1:1234", Some("tok-catchup"), PlaylistItemType::Catchup);
+        preserved.preserved = true;
+        let non_session = test_stream(2, "127.0.0.1:5678", Some("tok-vod"), PlaylistItemType::Video);
+        let mut status = shared::model::StatusCheck {
+            active_users: 1,
+            active_user_connections: 1,
+            active_user_streams: vec![preserved.clone(), non_session],
+            ..Default::default()
+        };
+
+        apply_active_user_change(&mut status, ActiveUserConnectionChange::Connections(1, 0));
+
+        assert_eq!(status.active_user_streams.len(), 2);
+        assert!(status.active_user_streams.iter().any(|s| s.uid == preserved.uid));
+    }
+
+    #[test]
+    fn test_connections_zero_soft_preserves_active_catchup_before_disconnect_event() {
+        // Reproduce backend ordering: Connections(0) can arrive before DisconnectedStream.
+        let active = test_stream(1, "127.0.0.1:1234", Some("m3u-catchup|archive|100|3600"), PlaylistItemType::Catchup);
+        let mut vod = test_stream(2, "127.0.0.1:5678", Some("tok-vod"), PlaylistItemType::Video);
+        vod.channel.url = "http://localhost/movie.ts".intern();
+        let mut status = shared::model::StatusCheck {
+            active_users: 1,
+            active_user_connections: 1,
+            active_user_streams: vec![active.clone(), vod],
+            ..Default::default()
+        };
+
+        apply_active_user_change(&mut status, ActiveUserConnectionChange::Connections(1, 0));
+
+        assert_eq!(status.active_user_streams.len(), 1);
+        assert_eq!(status.active_user_connections, 0);
+        assert!(status.active_user_streams.iter().any(|s| s.uid == active.uid && s.preserved));
+    }
+
+    #[test]
+    fn test_connections_zero_soft_preserves_live_typed_catchup_session_token() {
+        let active = test_stream(1, "127.0.0.1:1234", Some("m3u-catchup|x|archive|100|3600"), PlaylistItemType::Live);
+        let mut status = shared::model::StatusCheck {
+            active_users: 1,
+            active_user_connections: 1,
+            active_user_streams: vec![active.clone()],
+            ..Default::default()
+        };
+
+        apply_active_user_change(&mut status, ActiveUserConnectionChange::Connections(1, 0));
+
+        assert_eq!(status.active_user_streams.len(), 1);
+        assert!(status.active_user_streams[0].preserved);
+        assert_eq!(status.active_user_streams[0].uid, active.uid);
+        assert_eq!(status.active_user_connections, 0);
+    }
+
+    #[test]
+    fn test_server_status_snapshot_does_not_resurrect_sticky_omitted_by_backend() {
+        let mut preserved = test_stream(1, "127.0.0.1:1234", Some("tok-catchup"), PlaylistItemType::Catchup);
+        preserved.preserved = true;
+        preserved.ts = current_time_secs();
+        let mut status_holder = Some(Rc::new(shared::model::StatusCheck {
+            active_users: 1,
+            active_user_connections: 0,
+            active_user_streams: vec![preserved],
+            ..Default::default()
+        }));
+        let empty_backend_snapshot = shared::model::StatusCheck {
+            active_users: 0,
+            active_user_connections: 0,
+            active_user_streams: vec![],
+            ..Default::default()
+        };
+
+        let status = replace_server_status_snapshot(&mut status_holder, empty_backend_snapshot, &[]);
+
+        assert!(status.active_user_streams.is_empty());
+    }
+
+    #[test]
+    fn test_connections_zero_soft_preserves_catchup_without_session_token() {
+        let active = test_stream(1, "127.0.0.1:1234", None, PlaylistItemType::Catchup);
+        let mut status = shared::model::StatusCheck {
+            active_users: 1,
+            active_user_connections: 1,
+            active_user_streams: vec![active.clone()],
+            ..Default::default()
+        };
+
+        apply_active_user_change(&mut status, ActiveUserConnectionChange::Connections(1, 0));
+
+        assert_eq!(status.active_user_streams.len(), 1);
+        assert!(status.active_user_streams[0].preserved);
+        assert_eq!(status.active_user_streams[0].uid, active.uid);
+        assert_eq!(status.active_user_connections, 0);
+    }
+
+    #[test]
+    fn test_catchup_update_remaps_by_virtual_id_across_segment_addr_churn() {
+        let previous = test_stream(1, "127.0.0.1:1111", None, PlaylistItemType::Catchup);
+        let mut next = test_stream(99, "127.0.0.1:2222", None, PlaylistItemType::Catchup);
+        next.channel.virtual_id = previous.channel.virtual_id;
+        next.username = previous.username.clone();
+        let mut status = shared::model::StatusCheck {
+            active_users: 1,
+            active_user_connections: 1,
+            active_user_streams: vec![previous],
+            ..Default::default()
+        };
+
+        apply_active_user_change(&mut status, ActiveUserConnectionChange::Updated(next.clone()));
+
+        assert_eq!(status.active_user_streams.len(), 1);
+        assert_eq!(status.active_user_streams[0].uid, next.uid);
+        assert_eq!(status.active_user_streams[0].addr, next.addr);
+    }
+
+    #[test]
+    fn test_active_update_drops_preserved_previous_channel_on_zap() {
+        let mut previous = test_stream(1, "127.0.0.1:1111", Some("tok-old"), PlaylistItemType::LiveHls);
+        previous.preserved = true;
+        previous.channel.virtual_id = 100;
+        previous.channel.title = "Old Channel".intern();
+        let mut next = test_stream(2, "127.0.0.1:2222", Some("tok-new"), PlaylistItemType::LiveHls);
+        next.channel.virtual_id = 200;
+        next.channel.title = "New Channel".intern();
+        let mut status = shared::model::StatusCheck {
+            active_users: 1,
+            active_user_connections: 1,
+            active_user_streams: vec![previous],
+            ..Default::default()
+        };
+
+        apply_active_user_change(&mut status, ActiveUserConnectionChange::Updated(next.clone()));
+
+        assert_eq!(status.active_user_streams.len(), 1);
+        assert_eq!(status.active_user_streams[0].uid, next.uid);
+        assert_eq!(status.active_user_streams[0].channel.virtual_id, 200);
+        assert!(!status.active_user_streams[0].preserved);
+    }
+
+    #[test]
+    fn test_active_update_keeps_preserved_same_channel_during_segment_gap() {
+        let mut previous = test_stream(1, "127.0.0.1:1111", Some("tok-hls"), PlaylistItemType::LiveHls);
+        previous.preserved = true;
+        previous.channel.virtual_id = 100;
+        // Another user's preserved row must stay.
+        let mut other_user = test_stream(9, "127.0.0.1:9999", Some("tok-other"), PlaylistItemType::LiveHls);
+        other_user.preserved = true;
+        other_user.username = "other".to_string();
+        other_user.channel.virtual_id = 999;
+        let mut next = test_stream(2, "127.0.0.1:2222", Some("tok-hls-next"), PlaylistItemType::LiveHls);
+        next.channel.virtual_id = 100;
+        let mut status = shared::model::StatusCheck {
+            active_users: 2,
+            active_user_connections: 1,
+            active_user_streams: vec![previous.clone(), other_user.clone()],
+            ..Default::default()
+        };
+
+        apply_active_user_change(&mut status, ActiveUserConnectionChange::Updated(next.clone()));
+
+        assert_eq!(status.active_user_streams.len(), 2);
+        assert!(status.active_user_streams.iter().any(|s| s.uid == next.uid && s.channel.virtual_id == 100));
+        assert!(status.active_user_streams.iter().any(|s| s.uid == other_user.uid && s.preserved));
+    }
+
+    #[test]
+    fn test_disconnected_stream_soft_preserves_catchup_between_segments() {
+        let active = test_stream(1, "127.0.0.1:1234", Some("tok-catchup"), PlaylistItemType::Catchup);
+        let other = test_stream(2, "127.0.0.1:5678", Some("tok-live"), PlaylistItemType::LiveHls);
+        let mut status = shared::model::StatusCheck {
+            active_users: 2,
+            active_user_connections: 2,
+            active_user_streams: vec![active.clone(), other.clone()],
+            ..Default::default()
+        };
+
+        apply_active_user_change(
+            &mut status,
+            ActiveUserConnectionChange::DisconnectedStream { addr: active.addr, uid: active.uid },
+        );
+
+        assert_eq!(status.active_user_streams.len(), 2);
+        assert!(status.active_user_streams.iter().any(|stream| {
+            stream.uid == active.uid && stream.preserved && stream.channel.item_type == PlaylistItemType::Catchup
+        }));
+        assert!(status.active_user_streams.iter().any(|stream| stream == &other));
+    }
+
+    #[test]
+    fn test_disconnected_stream_hard_removes_already_preserved_on_session_expiry() {
+        let mut preserved = test_stream(1, "127.0.0.1:1234", Some("tok-catchup"), PlaylistItemType::Catchup);
+        preserved.preserved = true;
+        let other = test_stream(2, "127.0.0.1:5678", Some("tok-live"), PlaylistItemType::LiveHls);
+        let mut status = shared::model::StatusCheck {
+            active_users: 1,
+            active_user_connections: 0,
+            active_user_streams: vec![preserved.clone(), other.clone()],
+            ..Default::default()
+        };
+
+        apply_active_user_change(
+            &mut status,
+            ActiveUserConnectionChange::DisconnectedStream { addr: preserved.addr, uid: preserved.uid },
+        );
+
+        assert_eq!(status.active_user_streams, vec![other]);
+    }
+
+    #[test]
+    fn test_disconnected_addr_soft_preserves_catchup_and_drops_plain_live() {
+        let catchup = test_stream(1, "127.0.0.1:1234", Some("tok-catchup"), PlaylistItemType::Catchup);
+        let mut live = test_stream(2, "127.0.0.1:1234", Some("tok-live"), PlaylistItemType::Live);
+        live.channel.url = "http://localhost/live.ts".intern();
+        let mut status = shared::model::StatusCheck {
+            active_users: 1,
+            active_user_connections: 2,
+            active_user_streams: vec![catchup.clone(), live],
+            ..Default::default()
+        };
+
+        apply_active_user_change(&mut status, ActiveUserConnectionChange::Disconnected(catchup.addr));
+
+        assert_eq!(status.active_user_streams.len(), 1);
+        assert!(status.active_user_streams[0].preserved);
+        assert_eq!(status.active_user_streams[0].channel.item_type, PlaylistItemType::Catchup);
+    }
+
+    #[test]
+    fn test_disconnected_addr_hard_removes_already_preserved_sticky() {
+        let mut preserved = test_stream(1, "127.0.0.1:1234", Some("tok-catchup"), PlaylistItemType::Catchup);
+        preserved.preserved = true;
+        let other = test_stream(2, "127.0.0.1:5678", Some("tok-live"), PlaylistItemType::LiveHls);
+        let mut status = shared::model::StatusCheck {
+            active_users: 1,
+            active_user_connections: 0,
+            active_user_streams: vec![preserved.clone(), other.clone()],
+            ..Default::default()
+        };
+
+        apply_active_user_change(&mut status, ActiveUserConnectionChange::Disconnected(preserved.addr));
+
+        assert_eq!(status.active_user_streams, vec![other]);
     }
 
     #[test]

--- a/frontend/src/utils/mod.rs
+++ b/frontend/src/utils/mod.rs
@@ -65,5 +65,7 @@ pub fn join_non_empty_parts<'a>(parts: impl Iterator<Item = &'a str>, separator:
 }
 
 pub fn is_shared_hls_stream(stream: &StreamInfo) -> bool {
-    stream.channel.shared && stream.channel.item_type == PlaylistItemType::LiveHls
+    stream.channel.shared
+        && (stream.channel.item_type == PlaylistItemType::LiveHls
+            || stream.channel.item_type == PlaylistItemType::Catchup)
 }

--- a/shared/src/model/playlist.rs
+++ b/shared/src/model/playlist.rs
@@ -618,6 +618,28 @@ fn append_m3u_catchup_attributes(
     append_extra_catchup_attributes(line, &catchup.extra_attributes);
 }
 
+fn append_unified_catchup_type_attributes(
+    line: &mut String,
+    catchup: &CatchupProperties,
+    catchup_type: &str,
+    rewritten_source: Option<&Arc<str>>,
+    emit_source: bool,
+) {
+    // Unified export: always `catchup-type=╤В╨Р╨╢`, never `catchup=`.
+    write_m3u_attr(line, "catchup-type", catchup_type);
+    append_catchup_attribute(line, "catchup-days", catchup.days.as_ref());
+    if emit_source {
+        if let Some(source) = rewritten_source.filter(|source| !source.is_empty()) {
+            write_m3u_attr(line, "catchup-source", source.as_ref());
+        } else {
+            append_catchup_attribute(line, "catchup-source", catchup.source.as_ref());
+        }
+    }
+    append_catchup_attribute(line, "catchup-time", catchup.time.as_ref());
+    append_catchup_attribute(line, "catchup-correction", catchup.correction.as_ref());
+    append_extra_catchup_attributes(line, &catchup.extra_attributes);
+}
+
 impl M3uPlaylistItem {
     #[allow(clippy::missing_panics_doc)]
     pub fn to_m3u(&self, target_options: Option<&ConfigTargetOptions>, rewrite_urls: bool) -> String {
@@ -643,6 +665,15 @@ impl M3uPlaylistItem {
         if self.chno != 0 {
             let _ = write!(line, " tvg-chno=\"{}\"", self.chno);
         }
+        let flussonic_mode = self.additional_properties.as_ref().and_then(|props| match props {
+            StreamProperties::Live(live) => live.catchup.as_ref().and_then(CatchupProperties::native_flussonic_player_mode),
+            _ => None,
+        });
+        let append_type = self.additional_properties.as_ref().and_then(|props| match props {
+            StreamProperties::Live(live) => live.catchup.as_ref().and_then(CatchupProperties::append_player_type),
+            _ => None,
+        });
+        // Emit timeshift only when the source had it (non-empty). Never invent catchup attrs.
         to_m3u_non_empty_fields!(self, line,
             (parent_code, "parent-code"),
             (audio_track, "audio-track"),
@@ -650,12 +681,33 @@ impl M3uPlaylistItem {
             (rec, "tvg-rec"););
         if let Some(StreamProperties::Live(live)) = self.additional_properties.as_ref() {
             if let Some(catchup) = live.catchup.as_ref() {
-                append_m3u_catchup_attributes(
-                    &mut line,
-                    catchup,
-                    self.t_catchup_mode.as_ref(),
-                    self.t_catchup_source.as_ref(),
-                );
+                if let Some(mode) = flussonic_mode {
+                    // Unify catchup=/catchup-type=flussonic* ╤В╨Ц╨в catchup-type only.
+                    // No catchup=, no shift-style catchup-source, no invented days.
+                    append_unified_catchup_type_attributes(
+                        &mut line,
+                        catchup,
+                        mode,
+                        None,
+                        false,
+                    );
+                } else if let Some(append_type) = append_type {
+                    // Unify catchup=/catchup-type=append ╤В╨Ц╨в catchup-type="append" only.
+                    append_unified_catchup_type_attributes(
+                        &mut line,
+                        catchup,
+                        append_type,
+                        self.t_catchup_source.as_ref(),
+                        true,
+                    );
+                } else {
+                    append_m3u_catchup_attributes(
+                        &mut line,
+                        catchup,
+                        self.t_catchup_mode.as_ref(),
+                        self.t_catchup_source.as_ref(),
+                    );
+                }
             }
         }
 

--- a/shared/src/model/stream_properties.rs
+++ b/shared/src/model/stream_properties.rs
@@ -48,20 +48,54 @@ impl CatchupProperties {
             && self.extra_attributes.is_empty()
     }
 
+    fn is_flussonic_mode_str(mode: Option<&str>) -> bool {
+        mode.is_some_and(|m| {
+            matches!(
+                m.trim().to_ascii_lowercase().as_str(),
+                "flussonic" | "flussonic-hls" | "flussonic-ts" | "fs"
+            )
+        })
+    }
+
+    /// Prefer `catchup-type` when both are set so a leftover `catchup="shift"`/`append`
+    /// from a provider cannot steal Flussonic path-rewrite channels (v3.3.81 behavior).
+    pub fn is_flussonic(&self) -> bool {
+        if let Some(ct) = self.catchup_type.as_deref().filter(|v| !v.is_empty()) {
+            return Self::is_flussonic_mode_str(Some(ct));
+        }
+        Self::is_flussonic_mode_str(self.mode.as_deref())
+    }
+
     pub fn native_flussonic_player_mode(&self) -> Option<&'static str> {
+        if !self.is_flussonic() {
+            return None;
+        }
+        let raw = self
+            .catchup_type
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .or_else(|| self.mode.as_deref().map(str::trim).filter(|value| !value.is_empty()))
+            .unwrap_or("flussonic");
+        if raw.eq_ignore_ascii_case("flussonic-ts") {
+            Some("flussonic-ts")
+        } else {
+            Some("flussonic")
+        }
+    }
+
+    /// Canonical append label for unified M3U export (`catchup-type="append"` only).
+    pub fn append_player_type(&self) -> Option<&'static str> {
+        if self.native_flussonic_player_mode().is_some() {
+            return None;
+        }
         let mode = self
             .mode
             .as_deref()
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .or_else(|| self.catchup_type.as_deref().map(str::trim).filter(|value| !value.is_empty()))?;
-        if mode.eq_ignore_ascii_case("flussonic-ts") {
-            Some("flussonic-ts")
-        } else if ["fs", "flussonic", "flussonic-hls"].iter().any(|alias| mode.eq_ignore_ascii_case(alias)) {
-            Some("flussonic")
-        } else {
-            None
-        }
+        mode.eq_ignore_ascii_case("append").then_some("append")
     }
 }
 
@@ -1176,11 +1210,22 @@ mod tests {
             assert_eq!(catchup.native_flussonic_player_mode(), expected);
         }
 
+        // BitTV often ships catchup="append"/"shift" with catchup-type="flussonic".
+        // catchup-type must win so path-rewrite archive stays Flussonic (v3.3.81).
         let conflicting = CatchupProperties {
             mode: Some("append".into()),
             catchup_type: Some("flussonic".into()),
             ..CatchupProperties::default()
         };
-        assert_eq!(conflicting.native_flussonic_player_mode(), None);
+        assert!(conflicting.is_flussonic());
+        assert_eq!(conflicting.native_flussonic_player_mode(), Some("flussonic"));
+
+        let shift_type_wins = CatchupProperties {
+            mode: Some("flussonic".into()),
+            catchup_type: Some("shift".into()),
+            ..CatchupProperties::default()
+        };
+        assert!(!shift_type_wins.is_flussonic());
+        assert_eq!(shift_type_wins.native_flussonic_player_mode(), None);
     }
 }


### PR DESCRIPTION
Prefer catchup-type for Flussonic detection, keep archive rows stable across HLS segments without immortal ghosts, scroll Active Streams list, and dedupe HLS chips.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved catch-up and archive playback across HLS, M3U, and Xtream streams.
  * Added support for archive timestamps, session tokens, nested paths, and recovered DVR segments.
  * Enhanced playlist metadata for Flussonic and append-mode catch-up streams.

* **Bug Fixes**
  * Prevented catch-up sessions from being incorrectly closed or redirected to live playback.
  * Improved stream preservation and expiry during connection drops and playback transitions.
  * Corrected dashboard stream tracking and status snapshots.

* **UI Improvements**
  * Added smoother scrolling and improved interaction in the stream list.
  * Reduced duplicate technical labels in stream details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->