### PR TITLE
fix: make Xtream refresh generations safe and Windows durable

### DIFF
--- a/backend/src/repository/storage.rs
+++ b/backend/src/repository/storage.rs
@@ -1,11 +1,17 @@
 use crate::model::Config;
-use crate::repository::bplustree::common::sidecar_lock_path;
 use crate::repository::storage_const;
 use crate::utils;
 use fs2::FileExt;
 use shared::concat_string;
 use shared::error::TuliproxError;
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    fs::{File, OpenOptions},
+    io,
+    path::{Path, PathBuf},
+    time::{Duration, SystemTime},
+};
+use uuid::Uuid;
 
 pub fn get_target_id_mapping_file(target_path: &Path) -> PathBuf {
     // Join directly with &str to avoid an intermediate PathBuf allocation
@@ -95,18 +101,146 @@ pub async fn ensure_input_storage_path(cfg: &Config, input_name: &str) -> Result
 /// run 5–15 minutes, so the threshold is set to 30 minutes — comfortably
 /// above the slowest legitimate refresh, while still bounding stale-file
 /// disk usage to roughly half an hour after a crash.
-#[allow(clippy::duration_suboptimal_units)]
-const ORPHAN_STAGING_MIN_AGE: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+const ORPHAN_STAGING_MIN_AGE: Duration = Duration::from_mins(30);
+
+const REFRESH_GENERATION_GUARD_PREFIX: &str = ".xtream-refresh-";
+const REFRESH_GENERATION_GUARD_SUFFIX: &str = ".lease";
+const XTREAM_REFRESH_DATABASE_STEMS: [&str; 3] = ["live", "video", "series"];
+const XTREAM_REFRESH_CATEGORY_STEMS: [&str; 3] = [
+    storage_const::COL_CAT_LIVE,
+    storage_const::COL_CAT_VOD,
+    storage_const::COL_CAT_SERIES,
+];
+
+/// Owns the cross-process lock for one complete Xtream refresh generation.
+///
+/// The guard file is created before any staging artifact and the lock remains
+/// held until every clone of the corresponding refresh lease has been dropped.
+#[derive(Debug)]
+pub(crate) struct XtreamRefreshGenerationGuard {
+    file: Option<File>,
+    path: PathBuf,
+}
+
+impl XtreamRefreshGenerationGuard {
+    pub(crate) fn acquire(storage_path: &Path, generation: Uuid) -> io::Result<Self> {
+        let path = refresh_generation_guard_path(storage_path, generation);
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .open(&path)?;
+        if let Err(error) = file.lock_exclusive() {
+            drop(file);
+            if let Err(remove_error) = std::fs::remove_file(&path) {
+                if remove_error.kind() != io::ErrorKind::NotFound {
+                    log::warn!(
+                        "Failed to remove unusable Xtream refresh generation guard {}: {remove_error}",
+                        path.display()
+                    );
+                }
+            }
+            return Err(error);
+        }
+        Ok(Self { file: Some(file), path })
+    }
+
+    fn from_locked_file(path: PathBuf, file: File) -> Self { Self { file: Some(file), path } }
+}
+
+impl Drop for XtreamRefreshGenerationGuard {
+    fn drop(&mut self) {
+        if let Some(file) = self.file.take() {
+            if let Err(error) = FileExt::unlock(&file) {
+                log::warn!(
+                    "Failed to unlock Xtream refresh generation guard {}: {error}; the OS will release it on close",
+                    self.path.display()
+                );
+            }
+            drop(file);
+        }
+        if let Err(error) = std::fs::remove_file(&self.path) {
+            if error.kind() != io::ErrorKind::NotFound {
+                log::warn!(
+                    "Failed to remove Xtream refresh generation guard {}: {error}",
+                    self.path.display()
+                );
+            }
+        }
+    }
+}
+
+pub(crate) fn refresh_generation_guard_path(storage_path: &Path, generation: Uuid) -> PathBuf {
+    storage_path.join(format!(
+        "{REFRESH_GENERATION_GUARD_PREFIX}{}{REFRESH_GENERATION_GUARD_SUFFIX}",
+        generation.simple()
+    ))
+}
+
+enum RefreshGenerationClaim {
+    Active,
+    Acquired(XtreamRefreshGenerationGuard),
+}
+
+fn try_claim_refresh_generation(storage_path: &Path, generation: Uuid) -> io::Result<RefreshGenerationClaim> {
+    let path = refresh_generation_guard_path(storage_path, generation);
+    for _ in 0..2 {
+        let file = match OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .open(&path)
+        {
+            Ok(file) => file,
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                match OpenOptions::new().read(true).write(true).open(&path) {
+                    Ok(file) => file,
+                    Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+                    Err(error) => return Err(error),
+                }
+            }
+            Err(error) => return Err(error),
+        };
+        return match file.try_lock_exclusive() {
+            Ok(()) => Ok(RefreshGenerationClaim::Acquired(
+                XtreamRefreshGenerationGuard::from_locked_file(path, file),
+            )),
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => Ok(RefreshGenerationClaim::Active),
+            Err(error) => Err(error),
+        };
+    }
+    Err(io::Error::new(
+        io::ErrorKind::WouldBlock,
+        format!(
+            "Xtream refresh generation guard {} changed while cleanup tried to claim it",
+            path.display()
+        ),
+    ))
+}
+
+#[derive(Default)]
+struct OrphanRefreshGeneration {
+    artifacts: Vec<PathBuf>,
+    newest_modified: Option<SystemTime>,
+    inspection_failed: bool,
+}
 
 /// Removes staging files left behind by aborted refreshes (`.refresh-<uuid>.<ext>`).
 ///
-/// Best-effort: only the leaf filename pattern and an mtime check decide what
-/// to delete, never the file contents, so a successfully published file is
-/// never deleted and an in-flight parallel refresh is never interrupted.
-/// Errors are logged and otherwise ignored — this is a cleanup helper, not a
-/// guard.
-pub(crate) fn cleanup_orphaned_staging_artifacts(storage_path: &Path, min_age: std::time::Duration) {
-    let now = std::time::SystemTime::now();
+/// The mtime threshold only makes a generation eligible for cleanup. Before
+/// deleting anything, cleanup must exclusively claim the generation guard and
+/// retain it through every deletion attempt. Errors are logged and otherwise
+/// ignored because cleanup is best-effort and must fail closed.
+pub(crate) fn cleanup_orphaned_staging_artifacts(storage_path: &Path, min_age: Duration) {
+    cleanup_orphaned_staging_artifacts_with_hook(storage_path, min_age, |_, _| {});
+}
+
+fn cleanup_orphaned_staging_artifacts_with_hook(
+    storage_path: &Path,
+    min_age: Duration,
+    mut before_delete: impl FnMut(Uuid, &[PathBuf]),
+) {
+    let now = SystemTime::now();
     let entries = match std::fs::read_dir(storage_path) {
         Ok(entries) => entries,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return,
@@ -118,101 +252,141 @@ pub(crate) fn cleanup_orphaned_staging_artifacts(storage_path: &Path, min_age: s
             return;
         }
     };
-    for entry in entries.flatten() {
+    let mut generations = HashMap::<Uuid, OrphanRefreshGeneration>::new();
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                // Deletion starts only after the complete scan. An incomplete directory
+                // view cannot prove that every artifact of a generation is old, so abort
+                // the entire best-effort pass without deleting anything.
+                log::warn!(
+                    "Failed to enumerate storage path {} for orphaned refresh artifacts: {error}",
+                    storage_path.display()
+                );
+                return;
+            }
+        };
         let leaf = entry.file_name();
         let Some(name) = leaf.to_str() else { continue };
-        if !is_orphan_staging_name(name) {
+        let (generation, is_guard) = if let Some(generation) = refresh_generation_from_staging_name(name) {
+            (generation, false)
+        } else if let Some(generation) = refresh_generation_from_guard_name(name) {
+            (generation, true)
+        } else {
+            continue;
+        };
+        let generation_artifacts = generations.entry(generation).or_default();
+        let modified = match entry.metadata().and_then(|metadata| metadata.modified()) {
+            Ok(modified) => modified,
+            Err(error) => {
+                log::warn!(
+                    "Failed to inspect Xtream refresh generation artifact {}: {error}",
+                    entry.path().display()
+                );
+                generation_artifacts.inspection_failed = true;
+                continue;
+            }
+        };
+        if generation_artifacts
+            .newest_modified
+            .is_none_or(|newest_modified| modified > newest_modified)
+        {
+            generation_artifacts.newest_modified = Some(modified);
+        }
+        if !is_guard {
+            generation_artifacts.artifacts.push(entry.path());
+        }
+    }
+
+    for (generation, generation_artifacts) in generations {
+        if generation_artifacts.inspection_failed {
+            log::debug!("Skipping Xtream refresh generation {generation}: artifact inspection failed");
             continue;
         }
-        let metadata = match entry.metadata() {
-            Ok(metadata) => metadata,
-            Err(error) => {
-                log::warn!(
-                    "Failed to stat refresh artifact {}: {error}",
-                    entry.path().display()
-                );
-                continue;
-            }
+        let Some(newest_modified) = generation_artifacts.newest_modified else {
+            continue;
         };
-        let age = match metadata.modified() {
-            Ok(modified) => now.duration_since(modified).unwrap_or_default(),
-            Err(error) => {
-                log::warn!(
-                    "Failed to read mtime of refresh artifact {}: {error}",
-                    entry.path().display()
-                );
-                continue;
-            }
-        };
+        let age = now.duration_since(newest_modified).unwrap_or_default();
         if age < min_age {
             log::debug!(
-                "Skipping recent refresh artifact {} (age {:?} < {:?})",
-                entry.path().display(),
-                age,
-                min_age
+                "Skipping recent Xtream refresh generation {generation} (age {age:?} < {min_age:?})"
             );
             continue;
         }
-        // Cross-process safety: an active refresh holds an exclusive `flock` on the
-        // staging sidecar lock file. A non-blocking attempt that fails means another
-        // process (or a still-active older lease in this process) owns the artifact,
-        // even if the mtime looks stale. The lock handle is held through `remove_file`
-        // so a new refresh cannot acquire the sidecar and start writing before the
-        // deletion lands. We never create or truncate the sidecar: a missing sidecar
-        // means nothing owns the artifact, and creating it here would leave a stale
-        // `.lock` behind for every probed orphan.
-        let lock_path = sidecar_lock_path(&entry.path());
-        let lock_file = match std::fs::OpenOptions::new().read(true).write(true).open(&lock_path) {
-            Ok(file) => Some(file),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        let generation_guard = match try_claim_refresh_generation(storage_path, generation) {
+            Ok(RefreshGenerationClaim::Active) => {
+                log::debug!("Skipping Xtream refresh generation {generation}: generation lease is active");
+                continue;
+            }
+            Ok(RefreshGenerationClaim::Acquired(generation_guard)) => generation_guard,
             Err(error) => {
                 log::debug!(
-                    "Skipping refresh artifact {}: sidecar lock probe failed: {error}",
-                    entry.path().display()
+                    "Skipping Xtream refresh generation {generation}: generation guard probe failed: {error}"
                 );
                 continue;
             }
         };
-        if let Some(lock_file) = lock_file {
-            if lock_file.try_lock_exclusive().is_err() {
-                log::debug!(
-                    "Skipping refresh artifact {} owned by an active generation",
-                    entry.path().display()
-                );
-                continue;
+        before_delete(generation, &generation_artifacts.artifacts);
+        for artifact in &generation_artifacts.artifacts {
+            match std::fs::remove_file(artifact) {
+                Ok(()) => log::info!("Removed orphaned refresh artifact {}", artifact.display()),
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    log::warn!("Failed to remove orphaned refresh artifact {}: {error}", artifact.display());
+                }
             }
         }
-        let remove_result = std::fs::remove_file(entry.path());
-        debug_assert!(
-            !lock_path.exists(),
-            "cleanup must not leave a generated sidecar behind at {}",
-            lock_path.display()
-        );
-        if let Err(error) = remove_result {
-            log::warn!(
-                "Failed to remove orphaned refresh artifact {}: {error}",
-                entry.path().display()
-            );
-        } else {
-            log::info!("Removed orphaned refresh artifact {}", entry.path().display());
-        }
+        drop(generation_guard);
     }
 }
 
+#[cfg(test)]
 fn is_orphan_staging_name(leaf: &str) -> bool {
-    // `<stem>.refresh-<uuid>.<ext>`. The UUID is 32 lowercase hex chars via
-    // `Uuid::simple()`; requiring the dot boundary after the 32 hex chars and
-    // lowercase-only hex keeps operators safe from accidental matches on
-    // filenames that happen to contain `.refresh-`.
-    leaf.match_indices(".refresh-").any(|(index, _)| {
-        let after = &leaf[index + ".refresh-".len()..];
-        let uuid_bytes = after.as_bytes();
-        if uuid_bytes.len() <= 33 || uuid_bytes[32] != b'.' {
-            return false;
+    refresh_generation_from_staging_name(leaf).is_some()
+}
+
+fn refresh_generation_from_staging_name(leaf: &str) -> Option<Uuid> {
+    let (stem, generation_and_suffix) = leaf.split_once(".refresh-")?;
+    let generation_bytes = generation_and_suffix.as_bytes();
+    if generation_bytes.len() <= 32 {
+        return None;
+    }
+    let generation = generation_and_suffix.get(..32)?;
+    if !generation
+        .as_bytes()
+        .iter()
+        .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        return None;
+    }
+    let suffix = generation_and_suffix.get(32..)?;
+    let known_artifact = match suffix {
+        ".db" | ".idx" | ".db.wal" | ".db.wal.tmp" => {
+            XTREAM_REFRESH_DATABASE_STEMS.contains(&stem)
         }
-        let uuid = &uuid_bytes[..32];
-        uuid.iter().all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
-    })
+        ".lock" => stem
+            .strip_prefix('.')
+            .is_some_and(|database_stem| XTREAM_REFRESH_DATABASE_STEMS.contains(&database_stem)),
+        ".json" => XTREAM_REFRESH_CATEGORY_STEMS.contains(&stem),
+        _ => false,
+    };
+    if known_artifact {
+        Uuid::parse_str(generation).ok()
+    } else {
+        None
+    }
+}
+
+fn refresh_generation_from_guard_name(leaf: &str) -> Option<Uuid> {
+    let generation = leaf
+        .strip_prefix(REFRESH_GENERATION_GUARD_PREFIX)?
+        .strip_suffix(REFRESH_GENERATION_GUARD_SUFFIX)?;
+    let bytes = generation.as_bytes();
+    if bytes.len() != 32 || !bytes.iter().all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f')) {
+        return None;
+    }
+    Uuid::parse_str(generation).ok()
 }
 
 
@@ -226,21 +400,58 @@ pub fn get_file_path_for_db_index(db_path: &Path) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use super::{cleanup_orphaned_staging_artifacts, is_orphan_staging_name};
+    use super::{
+        cleanup_orphaned_staging_artifacts, cleanup_orphaned_staging_artifacts_with_hook,
+        is_orphan_staging_name, refresh_generation_guard_path, XtreamRefreshGenerationGuard,
+    };
     use fs2::FileExt;
     use std::{
-        fs,
-        path::Path,
-        time::{Duration, SystemTime},
+        env, fs, io,
+        path::{Path, PathBuf},
+        process::{Child, Command, ExitStatus, Stdio},
+        sync::mpsc,
+        thread,
+        time::{Duration, Instant, SystemTime},
     };
+    use uuid::Uuid;
+
+    const CROSS_PROCESS_TEST_ROOT: &str = "TULIPROX_XTREAM_GENERATION_GUARD_TEST_ROOT";
+    const CROSS_PROCESS_GENERATION: &str = "55555555555555555555555555555555";
+    const MATCHER_TEST_GENERATION: &str = "0d8f0d8f0d8f0d8f0d8f0d8f0d8f0d8f";
 
     #[test]
-    fn refresh_artifacts_match_orphan_pattern() {
-        assert!(is_orphan_staging_name("live.refresh-0d8f0d8f0d8f0d8f0d8f0d8f0d8f0d8f.db"));
-        assert!(is_orphan_staging_name("cat_live.refresh-0d8f0d8f0d8f0d8f0d8f0d8f0d8f0d8f.json"));
+    fn refresh_artifact_matcher_accepts_only_production_xtream_artifacts() {
+        for database_stem in ["live", "video", "series"] {
+            for suffix in [".db", ".idx", ".db.wal", ".db.wal.tmp"] {
+                let artifact = format!("{database_stem}.refresh-{MATCHER_TEST_GENERATION}{suffix}");
+                assert!(is_orphan_staging_name(&artifact), "production artifact did not match: {artifact}");
+            }
+            let sidecar = format!(".{database_stem}.refresh-{MATCHER_TEST_GENERATION}.lock");
+            assert!(is_orphan_staging_name(&sidecar), "production sidecar did not match: {sidecar}");
+        }
+        for category_stem in ["cat_live", "cat_vod", "cat_series"] {
+            let categories = format!("{category_stem}.refresh-{MATCHER_TEST_GENERATION}.json");
+            assert!(is_orphan_staging_name(&categories), "production category did not match: {categories}");
+        }
+
         assert!(!is_orphan_staging_name("live.db"));
         assert!(!is_orphan_staging_name("cat_live.json"));
         assert!(!is_orphan_staging_name("live.refresh-fixed.db"));
+        assert!(!is_orphan_staging_name(&format!(
+            "unknown.refresh-{MATCHER_TEST_GENERATION}.db"
+        )));
+        assert!(!is_orphan_staging_name(&format!(
+            "live.refresh-{MATCHER_TEST_GENERATION}.backup"
+        )));
+        assert!(!is_orphan_staging_name(&format!(
+            "live.extra.refresh-{MATCHER_TEST_GENERATION}.db"
+        )));
+        assert!(!is_orphan_staging_name(&format!(
+            "live.refresh-{MATCHER_TEST_GENERATION}.db.extra"
+        )));
+        assert!(!is_orphan_staging_name(&format!(
+            "é.refresh-{MATCHER_TEST_GENERATION}.db"
+        )));
     }
 
     #[test]
@@ -272,6 +483,64 @@ mod tests {
         file.set_modified(mtime).expect("set mtime");
     }
 
+    fn wait_for_path(path: &Path, timeout: Duration) -> io::Result<()> {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if path.exists() {
+                return Ok(());
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            format!("timed out waiting for {}", path.display()),
+        ))
+    }
+
+    struct ReapChildOnDrop {
+        child: Option<Child>,
+    }
+
+    impl ReapChildOnDrop {
+        fn new(child: Child) -> Self { Self { child: Some(child) } }
+
+        fn wait_for_exit(mut self, timeout: Duration) -> io::Result<ExitStatus> {
+            let deadline = Instant::now() + timeout;
+            loop {
+                let child = self
+                    .child
+                    .as_mut()
+                    .ok_or_else(|| io::Error::other("Xtream generation guard child is unavailable"))?;
+                match child.try_wait() {
+                    Ok(Some(status)) => {
+                        self.child.take();
+                        return Ok(status);
+                    }
+                    Ok(None) if Instant::now() < deadline => thread::sleep(Duration::from_millis(10)),
+                    Ok(None) => {
+                        return Err(io::Error::new(
+                            io::ErrorKind::TimedOut,
+                            "Xtream generation guard child timed out",
+                        ));
+                    }
+                    Err(error) => return Err(error),
+                }
+            }
+        }
+    }
+
+    impl Drop for ReapChildOnDrop {
+        fn drop(&mut self) {
+            let Some(mut child) = self.child.take() else {
+                return;
+            };
+            if !matches!(child.try_wait(), Ok(Some(_))) {
+                let _ = child.kill();
+            }
+            let _ = child.wait();
+        }
+    }
+
     #[test]
     fn cleanup_leaves_recent_staging_alone() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -280,7 +549,7 @@ mod tests {
         // would write here.
         touch_with_age(&active, Duration::from_secs(5));
 
-        cleanup_orphaned_staging_artifacts(dir.path(), Duration::from_secs(600));
+        cleanup_orphaned_staging_artifacts(dir.path(), Duration::from_mins(10));
 
         assert!(active.exists(), "recent staging file must not be deleted by a parallel refresh");
     }
@@ -292,39 +561,194 @@ mod tests {
         let active = dir.path().join("live.refresh-11111111111111111111111111111111.db");
         let orphan_db = dir.path().join("live.refresh-22222222222222222222222222222222.db");
         let orphan_cat = dir.path().join("cat_live.refresh-33333333333333333333333333333333.json");
+        let unknown_stem = dir.path().join("custom.refresh-22222222222222222222222222222222.db");
+        let unknown_suffix = dir.path().join("live.refresh-22222222222222222222222222222222.backup");
 
         fs::write(&published, b"kept").expect("write published");
         touch_with_age(&active, Duration::from_secs(5));
-        touch_with_age(&orphan_db, Duration::from_secs(3600));
-        touch_with_age(&orphan_cat, Duration::from_secs(3600));
+        touch_with_age(&orphan_db, Duration::from_hours(1));
+        touch_with_age(&orphan_cat, Duration::from_hours(1));
+        touch_with_age(&unknown_stem, Duration::from_hours(1));
+        touch_with_age(&unknown_suffix, Duration::from_hours(1));
 
-        cleanup_orphaned_staging_artifacts(dir.path(), Duration::from_secs(600));
+        cleanup_orphaned_staging_artifacts(dir.path(), Duration::from_mins(10));
 
         assert!(published.exists());
         assert!(active.exists(), "in-flight staging must survive");
         assert!(!orphan_db.exists());
         assert!(!orphan_cat.exists());
+        assert!(unknown_stem.exists(), "unknown refresh-like stem must survive");
+        assert!(unknown_suffix.exists(), "unknown refresh-like suffix must survive");
     }
 
     #[test]
     fn cleanup_skips_active_generation_older_than_min_age() {
-        // An in-flight refresh that exceeds `min_age` because it is unusually slow
-        // must not be reaped: the sidecar lock proves another owner is still alive.
         let dir = tempfile::tempdir().expect("tempdir");
+        let generation = Uuid::parse_str("44444444444444444444444444444444").expect("valid generation");
         let active = dir.path().join("live.refresh-44444444444444444444444444444444.db");
+        let categories = dir
+            .path()
+            .join("cat_live.refresh-44444444444444444444444444444444.json");
         let sidecar = dir.path().join(".live.refresh-44444444444444444444444444444444.lock");
+        let guard_path = refresh_generation_guard_path(dir.path(), generation);
+        let generation_guard = XtreamRefreshGenerationGuard::acquire(dir.path(), generation)
+            .expect("acquire active generation guard");
 
-        touch_with_age(&active, Duration::from_secs(3600));
-        let lock_file = fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(&sidecar)
-            .expect("open sidecar");
-        lock_file.lock_exclusive().expect("acquire active lease");
+        touch_with_age(&active, Duration::from_hours(1));
+        touch_with_age(&categories, Duration::from_hours(1));
+        touch_with_age(&sidecar, Duration::from_hours(1));
 
-        cleanup_orphaned_staging_artifacts(dir.path(), Duration::from_secs(600));
+        cleanup_orphaned_staging_artifacts(dir.path(), Duration::ZERO);
 
         assert!(active.exists(), "active generation older than min_age must survive");
+        assert!(categories.exists(), "active category staging must survive");
+        assert!(sidecar.exists(), "active generation sidecar must survive");
+        assert!(guard_path.exists(), "active generation guard must survive");
+
+        drop(generation_guard);
+        cleanup_orphaned_staging_artifacts(dir.path(), Duration::ZERO);
+
+        assert!(!active.exists());
+        assert!(!categories.exists());
+        assert!(!sidecar.exists());
+        assert!(!guard_path.exists());
+    }
+
+    #[test]
+    fn cleanup_removes_every_known_artifact_of_old_orphan_generation() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let generation = Uuid::parse_str("66666666666666666666666666666666").expect("valid generation");
+        let artifacts = [
+            dir.path().join("live.refresh-66666666666666666666666666666666.db"),
+            dir.path().join("live.refresh-66666666666666666666666666666666.idx"),
+            dir.path().join("live.refresh-66666666666666666666666666666666.db.wal"),
+            dir.path()
+                .join("live.refresh-66666666666666666666666666666666.db.wal.tmp"),
+            dir.path().join(".live.refresh-66666666666666666666666666666666.lock"),
+            dir.path()
+                .join("cat_live.refresh-66666666666666666666666666666666.json"),
+        ];
+        let guard_path = refresh_generation_guard_path(dir.path(), generation);
+        for artifact in &artifacts {
+            touch_with_age(artifact, Duration::from_hours(1));
+        }
+
+        cleanup_orphaned_staging_artifacts(dir.path(), Duration::from_mins(10));
+
+        for artifact in artifacts {
+            assert!(!artifact.exists(), "known orphan artifact survived: {}", artifact.display());
+        }
+        assert!(!guard_path.exists());
+    }
+
+    #[test]
+    fn cleanup_removes_old_guard_without_generation_artifacts() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let generation = Uuid::parse_str("88888888888888888888888888888888").expect("valid generation");
+        let guard_path = refresh_generation_guard_path(dir.path(), generation);
+        touch_with_age(&guard_path, Duration::from_hours(1));
+
+        cleanup_orphaned_staging_artifacts(dir.path(), Duration::from_mins(10));
+
+        assert!(!guard_path.exists(), "old unlocked guard-only orphan must be removed");
+    }
+
+    #[test]
+    fn cleanup_holds_generation_claim_through_artifact_deletion() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let generation = Uuid::parse_str("77777777777777777777777777777777").expect("valid generation");
+        let orphan = dir.path().join("live.refresh-77777777777777777777777777777777.db");
+        let guard_path = refresh_generation_guard_path(dir.path(), generation);
+        touch_with_age(&orphan, Duration::from_hours(1));
+        touch_with_age(&guard_path, Duration::from_hours(1));
+
+        let cleanup_path = dir.path().to_path_buf();
+        let (claimed_sender, claimed_receiver) = mpsc::sync_channel(0);
+        let (release_sender, release_receiver) = mpsc::sync_channel(0);
+        let cleanup = thread::spawn(move || {
+            cleanup_orphaned_staging_artifacts_with_hook(
+                &cleanup_path,
+                Duration::from_mins(10),
+                move |claimed_generation, _| {
+                    claimed_sender
+                        .send(claimed_generation)
+                        .expect("report claimed generation");
+                    release_receiver.recv().expect("wait for competing lock probe");
+                },
+            );
+        });
+
+        assert_eq!(
+            claimed_receiver
+                .recv_timeout(Duration::from_secs(5))
+                .expect("cleanup should claim generation"),
+            generation
+        );
+        let competing_file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&guard_path)
+            .expect("open claimed generation guard");
+        let contention = competing_file
+            .try_lock_exclusive()
+            .expect_err("cleanup must retain generation lock through deletion");
+        assert_eq!(contention.kind(), io::ErrorKind::WouldBlock);
+        release_sender.send(()).expect("release cleanup");
+        cleanup.join().expect("cleanup thread should complete");
+
+        assert!(!orphan.exists());
+        assert!(!guard_path.exists());
+    }
+
+    #[test]
+    fn generation_guard_child_process() -> io::Result<()> {
+        let Some(storage_root) = env::var_os(CROSS_PROCESS_TEST_ROOT) else {
+            return Ok(());
+        };
+        let storage_root = PathBuf::from(storage_root);
+        let generation = Uuid::parse_str(CROSS_PROCESS_GENERATION).map_err(io::Error::other)?;
+        let _generation_guard = XtreamRefreshGenerationGuard::acquire(&storage_root, generation)?;
+        let orphan = storage_root.join(format!("live.refresh-{CROSS_PROCESS_GENERATION}.db"));
+        let sidecar = storage_root.join(format!(".live.refresh-{CROSS_PROCESS_GENERATION}.lock"));
+        touch_with_age(&orphan, Duration::from_hours(1));
+        touch_with_age(&sidecar, Duration::from_hours(1));
+        fs::write(storage_root.join("ready"), b"ready")?;
+        wait_for_path(&storage_root.join("release"), Duration::from_secs(10))?;
+
+        std::process::exit(0);
+    }
+
+    #[test]
+    fn cleanup_coordinates_generation_ownership_across_processes() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let generation = Uuid::parse_str(CROSS_PROCESS_GENERATION).map_err(io::Error::other)?;
+        let orphan = dir.path().join(format!("live.refresh-{CROSS_PROCESS_GENERATION}.db"));
+        let sidecar = dir.path().join(format!(".live.refresh-{CROSS_PROCESS_GENERATION}.lock"));
+        let guard_path = refresh_generation_guard_path(dir.path(), generation);
+        let child = Command::new(env::current_exe()?)
+            .arg("--exact")
+            .arg("repository::storage::tests::generation_guard_child_process")
+            .arg("--nocapture")
+            .env(CROSS_PROCESS_TEST_ROOT, dir.path())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()?;
+        let child = ReapChildOnDrop::new(child);
+        wait_for_path(&dir.path().join("ready"), Duration::from_secs(10))?;
+
+        cleanup_orphaned_staging_artifacts(dir.path(), Duration::ZERO);
+        assert!(orphan.exists(), "artifact owned by child generation must survive");
+        assert!(sidecar.exists(), "sidecar owned by child generation must survive");
+        assert!(guard_path.exists(), "active child generation guard must survive");
+
+        fs::write(dir.path().join("release"), b"release")?;
+        let status = child.wait_for_exit(Duration::from_secs(10))?;
+        assert!(status.success(), "generation guard child failed with {status}");
+
+        cleanup_orphaned_staging_artifacts(dir.path(), Duration::ZERO);
+        assert!(!orphan.exists());
+        assert!(!sidecar.exists());
+        assert!(!guard_path.exists());
+        Ok(())
     }
 }

--- a/backend/src/repository/xtream_repository.rs
+++ b/backend/src/repository/xtream_repository.rs
@@ -11,7 +11,11 @@ use crate::repository::bplustree::{
 };
 use crate::repository::open_playlist_reader;
 use crate::repository::playlist_scratch::PlaylistScratch;
-use crate::repository::storage::{ensure_input_storage_path, ensure_target_storage_subpath, get_file_path_for_db_index, get_input_storage_path, get_target_id_mapping_file, get_target_storage_path};
+use crate::repository::storage::{
+    ensure_input_storage_path, ensure_target_storage_subpath, get_file_path_for_db_index,
+    get_input_storage_path, get_target_id_mapping_file, get_target_storage_path,
+    XtreamRefreshGenerationGuard,
+};
 use crate::repository::storage_const;
 use crate::repository::target_id_mapping::VirtualIdRecord;
 use crate::repository::xtream_playlist_iterator::XtreamPlaylistJsonIterator;
@@ -841,6 +845,7 @@ struct XtreamRefreshLease(Arc<XtreamRefreshLeaseInner>);
 struct XtreamRefreshLeaseInner {
     paths: XtreamRefreshPaths,
     database_artifacts: BPlusTreeStagingArtifacts,
+    _generation_guard: XtreamRefreshGenerationGuard,
 }
 
 impl XtreamRefreshLease {
@@ -855,7 +860,26 @@ impl XtreamRefreshLease {
                 paths.generation
             ))
         })?;
-        Ok(Self(Arc::new(XtreamRefreshLeaseInner { paths, database_artifacts })))
+        let storage_path = paths.staging_database.parent().ok_or_else(|| {
+            TuliproxError::RepositoryXtream(format!(
+                "Xtream staging database has no storage directory: {}",
+                paths.staging_database.display()
+            ))
+        })?;
+        let generation_guard = XtreamRefreshGenerationGuard::acquire(storage_path, paths.generation).map_err(
+            |error| {
+                TuliproxError::RepositoryXtream(format!(
+                    "Failed to acquire Xtream refresh generation guard {} in {}: {error}",
+                    paths.generation,
+                    storage_path.display()
+                ))
+            },
+        )?;
+        Ok(Self(Arc::new(XtreamRefreshLeaseInner {
+            paths,
+            database_artifacts,
+            _generation_guard: generation_guard,
+        })))
     }
 
     fn paths(&self) -> &XtreamRefreshPaths { &self.0.paths }
@@ -1851,10 +1875,12 @@ mod tests {
     };
     use crate::repository::{
         bplustree::common::{ensure_distinct_sidecar_lock_domains, sidecar_lock_path},
-        build_input_storage_path, get_file_path_for_db_index, BPlusTreeQuery, BPlusTreeUpdate,
+        build_input_storage_path, cleanup_orphaned_staging_artifacts, get_file_path_for_db_index,
+        refresh_generation_guard_path, BPlusTreeQuery, BPlusTreeUpdate,
     };
     use crate::utils::{request::DynReader, FileLockManager};
     use arc_swap::{ArcSwap, ArcSwapOption};
+    use fs2::FileExt;
     use shared::model::{
         CatchupProperties, ConfigPaths, InputType, LiveStreamProperties, SeriesStreamProperties, StreamProperties,
         VideoStreamProperties, XtreamCluster, XtreamPlaylistItem,
@@ -2440,6 +2466,7 @@ mod tests {
     fn refresh_lease_defers_cleanup_until_last_worker_clone_drops() {
         let dir = tempdir().expect("temp dir should be created");
         let paths = fixed_refresh_paths(dir.path(), 13);
+        let guard_path = refresh_generation_guard_path(dir.path(), paths.generation);
         let parent_lease = XtreamRefreshLease::new(paths.clone()).expect("refresh lease should be valid");
         let worker_lease = parent_lease.clone();
         fs::write(&paths.staging_database, b"staging").expect("staging fixture should be written");
@@ -2448,10 +2475,48 @@ mod tests {
         drop(parent_lease);
         assert!(paths.staging_database.exists());
         assert!(paths.staging_categories.exists());
+        assert!(guard_path.exists());
 
         drop(worker_lease);
         assert!(!paths.staging_database.exists());
         assert!(!paths.staging_categories.exists());
+        assert!(!guard_path.exists());
+    }
+
+    #[test]
+    fn active_refresh_between_btree_batches_survives_orphan_cleanup() {
+        let dir = tempdir().expect("temp dir should be created");
+        let paths = fixed_refresh_paths(dir.path(), 14);
+        let guard_path = refresh_generation_guard_path(dir.path(), paths.generation);
+        let lease = XtreamRefreshLease::new(paths.clone()).expect("refresh lease should be valid");
+        let sidecar = sidecar_lock_path(&paths.staging_database);
+        fs::write(&paths.staging_database, b"staging").expect("staging fixture should be written");
+        fs::write(&paths.staging_categories, b"categories").expect("category fixture should be written");
+        fs::write(&sidecar, b"").expect("sidecar fixture should be written");
+
+        let between_batch_probe = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&sidecar)
+            .expect("open staging sidecar");
+        between_batch_probe
+            .try_lock_exclusive()
+            .expect("staging sidecar should be unlocked between batches");
+        fs2::FileExt::unlock(&between_batch_probe).expect("release between-batch probe");
+        drop(between_batch_probe);
+
+        cleanup_orphaned_staging_artifacts(dir.path(), Duration::ZERO);
+
+        assert!(paths.staging_database.exists());
+        assert!(paths.staging_categories.exists());
+        assert!(sidecar.exists());
+        assert!(guard_path.exists());
+
+        drop(lease);
+        assert!(!paths.staging_database.exists());
+        assert!(!paths.staging_categories.exists());
+        assert!(!sidecar.exists());
+        assert!(!guard_path.exists());
     }
 
     #[test]

--- a/backend/src/repository/xtream_repository.rs
+++ b/backend/src/repository/xtream_repository.rs
@@ -1346,7 +1346,7 @@ pub async fn persist_input_xtream_playlist_cluster_to_disk(
 }
 
 fn publish_staged_file_same_directory(staging: &Path, published: &Path) -> io::Result<()> {
-    use crate::repository::bplustree::common::{parent_or_dot, require_same_parent_directory};
+    use crate::repository::bplustree::common::require_same_parent_directory;
     require_same_parent_directory(staging, published)?;
     let staging_path = tempfile::TempPath::try_from_path(staging).map_err(|error| {
         io::Error::new(
@@ -1354,8 +1354,23 @@ fn publish_staged_file_same_directory(staging: &Path, published: &Path) -> io::R
             format!("failed to prepare staging file {} for publication: {error}", staging.display()),
         )
     })?;
+    publish_staged_file_platform(staging_path, published)
+}
+
+#[cfg(not(windows))]
+fn publish_staged_file_platform(staging_path: tempfile::TempPath, published: &Path) -> io::Result<()> {
+    publish_staged_file_with_parent_sync(staging_path, published, sync_published_file_parent)
+}
+
+#[cfg(not(windows))]
+fn publish_staged_file_with_parent_sync(
+    staging_path: tempfile::TempPath,
+    published: &Path,
+    sync_parent: impl FnOnce(&Path) -> io::Result<()>,
+) -> io::Result<()> {
+    use crate::repository::bplustree::common::parent_or_dot;
     staging_path.persist(published).map_err(io::Error::from)?;
-    sync_published_file_parent(published).map_err(|error| {
+    sync_parent(published).map_err(|error| {
         io::Error::new(
             error.kind(),
             format!(
@@ -1367,18 +1382,69 @@ fn publish_staged_file_same_directory(staging: &Path, published: &Path) -> io::R
     })
 }
 
+#[cfg(windows)]
+fn publish_staged_file_platform(mut staging_path: tempfile::TempPath, published: &Path) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+
+    fn encode_path(path: &Path) -> io::Result<Vec<u16>> {
+        let mut encoded = path.as_os_str().encode_wide().collect::<Vec<_>>();
+        if encoded.contains(&0) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("Windows path contains an embedded NUL: {}", path.display()),
+            ));
+        }
+        encoded.push(0);
+        Ok(encoded)
+    }
+
+    let staging_encoded = encode_path(staging_path.as_ref())?;
+    let published_encoded = encode_path(published)?;
+
+    // SAFETY: both buffers are live, immutable, and NUL-terminated for the
+    // duration of the call. The same-directory check above ensures that the
+    // operation cannot degrade into a cross-volume copy.
+    let result = unsafe {
+        MoveFileExW(
+            staging_encoded.as_ptr(),
+            published_encoded.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if result == 0 {
+        let error = io::Error::last_os_error();
+        return Err(io::Error::new(
+            error.kind(),
+            format!(
+                "failed to atomically publish staging file {} as {} with a Windows write-through rename: {error}",
+                staging_path.display(),
+                published.display()
+            ),
+        ));
+    }
+
+    // MoveFileExW consumed the source path. Prevent TempPath from issuing a
+    // redundant delete for a path that no longer exists.
+    staging_path.disable_cleanup(true);
+    Ok(())
+}
+
 #[cfg(unix)]
 fn sync_published_file_parent(path: &Path) -> io::Result<()> {
     File::open(crate::repository::bplustree::common::parent_or_dot(path))?.sync_all()
 }
 
-/// Windows (NTFS) and other non-Unix targets open directories as files for
-/// `sync_all`, just as Unix does. The durability barrier is required after
-/// every rename so a power loss cannot leave the directory entry pointing at
-/// the pre-rename file.
-#[cfg(not(unix))]
-fn sync_published_file_parent(path: &Path) -> io::Result<()> {
-    File::open(crate::repository::bplustree::common::parent_or_dot(path))?.sync_all()
+/// There is no supported directory durability barrier for other targets.
+/// Callers report this only after the atomic rename has completed.
+#[cfg(all(not(unix), not(windows)))]
+fn sync_published_file_parent(_path: &Path) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "parent-directory synchronization is unsupported on this platform",
+    ))
 }
 
 /// Owns the staging category file plus its `flock`, so the lock is released
@@ -2539,6 +2605,61 @@ mod tests {
 
         publish_staged_file_same_directory(&staging, &published).expect("category publish should succeed");
 
+        assert_eq!(fs::read(&published).expect("published categories should be readable"), b"new");
+        assert!(!staging.exists());
+    }
+
+    #[test]
+    fn category_publish_creates_missing_same_directory_file() {
+        let dir = tempdir().expect("temp dir should be created");
+        let published = dir.path().join("cat_live.json");
+        let staging = dir.path().join("cat_live.refresh-fixed.json");
+        fs::write(&staging, b"new").expect("staging fixture should be written");
+
+        publish_staged_file_same_directory(&staging, &published).expect("category publish should succeed");
+
+        assert_eq!(fs::read(&published).expect("published categories should be readable"), b"new");
+        assert!(!staging.exists());
+    }
+
+    #[test]
+    fn category_publish_rejects_different_parent_before_replace() {
+        let dir = tempdir().expect("temp dir should be created");
+        let staging_dir = dir.path().join("staging");
+        let published_dir = dir.path().join("published");
+        fs::create_dir_all(&staging_dir).expect("staging directory should be created");
+        fs::create_dir_all(&published_dir).expect("published directory should be created");
+        let staging = staging_dir.join("cat_live.refresh-fixed.json");
+        let published = published_dir.join("cat_live.json");
+        fs::write(&staging, b"new").expect("staging fixture should be written");
+        fs::write(&published, b"old").expect("published fixture should be written");
+
+        let error = publish_staged_file_same_directory(&staging, &published)
+            .expect_err("cross-directory category publication should fail");
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(fs::read(&staging).expect("staging fixture should remain"), b"new");
+        assert_eq!(fs::read(&published).expect("published fixture should remain"), b"old");
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn category_publish_reports_post_rename_barrier_failure_truthfully() {
+        let dir = tempdir().expect("temp dir should be created");
+        let published = dir.path().join("cat_live.json");
+        let staging = dir.path().join("cat_live.refresh-fixed.json");
+        fs::write(&published, b"old").expect("published fixture should be written");
+        fs::write(&staging, b"new").expect("staging fixture should be written");
+        let staging_path = tempfile::TempPath::try_from_path(&staging)
+            .expect("staging fixture should become an owned temporary path");
+
+        let error = super::publish_staged_file_with_parent_sync(staging_path, &published, |_| {
+            Err(io::Error::other("injected parent synchronization failure"))
+        })
+        .expect_err("post-rename synchronization failure should be reported");
+
+        assert_eq!(error.kind(), io::ErrorKind::Other);
+        assert!(error.to_string().contains("was published, but its parent directory"));
         assert_eq!(fs::read(&published).expect("published categories should be readable"), b"new");
         assert!(!staging.exists());
     }


### PR DESCRIPTION
## Summary

- Keep an Xtream refresh generation protected for its complete lifetime so orphan cleanup cannot delete active staging artifacts between B+Tree batches.
- Hold cleanup ownership through deletion and remove inactive generation artifacts, sidecars, and guards as one coordinated unit.
- Publish Xtream category snapshots on Windows with an atomic write-through rename while preserving the existing Unix parent-directory durability barrier.
- Add deterministic regression coverage for cleanup races, active generations, stale sidecars, atomic category replacement, and partial-publication errors.

## Root cause

The orphan sweep previously used an instantaneous sidecar-lock probe as proof that a refresh generation was inactive. Legitimate unlocked intervals between B+Tree batches created a race in which active staging data could be removed.

The category publisher also reused the Unix directory-sync approach on Windows. The rename could succeed before opening the parent directory failed, causing the refresh to report a misleading partial-publication error.

## Validation

- `make fmt-check`
- `make lint`
- `cargo +stable clippy --workspace --all-targets --all-features -- -D warnings`
- `make test` — 3100 backend tests passed, 5 ignored; integration and documentation tests passed
- `make markdown-lint`
- Focused Xtream cleanup and category-publication regression tests

Closes #817
Closes #818


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of outdated Xtream refresh data while protecting active refreshes from accidental deletion.
  * Added safer handling for incomplete, invalid, or locked refresh data.
  * Improved reliability when publishing refreshed category data across supported platforms.
  * Added stricter validation to prevent unrelated files from being removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->