### PR TITLE
Fix M3U alias credential rewriting on provider fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -928,6 +928,12 @@
 
 ## 🐛 Fixes
 
+- **M3U alias failover now uses the allocated provider's opaque query credentials.** When capacity allocation moved a
+  stream from the primary input to an alias, a playlist URL carrying credentials such as `token` or `api_key` could
+  retain the primary provider's value because failover only understood base URLs and username/password credentials.
+  Tuliprox now matches authentication-like query fields against the configured M3U account URL and replaces both key
+  and value with those of the selected provider while preserving unrelated query parameters. Different key names such
+  as `token` and `api_key` are mapped only for an unambiguous one-to-one pair; ambiguous mappings fail closed.
 - **Admission: a request that ended up denied anyway could leave several other streams killed behind it.** Eviction is
   destructive and is never rolled back, but the strategy loop would kick a target, find the retry still denied, and
   move straight on to the next eviction strategy. The loop now samples `user_connections` either side of the kick. A

--- a/backend/app/src/api/api_utils/mod.rs
+++ b/backend/app/src/api/api_utils/mod.rs
@@ -726,6 +726,10 @@ fn get_stream_alternative_url_m3u(
     input: &ConfigInput,
     alias_input: &Arc<ProviderConfig>,
 ) -> Option<String> {
+    if let Some(source_config_url) = find_input_account_by_query_signature(stream_url, input) {
+        return rewrite_account_query_fields(stream_url, source_config_url, &alias_input.url);
+    }
+
     if let Some((source_base_url, source_username, source_password)) =
         find_input_account_by_signature(stream_url, input)
     {
@@ -762,6 +766,110 @@ fn get_stream_alternative_url_m3u(
     if stream_url_has_account_signature(stream_url, &alt_input_user_info) {
         return None;
     }
+    Some(stream_url.to_string())
+}
+
+fn is_account_query_key(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    matches!(
+        key.as_str(),
+        "token"
+            | "access_token"
+            | "auth_token"
+            | "key"
+            | "apikey"
+            | "api_key"
+            | "accesskey"
+            | "access_key"
+            | "auth"
+            | "authorization"
+    ) || key.ends_with("_token")
+        || key.ends_with("_key")
+}
+
+fn find_input_account_by_query_signature<'a>(stream_url: &str, input: &'a ConfigInput) -> Option<&'a str> {
+    if stream_url_account_query_matches(stream_url, &input.url) {
+        return Some(&input.url);
+    }
+
+    input.aliases.as_ref().and_then(|aliases| {
+        aliases
+            .iter()
+            .find(|alias| stream_url_account_query_matches(stream_url, &alias.url))
+            .map(|alias| alias.url.as_str())
+    })
+}
+
+fn stream_url_account_query_matches(stream_url: &str, config_url: &str) -> bool {
+    let (Ok(stream_url), Ok(config_url)) = (Url::parse(stream_url), Url::parse(config_url)) else {
+        return false;
+    };
+
+    config_url.query_pairs().any(|(config_key, config_value)| {
+        is_account_query_key(&config_key)
+            && stream_url.query_pairs().any(|(stream_key, stream_value)| {
+                stream_key.eq_ignore_ascii_case(&config_key) && stream_value == config_value
+            })
+    })
+}
+
+fn rewrite_account_query_fields(stream_url: &str, source_config_url: &str, target_config_url: &str) -> Option<String> {
+    let mut stream_url = Url::parse(stream_url).ok()?;
+    let source_config_url = Url::parse(source_config_url).ok()?;
+    let target_config_url = Url::parse(target_config_url).ok()?;
+    let source_pairs: Vec<_> = source_config_url
+        .query_pairs()
+        .filter(|(key, _)| is_account_query_key(key))
+        .map(|(key, value)| (key.into_owned(), value.into_owned()))
+        .collect();
+    let target_pairs: Vec<_> = target_config_url
+        .query_pairs()
+        .filter(|(key, _)| is_account_query_key(key))
+        .map(|(key, value)| (key.into_owned(), value.into_owned()))
+        .collect();
+    let unambiguous_cross_key_target =
+        if source_pairs.len() == 1 && target_pairs.len() == 1 { target_pairs.first() } else { None };
+    let replacements: Vec<_> = source_pairs
+        .iter()
+        .filter_map(|(source_key, source_value)| {
+            target_pairs
+                .iter()
+                .find(|(target_key, _)| target_key.eq_ignore_ascii_case(source_key))
+                .or(unambiguous_cross_key_target)
+                .map(|(target_key, target_value)| {
+                    (source_key.clone(), source_value.clone(), target_key.clone(), target_value.clone())
+                })
+        })
+        .collect();
+
+    if replacements.is_empty() {
+        return None;
+    }
+
+    let mut replaced = false;
+    let stream_pairs: Vec<(String, String)> = stream_url
+        .query_pairs()
+        .map(|(key, value)| {
+            if let Some((_, _, target_key, target_value)) =
+                replacements.iter().find(|(source_key, source_value, _, _)| {
+                    key.eq_ignore_ascii_case(source_key) && value == source_value.as_str()
+                })
+            {
+                replaced = true;
+                (target_key.clone(), target_value.clone())
+            } else {
+                (key.into_owned(), value.into_owned())
+            }
+        })
+        .collect();
+
+    if !replaced {
+        return None;
+    }
+    stream_url
+        .query_pairs_mut()
+        .clear()
+        .extend_pairs(stream_pairs.iter().map(|(key, value)| (key.as_str(), value.as_str())));
     Some(stream_url.to_string())
 }
 
@@ -892,8 +1000,10 @@ fn rewrite_path_auth_fields(
 }
 
 fn stream_url_matches_provider(stream_url: &str, provider_cfg: &ProviderConfig) -> bool {
+    let account_query_matches =
+        provider_cfg.input_type.is_m3u() && stream_url_account_query_matches(stream_url, &provider_cfg.url);
     let Some(user_info) = provider_cfg.get_user_info() else {
-        return false;
+        return account_query_matches;
     };
     if stream_url_base_matches(stream_url, &user_info.base_url) {
         // Same-host fast path: both base URL and account identity must match.

--- a/backend/app/src/api/api_utils/mod.rs
+++ b/backend/app/src/api/api_utils/mod.rs
@@ -829,7 +829,15 @@ fn rewrite_account_query_fields(stream_url: &str, source_config_url: &str, targe
         .collect();
     let unambiguous_cross_key_target =
         if source_pairs.len() == 1 && target_pairs.len() == 1 { target_pairs.first() } else { None };
-    let replacements: Vec<_> = source_pairs
+    let present_source_pairs: Vec<_> = source_pairs
+        .iter()
+        .filter(|(source_key, source_value)| {
+            stream_url.query_pairs().any(|(stream_key, stream_value)| {
+                stream_key.eq_ignore_ascii_case(source_key) && stream_value == source_value.as_str()
+            })
+        })
+        .collect();
+    let replacements: Vec<_> = present_source_pairs
         .iter()
         .filter_map(|(source_key, source_value)| {
             target_pairs
@@ -842,7 +850,7 @@ fn rewrite_account_query_fields(stream_url: &str, source_config_url: &str, targe
         })
         .collect();
 
-    if replacements.is_empty() {
+    if replacements.len() != present_source_pairs.len() || replacements.is_empty() {
         return None;
     }
 

--- a/backend/app/src/api/api_utils/tests.rs
+++ b/backend/app/src/api/api_utils/tests.rs
@@ -499,6 +499,29 @@ fn get_stream_alternative_url_rejects_ambiguous_cross_key_credential_mapping() {
 }
 
 #[test]
+fn get_stream_alternative_url_rejects_partial_source_credential_mapping() {
+    let input = ConfigInput {
+        name: "source".intern(),
+        url: "http://playlist.example/a.m3u?token=provider-a-token&api_key=provider-a-key".to_string(),
+        input_type: InputType::M3u,
+        ..ConfigInput::default()
+    };
+    let alias = test_runtime_provider_without_credentials(
+        "http://playlist.example/b.m3u?token=provider-b-token",
+        InputType::M3u,
+    );
+
+    assert_eq!(
+        get_stream_alternative_url(
+            "http://stream.example/segment.ts?token=provider-a-token&api_key=provider-a-key&quality=hd",
+            &input,
+            &alias,
+        ),
+        None
+    );
+}
+
+#[test]
 fn select_provider_stream_url_rewrites_opaque_m3u_token_for_allocated_alias() {
     let input = ConfigInput {
         name: "provider-a".intern(),

--- a/backend/app/src/api/api_utils/tests.rs
+++ b/backend/app/src/api/api_utils/tests.rs
@@ -427,6 +427,116 @@ fn get_stream_alternative_url_rewrites_external_cdn_url_with_valid_account_signa
 }
 
 #[test]
+fn get_stream_alternative_url_rewrites_opaque_m3u_token_for_alias_account() {
+    let input = ConfigInput {
+        name: "source".intern(),
+        url: "http://playlist.example/a.m3u?token=provider-a-token".to_string(),
+        input_type: InputType::M3u,
+        aliases: Some(vec![ConfigInputAlias {
+            id: 2,
+            name: "alias".intern(),
+            url: "http://playlist.example/b.m3u?token=provider-b-token".to_string(),
+            username: None,
+            password: None,
+            max_connections: 0,
+            priority: 0,
+            exp_date: None,
+            enabled: true,
+            stalker: None,
+        }]),
+        ..ConfigInput::default()
+    };
+    let alias = test_runtime_provider_without_credentials(
+        "http://playlist.example/b.m3u?token=provider-b-token",
+        InputType::M3u,
+    );
+
+    let rewritten =
+        get_stream_alternative_url("http://stream.example/channel/segment.ts?token=provider-a-token", &input, &alias);
+
+    assert_eq!(rewritten, Some("http://stream.example/channel/segment.ts?token=provider-b-token".to_string()));
+}
+
+#[test]
+fn get_stream_alternative_url_rewrites_single_opaque_m3u_credential_with_different_key() {
+    let input = ConfigInput {
+        name: "source".intern(),
+        url: "http://playlist.example/a.m3u?token=provider-a-token".to_string(),
+        input_type: InputType::M3u,
+        ..ConfigInput::default()
+    };
+    let alias = test_runtime_provider_without_credentials(
+        "http://playlist.example/b.m3u?api_key=provider-b-key",
+        InputType::M3u,
+    );
+
+    let rewritten = get_stream_alternative_url(
+        "http://stream.example/segment.ts?token=provider-a-token&quality=hd",
+        &input,
+        &alias,
+    );
+
+    assert_eq!(rewritten, Some("http://stream.example/segment.ts?api_key=provider-b-key&quality=hd".to_string()));
+}
+
+#[test]
+fn get_stream_alternative_url_rejects_ambiguous_cross_key_credential_mapping() {
+    let input = ConfigInput {
+        name: "source".intern(),
+        url: "http://playlist.example/a.m3u?token=provider-a-token".to_string(),
+        input_type: InputType::M3u,
+        ..ConfigInput::default()
+    };
+    let alias = test_runtime_provider_without_credentials(
+        "http://playlist.example/b.m3u?api_key=provider-b-key&auth=provider-b-auth",
+        InputType::M3u,
+    );
+
+    assert_eq!(
+        get_stream_alternative_url("http://stream.example/segment.ts?token=provider-a-token", &input, &alias),
+        None
+    );
+}
+
+#[test]
+fn select_provider_stream_url_rewrites_opaque_m3u_token_for_allocated_alias() {
+    let input = ConfigInput {
+        name: "provider-a".intern(),
+        url: "http://playlist.example/a.m3u?token=provider-a-token".to_string(),
+        input_type: InputType::M3u,
+        aliases: Some(vec![ConfigInputAlias {
+            id: 2,
+            name: "provider-b".intern(),
+            url: "http://playlist.example/b.m3u?token=provider-b-token".to_string(),
+            username: None,
+            password: None,
+            max_connections: 0,
+            priority: 0,
+            exp_date: None,
+            enabled: true,
+            stalker: None,
+        }]),
+        ..ConfigInput::default()
+    };
+    let alias = test_runtime_provider_without_credentials(
+        "http://playlist.example/b.m3u?token=provider-b-token",
+        InputType::M3u,
+    );
+
+    let selected = select_provider_stream_url(
+        "http://stream.example/channel/segment.ts?token=provider-a-token",
+        &input,
+        &alias,
+        false,
+    );
+
+    assert_eq!(
+        selected,
+        Some(("provider".intern(), "http://stream.example/channel/segment.ts?token=provider-b-token".to_string(),))
+    );
+}
+
+#[test]
 fn get_stream_alternative_url_rewrites_timeshift_path_credentials_for_alias_account() {
     let input = ConfigInput {
         name: "source".intern(),
@@ -944,6 +1054,75 @@ async fn resolve_streaming_strategy_rewrites_stale_alias_url_to_selected_main_pr
     assert_eq!(url.as_ref(), "http://provider-1.example/live/user1/pass1/100.ts");
 
     app_state.active_provider.release_connection(&addr).await;
+}
+
+#[tokio::test]
+async fn resolve_streaming_strategy_rewrites_opaque_m3u_token_after_alias_allocation() {
+    let app_config = create_test_dual_provider_app_config();
+    let input = Arc::new(ConfigInput {
+        id: 1,
+        name: "provider-a".intern(),
+        input_type: InputType::M3u,
+        url: "http://playlist.example/a.m3u?token=provider-a-token".to_string(),
+        enabled: true,
+        max_connections: 1,
+        aliases: Some(vec![ConfigInputAlias {
+            id: 2,
+            name: "provider-b".intern(),
+            url: "http://playlist.example/b.m3u?token=provider-b-token".to_string(),
+            username: None,
+            password: None,
+            max_connections: 0,
+            priority: 1,
+            exp_date: None,
+            enabled: true,
+            stalker: None,
+        }]),
+        ..ConfigInput::default()
+    });
+    app_config.sources.store(Arc::new(SourcesConfig { inputs: vec![Arc::clone(&input)], ..SourcesConfig::default() }));
+    let app_state = create_test_app_state_for_config(Arc::new(app_config));
+    let provider_a = "provider-a".intern();
+    let busy_addr: SocketAddr = "127.0.0.1:55306".parse().unwrap_or_else(|_| unreachable!());
+    let alias_addr: SocketAddr = "127.0.0.1:55307".parse().unwrap_or_else(|_| unreachable!());
+
+    let busy = app_state
+        .active_provider
+        .acquire_exact_connection_with_grace(
+            &provider_a,
+            &busy_addr,
+            false,
+            0,
+            crate::api::model::ConnectionKind::Normal,
+        )
+        .await;
+    assert!(busy.is_some(), "setup should occupy provider A");
+
+    let strategy = resolve_streaming_strategy(
+        &app_state,
+        "http://stream.example/channel/segment.ts?token=provider-a-token",
+        &create_test_fingerprint(alias_addr),
+        &input,
+        StreamingAcquireOptions {
+            force_provider: None,
+            allow_forced_provider_fallback: false,
+            allow_provider_grace: false,
+            user_priority: 0,
+            connection_kind: crate::api::model::ConnectionKind::Normal,
+            session_owner: Some("live-session"),
+            accept_requested_stream_url: false,
+        },
+    )
+    .await;
+
+    let ProviderStreamState::Available(Some(provider), url) = strategy.provider_stream_state else {
+        panic!("request should allocate provider B")
+    };
+    assert_eq!(provider.as_ref(), "provider-b");
+    assert_eq!(url.as_ref(), "http://stream.example/channel/segment.ts?token=provider-b-token");
+
+    app_state.active_provider.release_connection(&busy_addr).await;
+    app_state.active_provider.release_connection(&alias_addr).await;
 }
 
 #[tokio::test]

--- a/frontend/scss/_theme.scss
+++ b/frontend/scss/_theme.scss
@@ -615,13 +615,13 @@ body {
   --tag-series-border-color: var(--theme-brand-quaternary);
 
   --toastr-success-color: var(--theme-brand-text-inverse);
-  --toastr-success-background-color: color-mix(in srgb, var(--theme-brand-positive) 40%, transparent);
+  --toastr-success-background-color: color-mix(in srgb, var(--theme-brand-positive) 10%, transparent);
   --toastr-error-color: var(--theme-brand-text-inverse);
-  --toastr-error-background-color: color-mix(in srgb, var(--theme-brand-danger-strong) 40%, transparent);
+  --toastr-error-background-color: color-mix(in srgb, var(--theme-brand-danger-strong) 10%, transparent);
   --toastr-info-color: var(--theme-brand-text-inverse);
-  --toastr-info-background-color: color-mix(in srgb, var(--theme-brand-primary-border) 40%, transparent);
+  --toastr-info-background-color: color-mix(in srgb, var(--theme-brand-primary-border) 10%, transparent);
   --toastr-warning-color: var(--theme-brand-text-inverse);
-  --toastr-warning-background-color: color-mix(in srgb, var(--theme-brand-warning-strong) 40%, transparent);
+  --toastr-warning-background-color: color-mix(in srgb, var(--theme-brand-warning-strong) 10%, transparent);
   --toastr-shadow: var(--theme-brand-toast-shadow);
 
   --spinner-color: color-mix(in srgb, var(--theme-brand-text-inverse) 40%, transparent);

--- a/frontend/src/app/components/dashboard/stats_view.rs
+++ b/frontend/src/app/components/dashboard/stats_view.rs
@@ -122,43 +122,45 @@ pub fn StatsView(props: &StatsViewProps) -> Html {
 
         html! {
         <div class="tp__stats">
-            <CollapsePanel expanded={true} title_content={Some(html! {
+            <div class="tp__stats__body">
+                <CollapsePanel expanded={true} title_content={Some(html! {
+                    <div class="tp__stats__header">
+                     <h1>{ translate.t("LABEL.STATS")}</h1>
+                    </div>
+                    })}>
+                    <div class="tp__stats__body">
+                      { render_system_stats(cache) }
+                    </div>
+                </CollapsePanel>
+                <CollapsePanel expanded={true} title_content={Some(html! {
+                    <div class="tp__stats__header">
+                     <h1>{ translate.t("LABEL.STREAMS")}</h1>
+                    </div>
+                    })}>
+                    <div class="tp__stats__body">
+                      <div class="tp__stats__body-group">
+                         <StreamsView embedded={true} />
+                      </div>
+                    </div>
+                </CollapsePanel>
                 <div class="tp__stats__header">
-                 <h1>{ translate.t("LABEL.STATS")}</h1>
+                    <h1>{ translate.t("LABEL.PLAYLIST_UPDATE")}</h1>
                 </div>
-                })}>
-                <div class="tp__stats__body">
-                  { render_system_stats(cache) }
+                <div class="tp__stats__body-group">
+                    <Card><PlaylistProgressStatusCard /></Card>
                 </div>
-            </CollapsePanel>
-            <CollapsePanel expanded={true} title_content={Some(html! {
-                <div class="tp__stats__header">
-                 <h1>{ translate.t("LABEL.STREAMS")}</h1>
-                </div>
-                })}>
-                <div class="tp__stats__body">
-                  <div class="tp__stats__body-group">
-                     <StreamsView embedded={true} />
-                  </div>
-                </div>
-            </CollapsePanel>
-            <div class="tp__stats__header">
-                <h1>{ translate.t("LABEL.PLAYLIST_UPDATE")}</h1>
+                <CollapsePanel expanded={*logs_expanded} on_state_change={on_logs_toggle.clone()} title_content={Some(html! {
+                    <div class="tp__stats__header">
+                     <h1>{ translate.t("LABEL.LOGS")}</h1>
+                    </div>
+                    })}>
+                    <div class="tp__stats__body">
+                        <LogConsole active={*logs_expanded} />
+                    </div>
+                </CollapsePanel>
             </div>
-            <div class="tp__stats__body-group">
-                <Card><PlaylistProgressStatusCard /></Card>
-            </div>
-            <CollapsePanel expanded={*logs_expanded} on_state_change={on_logs_toggle.clone()} title_content={Some(html! {
-                <div class="tp__stats__header">
-                 <h1>{ translate.t("LABEL.LOGS")}</h1>
-                </div>
-                })}>
-                <div class="tp__stats__body">
-                    <LogConsole active={*logs_expanded} />
-                </div>
-            </CollapsePanel>
-            </div>
-            }
+        </div>
+        }
     };
 
     let render_stats_only = || {


### PR DESCRIPTION
Fix M3U alias credential rewriting on provider fallback
  Rewrite opaque authentication query parameters when stream allocation
  switches from the primary M3U provider to an alias.

  Support unambiguous cross-key mappings such as token to api_key while
  preserving unrelated query parameters and rejecting ambiguous mappings.

  Add regression coverage for URL rewriting and provider allocation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved M3U stream failover when authentication credentials are provided in URL query parameters.
  * Alias providers now use their own credentials while preserving unrelated query parameters.
  * Ambiguous or incomplete credential mappings safely fail instead of selecting an incorrect account.
  * Stream URLs can now be matched correctly when provider credentials are stored in query parameters.

* **Improvements**
  * Made notification backgrounds more subtle.
  * Added collapsible panels for system statistics and stream information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->