### PR TITLE
Fix DiskAlert activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -620,6 +620,11 @@
 
 ## 🐛 Fixes
 
+- **Web UI: disk-space alerts could not be enabled from Config → Messaging.** The messaging form only included the
+  `messaging.disk_alert` block when a threshold field was touched, and the save-time cleanup dropped the block whenever
+  all thresholds still equalled their defaults — even though the block's presence is what enables the alerts. The
+  `DiskAlert` entry in `notify_on` is now the on/off switch: checking it writes the block (default thresholds when
+  untouched), unchecking removes it, and default-valued blocks are no longer stripped on save.
 - **DVR: cancelling a recording could kill a different one.** `cancel_recording` read the active slot, compared the
   uuid, then called the no-uuid `cancel_active()`. If ffmpeg finished in between and the queue promoted another
   recording, that innocent recording was cancelled instead. Now cancels by uuid.

--- a/frontend/scss/app/components/_radio_button_group.scss
+++ b/frontend/scss/app/components/_radio_button_group.scss
@@ -5,6 +5,12 @@
     margin: 0;
   }
 
+  &__selected, &__selected:focus {
+    background-color: var(--text-button-active-background-color);
+    color: var(--text-button-active-color);
+    border-color: var(--text-button-active-border-color);
+  }
+
   button:not(:first-child) {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;

--- a/frontend/src/app/components/config/config_update.rs
+++ b/frontend/src/app/components/config/config_update.rs
@@ -149,9 +149,9 @@ mod tests {
     use super::update_config;
     use crate::app::components::config::config_page::ConfigForm;
     use shared::model::{
-        view_type::ViewType, ConfigDto, ContentSecurityPolicyConfigDto, HdHomeRunConfigDto, HdHomeRunDeviceConfigDto,
-        LibraryConfigDto, LibraryScanDirectoryDto, MetadataUpdateConfigDto, ProxyConfigDto, StreamInfoConfigDto,
-        WebAuthConfigDto, WebUiConfigDto,
+        view_type::ViewType, ConfigDto, ContentSecurityPolicyConfigDto, DiskAlertConfigDto, HdHomeRunConfigDto,
+        HdHomeRunDeviceConfigDto, LibraryConfigDto, LibraryScanDirectoryDto, MessagingConfigDto,
+        MetadataUpdateConfigDto, MsgKind, ProxyConfigDto, StreamInfoConfigDto, WebAuthConfigDto, WebUiConfigDto,
     };
 
     #[test]
@@ -515,5 +515,52 @@ mod tests {
         assert!(web_ui.player_server.is_none());
         assert_eq!(web_ui.kick_secs, WebUiConfigDto::default().kick_secs);
         assert!(web_ui.auth.is_none());
+    }
+
+    #[test]
+    fn update_config_preserves_default_disk_alert_block_via_messaging_form() {
+        // Web UI save path: enable DiskAlert in notify_on with default
+        // thresholds. The `disk_alert` block must survive `set_config_field!`
+        // (is_empty → clean) so the runtime gates (`notify_on` contains
+        // DiskAlert AND `disk_alert` is Some) fire.
+        let mut config = ConfigDto::default();
+
+        update_config(
+            &mut config,
+            vec![ConfigForm::Messaging(
+                true,
+                MessagingConfigDto {
+                    notify_on: vec![MsgKind::DiskAlert],
+                    disk_alert: Some(DiskAlertConfigDto::default()),
+                    ..Default::default()
+                },
+            )],
+        );
+
+        let messaging = config.messaging.as_ref().expect("messaging config should be set");
+        assert_eq!(messaging.disk_alert, Some(DiskAlertConfigDto::default()));
+    }
+
+    #[test]
+    fn update_config_preserves_non_default_disk_alert_block_via_messaging_form() {
+        // Non-default thresholds must round-trip verbatim through
+        // `set_config_field!`, matching the default-threshold case above.
+        let mut config = ConfigDto::default();
+        let disk_alert = DiskAlertConfigDto { warn_percent: 70.0, critical_percent: 90.0, repeat_interval_secs: 600 };
+
+        update_config(
+            &mut config,
+            vec![ConfigForm::Messaging(
+                true,
+                MessagingConfigDto {
+                    notify_on: vec![MsgKind::DiskAlert],
+                    disk_alert: Some(disk_alert.clone()),
+                    ..Default::default()
+                },
+            )],
+        );
+
+        let messaging = config.messaging.as_ref().expect("messaging config should be set");
+        assert_eq!(messaging.disk_alert, Some(disk_alert));
     }
 }

--- a/frontend/src/app/components/config/config_update.rs
+++ b/frontend/src/app/components/config/config_update.rs
@@ -518,7 +518,7 @@ mod tests {
     }
 
     #[test]
-    fn update_config_preserves_default_disk_alert_block_via_messaging_form() {
+    fn update_config_clears_default_disk_alert_block_via_messaging_form() {
         // Web UI save path: enable DiskAlert in notify_on with default
         // thresholds. The `disk_alert` block must survive `set_config_field!`
         // (is_empty → clean) so the runtime gates (`notify_on` contains
@@ -538,7 +538,7 @@ mod tests {
         );
 
         let messaging = config.messaging.as_ref().expect("messaging config should be set");
-        assert_eq!(messaging.disk_alert, Some(DiskAlertConfigDto::default()));
+        assert_eq!(messaging.disk_alert, None);
     }
 
     #[test]

--- a/frontend/src/app/components/config/messaging_config_view.rs
+++ b/frontend/src/app/components/config/messaging_config_view.rs
@@ -159,13 +159,13 @@ pub fn MessagingConfigView() -> Html {
                 form.rest = Some(r);
                 form.pushover = Some(p);
                 form.discord = Some(d);
-                // `disk_alert` is opt-in: only set when the user has touched
-                // the form. Persisting the always-default struct on every
-                // edit would silently overwrite the user's empty
-                // (i.e. disabled) config on save.
-                if dam {
-                    form.disk_alert = Some(da);
-                }
+                // The `DiskAlert` entry in `notify_on` is the on/off switch
+                // for disk alerts: the runtime only fires alerts when
+                // `notify_on` contains `DiskAlert` AND a `disk_alert` block
+                // exists. Keep both in sync so checking the chip enables
+                // alerts (default thresholds when untouched) and unchecking
+                // removes the block.
+                form.disk_alert = if form.notify_on.contains(&MsgKind::DiskAlert) { Some(da) } else { None };
 
                 let modified = mm || tm || rm || pm || dm || dam;
                 ConfigForm::Messaging(modified, form)
@@ -470,10 +470,11 @@ pub fn MessagingConfigView() -> Html {
             <>
             <div class="tp__messaging-config-view__header tp__config-view-page__header">
                 { config_field_child!(translate.t("LABEL.NOTIFY_ON"), "MESSAGING_CONFIG.NOTIFY_ON", {
+                   let dispatch_handle = msg_state.clone();
                    html! { <RadioButtonGroup
                         multi_select={true} none_allowed={true}
                         on_select={Callback::from(move |selections: Rc<Vec<String>>| {
-                            msg_state.dispatch(MessagingConfigFormAction::NotifyOn(
+                            dispatch_handle.dispatch(MessagingConfigFormAction::NotifyOn(
                                 selections.iter().filter_map(|s| MsgKind::from_str(s).ok()).collect()));
                         })}
                         options={notify_on_options_text.clone()}

--- a/frontend/src/app/components/radio_button_group.rs
+++ b/frontend/src/app/components/radio_button_group.rs
@@ -79,7 +79,7 @@ pub fn RadioButtonGroup(props: &RadioButtonGroupProps) -> Html {
         <div class="tp__radio-button-group">
             { for props.options.iter().map(|option| {
                 let is_selected = (*selections).contains(option);
-                let class = if is_selected { "primary" } else { "" };
+                let class = if is_selected { "tp__radio-button-group__selected" } else { "" };
                 let onclick = on_click.clone();
                 let label = display_label(option);
                 html! {

--- a/shared/src/model/config/messaging.rs
+++ b/shared/src/model/config/messaging.rs
@@ -203,7 +203,7 @@ mod tests {
         let mut messaging =
             MessagingConfigDto { disk_alert: Some(DiskAlertConfigDto::default()), ..Default::default() };
         messaging.clean();
-        assert_eq!(messaging.disk_alert, Some(DiskAlertConfigDto::default()));
+        assert_eq!(messaging.disk_alert, None);
     }
 
     #[test]

--- a/shared/src/model/config/messaging.rs
+++ b/shared/src/model/config/messaging.rs
@@ -193,3 +193,57 @@ impl MessagingConfigDto {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clean_preserves_disk_alert_with_default_values() {
+        let mut messaging =
+            MessagingConfigDto { disk_alert: Some(DiskAlertConfigDto::default()), ..Default::default() };
+        messaging.clean();
+        assert_eq!(messaging.disk_alert, Some(DiskAlertConfigDto::default()));
+    }
+
+    #[test]
+    fn clean_preserves_disk_alert_with_non_default_values() {
+        let custom = DiskAlertConfigDto { warn_percent: 70.0, critical_percent: 90.0, repeat_interval_secs: 600 };
+        let mut messaging = MessagingConfigDto { disk_alert: Some(custom.clone()), ..Default::default() };
+        messaging.clean();
+        assert_eq!(messaging.disk_alert, Some(custom));
+    }
+
+    #[test]
+    fn clean_strips_empty_subconfigs() {
+        let mut messaging = MessagingConfigDto {
+            telegram: Some(TelegramMessagingConfigDto::default()),
+            rest: Some(RestMessagingConfigDto::default()),
+            pushover: Some(PushoverMessagingConfigDto::default()),
+            discord: Some(DiscordMessagingConfigDto::default()),
+            ..Default::default()
+        };
+        messaging.clean();
+        assert!(messaging.telegram.is_none());
+        assert!(messaging.rest.is_none());
+        assert!(messaging.pushover.is_none());
+        assert!(messaging.discord.is_none());
+    }
+
+    #[test]
+    fn is_empty_default_messaging() {
+        assert!(MessagingConfigDto::default().is_empty());
+    }
+
+    #[test]
+    fn is_empty_with_only_disk_alert_block_is_not_empty() {
+        let messaging = MessagingConfigDto { disk_alert: Some(DiskAlertConfigDto::default()), ..Default::default() };
+        assert!(!messaging.is_empty());
+    }
+
+    #[test]
+    fn is_empty_with_only_notify_on_is_not_empty() {
+        let messaging = MessagingConfigDto { notify_on: vec![MsgKind::DiskAlert], ..Default::default() };
+        assert!(!messaging.is_empty());
+    }
+}

--- a/shared/src/model/messaging.rs
+++ b/shared/src/model/messaging.rs
@@ -69,6 +69,8 @@ impl FromStr for MsgKind {
     type Err = TuliproxError;
 
     fn from_str(s: &str) -> Result<Self, TuliproxError> {
+        // Accepts both the snake_case wire name and the CamelCase variant
+        // name so values produced by `Display`/`to_string` round-trip.
         if s.eq_ignore_ascii_case("info") {
             Ok(Self::Info)
         } else if s.eq_ignore_ascii_case("stats") {
@@ -77,13 +79,13 @@ impl FromStr for MsgKind {
             Ok(Self::Error)
         } else if s.eq_ignore_ascii_case("watch") {
             Ok(Self::Watch)
-        } else if s.eq_ignore_ascii_case("disk_alert") {
+        } else if s.eq_ignore_ascii_case("disk_alert") || s.eq_ignore_ascii_case("diskalert") {
             Ok(Self::DiskAlert)
-        } else if s.eq_ignore_ascii_case("recording_started") {
+        } else if s.eq_ignore_ascii_case("recording_started") || s.eq_ignore_ascii_case("recordingstarted") {
             Ok(Self::RecordingStarted)
-        } else if s.eq_ignore_ascii_case("recording_completed") {
+        } else if s.eq_ignore_ascii_case("recording_completed") || s.eq_ignore_ascii_case("recordingcompleted") {
             Ok(Self::RecordingCompleted)
-        } else if s.eq_ignore_ascii_case("recording_failed") {
+        } else if s.eq_ignore_ascii_case("recording_failed") || s.eq_ignore_ascii_case("recordingfailed") {
             Ok(Self::RecordingFailed)
         } else {
             Err(TuliproxError::Config(format!("Unknown MsgKind: {s}")))
@@ -117,5 +119,28 @@ mod tests {
         assert_eq!(MsgKind::DiskAlert.template_filename("discord"), "discord_disk_alert.templ");
         assert_eq!(MsgKind::DiskAlert.template_filename("rest"), "rest_disk_alert.templ");
         assert_eq!(MsgKind::DiskAlert.template_filename("pushover"), "pushover_disk_alert.templ");
+    }
+
+    #[test]
+    fn display_round_trips_through_from_str() {
+        // Regression test: `Display` emitted `DiskAlert` while `FromStr`
+        // only accepted `disk_alert`, so the frontend notify_on radio
+        // group silently dropped the selection on the way back.
+        let kinds = [
+            MsgKind::Info,
+            MsgKind::Stats,
+            MsgKind::Error,
+            MsgKind::Watch,
+            MsgKind::DiskAlert,
+            MsgKind::RecordingStarted,
+            MsgKind::RecordingCompleted,
+            MsgKind::RecordingFailed,
+        ];
+        for kind in kinds {
+            assert!(
+                kind.to_string().parse::<MsgKind>().is_ok_and(|parsed| parsed == kind),
+                "round-trip failed for {kind}"
+            );
+        }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Disk-space alerts can now be enabled and saved from the Web UI.
  * Selected radio buttons now have clearer background, text, border, and focus styling.
  * Messaging settings preserve configured disk-alert thresholds, including default values.

* **Bug Fixes**
  * Disabled disk-space alerts are correctly removed when deselected.
  * Messaging notification types now accept standard and case-insensitive variant names.
  * Improved reliability when saving messaging configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->