### PR TITLE
Fix/dialog stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5347,9 +5347,9 @@ dependencies = [
 
 [[package]]
 name = "yew"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b446be974884d87d58548f1662bc50c051996203a17d2558f8d6c56942b6ac"
+checksum = "2c154fadfa97eabdd3f3b79345ceeb9c05ee8f13f76d3d881d17fba618bf558d"
 dependencies = [
  "console_error_panic_hook",
  "futures",
@@ -5372,9 +5372,9 @@ dependencies = [
 
 [[package]]
 name = "yew-hooks"
-version = "0.5.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b46ac200ea3b129df1826aee9a1328df1c1a061b91399638cf52565bf85819"
+checksum = "bc57e40d6cae633bc2ebc2c297db2eb405bc5362288e5ab8b739ce7864ca50b9"
 dependencies = [
  "gloo",
  "js-sys",
@@ -5390,9 +5390,9 @@ dependencies = [
 
 [[package]]
 name = "yew-macro"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a708a4027c143be6ca160a341700b59f9ecc36a7ebd95e3c477018de8cf71c75"
+checksum = "c08b883d84a035f57519d057f65a2a07ae25f1884ad485e1a9a523c9d880c1ad"
 dependencies = [
  "prettyplease",
  "proc-macro-error",
@@ -5404,9 +5404,9 @@ dependencies = [
 
 [[package]]
 name = "yew-router"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "415cb628900ddf1eaf55ebd04163adf1ea80d3f5a9832a876554f9c0fdd4c282"
+checksum = "870bd2a1aa6d608c0c789c122654e25f4927bb6bfe344cc0da3b630ac3c73260"
 dependencies = [
  "gloo",
  "js-sys",
@@ -5423,9 +5423,9 @@ dependencies = [
 
 [[package]]
 name = "yew-router-macro"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e87a3ce33434ab66a700edbaf2cc8a417d9b89f00a6fd8216fd6ac83b0e7b1c"
+checksum = "8399f1d134ab8e69abc7cded19f114621d520bd9c79c5a0f34091bf664d7325b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -7,9 +7,9 @@ rust-version.workspace = true
 [dependencies]
 shared = { version = "3.3.88", path = "../shared" }
 chrono.workspace = true
-yew = "0.22.1"
-yew-router = "0.19.0"
-yew-hooks = "0.5.0"
+yew = "0.23.0"
+yew-router = "0.20.0"
+yew-hooks = "0.6.4"
 i18nrs = "0.1.9"
 serde_json.workspace = true
 serde.workspace = true

--- a/frontend/src/provider/dialog_provider.rs
+++ b/frontend/src/provider/dialog_provider.rs
@@ -3,81 +3,196 @@ use crate::{
     model::DialogResult,
     services::{DialogRequest, DialogService},
 };
-use yew::{component, html, use_effect_with, use_state, Callback, Children, ContextProvider, Html, Properties};
+use std::rc::Rc;
+use yew::{
+    component, functional::UseReducerDispatcher, html, use_effect_with, use_memo, use_reducer, use_state, Callback,
+    Children, ContextProvider, Html, Properties, Reducible,
+};
 
 #[derive(Properties, PartialEq)]
-pub struct ConfirmProviderProps {
+pub struct DialogProviderProps {
     pub children: Children,
 }
 
+/// Provides the [DialogService] context and mounts a [DialogHost] that owns
+/// the dialog stack. The stack state intentionally lives in `DialogHost`, so
+/// pushing or popping a dialog never re-renders the application children.
 #[component]
-pub fn DialogProvider(props: &ConfirmProviderProps) -> Html {
+pub fn DialogProvider(props: &DialogProviderProps) -> Html {
     let service = use_state(DialogService::new);
-    let dialog_request = use_state(|| None::<DialogRequest>);
-
-    {
-        let service = service.clone();
-        let request = dialog_request.clone();
-        use_effect_with((), move |_| {
-            service.register(Callback::from(move |req: DialogRequest| {
-                request.set(Some(req));
-            }));
-            || ()
-        });
-    }
-
-    let on_confirm = {
-        let request = dialog_request.clone();
-        Callback::from(move |result: DialogResult| {
-            if let Some(req) = &*request {
-                match req {
-                    DialogRequest::Confirm(confirm) => {
-                        if let Some(cb) = confirm.resolve.borrow_mut().take() {
-                            cb(result);
-                        }
-                    }
-                    DialogRequest::Content(content) => {
-                        if let Some(cb) = content.resolve.borrow_mut().take() {
-                            cb(result);
-                        }
-                    }
-                }
-            }
-            request.set(None);
-        })
-    };
 
     html! {
         <ContextProvider<DialogService> context={(*service).clone()}>
             { for props.children.iter() }
-            {
-                if let Some(request) = &*dialog_request {
-                     match request {
-                        DialogRequest::Confirm(confirm) => {
-                            html! {
-                              <ConfirmDialog
-                                    title={confirm.title.clone()}
-                                    ok_caption={confirm.ok_caption.clone()}
-                                    cancel_caption={confirm.cancel_caption.clone()}
-                                    on_confirm={on_confirm.clone()}
-                                />
-                            }
-                        }
-                        DialogRequest::Content(content) => {
-                            html! {
-                              <ContentDialog
-                                    content={content.content.clone()}
-                                    actions={content.actions.clone()}
-                                    close_on_backdrop_click={content.close_on_backdrop_click}
-                                    on_confirm={on_confirm.clone()}
-                                />
-                            }
-                        }
-                    }
-                } else {
-                    html! {}
-                }
-            }
+
+            <DialogHost service={(*service).clone()} />
         </ContextProvider<DialogService>>
+    }
+}
+
+#[derive(Clone)]
+struct DialogEntry {
+    id: u64,
+    request: DialogRequest,
+}
+
+// Entries are immutable once pushed, so the id fully determines identity.
+impl PartialEq for DialogEntry {
+    fn eq(&self, other: &Self) -> bool { self.id == other.id }
+}
+
+#[derive(Default)]
+struct DialogStack {
+    next_id: u64,
+    dialogs: Vec<DialogEntry>,
+}
+
+enum DialogStackAction {
+    Push(DialogRequest),
+    Pop(u64),
+}
+
+impl Reducible for DialogStack {
+    type Action = DialogStackAction;
+
+    fn reduce(self: Rc<Self>, action: Self::Action) -> Rc<Self> {
+        match action {
+            DialogStackAction::Push(request) => {
+                let mut dialogs = self.dialogs.clone();
+
+                dialogs.push(DialogEntry { id: self.next_id, request });
+
+                Self { next_id: self.next_id + 1, dialogs }.into()
+            }
+
+            // Nur der oberste Dialog darf entfernt werden. Ein verspätetes
+            // Pop für eine darunterliegende id tut bewusst nichts und gibt
+            // den unveränderten State zurück (kein Clone, kein Re-Render).
+            DialogStackAction::Pop(id) => {
+                if self.dialogs.last().map(|entry| entry.id) != Some(id) {
+                    return self;
+                }
+
+                let mut dialogs = self.dialogs.clone();
+                dialogs.pop();
+
+                Self { next_id: self.next_id, dialogs }.into()
+            }
+        }
+    }
+}
+
+#[derive(Properties, PartialEq)]
+struct DialogHostProps {
+    service: DialogService,
+}
+
+/// Owns the dialog stack and renders one [DialogLayer] per stacked dialog.
+/// Only this component re-renders when the stack changes.
+#[component]
+fn DialogHost(props: &DialogHostProps) -> Html {
+    // Ab Yew 0.23 rendert `use_reducer` nicht, wenn der Reducer dieselbe
+    // `Rc` zurückgibt. Ein No-op-Pop (siehe `reduce`) bleibt damit
+    // konsequenzlos; ein neues `Rc` löst genau dann einen Render aus, wenn
+    // sich der Stack tatsächlich geändert hat.
+    let dialog_stack = use_reducer(DialogStack::default);
+
+    {
+        let service = props.service.clone();
+        let dispatcher = dialog_stack.dispatcher();
+
+        use_effect_with((), move |_| {
+            service.register(Callback::from(move |request: DialogRequest| {
+                dispatcher.dispatch(DialogStackAction::Push(request));
+            }));
+
+            || ()
+        });
+    }
+
+    let dispatcher = dialog_stack.dispatcher();
+    let dialog_count = dialog_stack.dialogs.len();
+
+    html! {
+        {
+            for dialog_stack
+                .dialogs
+                .iter()
+                .enumerate()
+                .map(|(index, entry)| {
+                    html! {
+                        <DialogLayer
+                            key={entry.id}
+                            entry={entry.clone()}
+                            active={index + 1 == dialog_count}
+                            dispatcher={dispatcher.clone()}
+                        />
+                    }
+                })
+        }
+    }
+}
+
+#[derive(Properties, PartialEq)]
+struct DialogLayerProps {
+    entry: DialogEntry,
+    active: bool,
+    dispatcher: UseReducerDispatcher<DialogStack>,
+}
+
+/// Renders a single stacked dialog. The stable key on this component keeps
+/// lower dialogs mounted while a dialog above them opens or closes, so their
+/// enter animation never replays.
+#[component]
+fn DialogLayer(props: &DialogLayerProps) -> Html {
+    // Der Layer löst seinen eigenen Request auf: id, request und Resolver
+    // sind unveränderlich, der Dispatcher ist stabil — der Callback braucht
+    // daher keinen Zugriff auf den aktuellen Stack.
+    let on_confirm = {
+        let id = props.entry.id;
+        let request = props.entry.request.clone();
+        let dispatcher = props.dispatcher.clone();
+
+        use_memo(id, move |_| {
+            Callback::from(move |result: DialogResult| {
+                let resolver = match &request {
+                    DialogRequest::Confirm(confirm) => confirm.resolve.borrow_mut().take(),
+                    DialogRequest::Content(content) => content.resolve.borrow_mut().take(),
+                };
+
+                if let Some(resolve) = resolver {
+                    // Wichtig: zuerst genau diesen Dialog vom Stack
+                    // entfernen, dann erst die Future fortsetzen. Die Future
+                    // darf sofort einen neuen Dialog öffnen, der dann auf
+                    // dem bereits geleerten Platz landet.
+                    dispatcher.dispatch(DialogStackAction::Pop(id));
+
+                    resolve(result);
+                }
+            })
+        })
+    };
+
+    // Nur der oberste Dialog darf Ergebnisse liefern.
+    let on_confirm = if props.active { (*on_confirm).clone() } else { Callback::noop() };
+
+    match &props.entry.request {
+        DialogRequest::Confirm(confirm) => html! {
+            <ConfirmDialog
+                title={confirm.title.clone()}
+                ok_caption={confirm.ok_caption.clone()}
+                cancel_caption={confirm.cancel_caption.clone()}
+                on_confirm={on_confirm}
+            />
+        },
+
+        DialogRequest::Content(content) => html! {
+            <ContentDialog
+                content={content.content.clone()}
+                actions={content.actions.clone()}
+                close_on_backdrop_click={props.active && content.close_on_backdrop_click}
+                on_confirm={on_confirm}
+            />
+        },
     }
 }

--- a/frontend/src/provider/dialog_provider.rs
+++ b/frontend/src/provider/dialog_provider.rs
@@ -91,10 +91,10 @@ struct DialogHostProps {
 /// Only this component re-renders when the stack changes.
 #[component]
 fn DialogHost(props: &DialogHostProps) -> Html {
-    // Ab Yew 0.23 rendert `use_reducer` nicht, wenn der Reducer dieselbe
-    // `Rc` zurückgibt. Ein No-op-Pop (siehe `reduce`) bleibt damit
-    // konsequenzlos; ein neues `Rc` löst genau dann einen Render aus, wenn
-    // sich der Stack tatsächlich geändert hat.
+    // Since Yew 0.23, `use_reducer` does not re-render when the reducer
+    // returns the same `Rc`. Therefore, a no-op `Pop` (see `reduce`) has
+    // no effect. Every actual stack change returns a new `Rc` and triggers
+    // the required re-render.
     let dialog_stack = use_reducer(DialogStack::default);
 
     {

--- a/shared/src/model/config/messaging.rs
+++ b/shared/src/model/config/messaging.rs
@@ -236,12 +236,6 @@ mod tests {
     }
 
     #[test]
-    fn is_empty_with_only_disk_alert_block_is_not_empty() {
-        let messaging = MessagingConfigDto { disk_alert: Some(DiskAlertConfigDto::default()), ..Default::default() };
-        assert!(!messaging.is_empty());
-    }
-
-    #[test]
     fn is_empty_with_only_notify_on_is_not_empty() {
         let messaging = MessagingConfigDto { notify_on: vec![MsgKind::DiskAlert], ..Default::default() };
         assert!(!messaging.is_empty());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dialogs can now be stacked, allowing multiple dialogs to remain open while keeping only the topmost dialog interactive.
  * Added improved dialog layering and dismissal behavior for nested dialogs.

* **Improvements**
  * Updated the Yew framework and related routing and hooks libraries.
  * Improved dialog handling so background layers remain visible without responding to clicks or results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->