### PR TITLE
fix HLS cache race and session reservations

### DIFF
--- a/backend/app/src/api/endpoints/hls_api/segment.rs
+++ b/backend/app/src/api/endpoints/hls_api/segment.rs
@@ -2660,7 +2660,8 @@ pub(super) fn hls_entry_user_session_token(
     if let Some(timestamp) = archive_reference {
         return create_m3u_catchup_session_key(fingerprint, username, virtual_id, &format!("archive|{timestamp}|0"));
     }
-    create_playback_session_fingerprint(fingerprint, username, virtual_id, PlaylistItemType::LiveHls, None)
+    let base = create_playback_session_fingerprint(fingerprint, username, virtual_id, PlaylistItemType::LiveHls, None);
+    format!("{base}|hls|{}", generate_random_string(16))
 }
 
 #[allow(clippy::too_many_lines)]

--- a/backend/app/src/api/endpoints/hls_api/tests.rs
+++ b/backend/app/src/api/endpoints/hls_api/tests.rs
@@ -160,6 +160,17 @@ fn append_catchup_session_hint_keeps_m3u_catchup_token_without_shared_hls_cache(
 }
 
 #[test]
+fn live_hls_entry_tokens_separate_parallel_playbacks_with_the_same_fingerprint() {
+    let fingerprint = test_fingerprint();
+    let first = super::hls_entry_user_session_token(&fingerprint, "alice", 42, None, None);
+    let second = super::hls_entry_user_session_token(&fingerprint, "alice", 42, None, None);
+
+    assert_ne!(first, second);
+    assert!(first.contains("|hls|"));
+    assert!(second.contains("|hls|"));
+}
+
+#[test]
 fn leaked_dvr_relative_joins_against_media_playlist_and_dvr_session_root() {
     assert_eq!(
         resolve_leaked_hls_relative_origin(

--- a/backend/hls/src/cache.rs
+++ b/backend/hls/src/cache.rs
@@ -366,10 +366,11 @@ pub enum CacheInvalidationOutcome {
 
 /// File-backed cache for committed HLS segment objects.
 ///
-/// Lock order: the capacity-pressure gate serializes projected reclamation and the following reservation. A failed
-/// reservation releases the cache-path read lease before calling the GC reclaimer because cache-root handoff orders
-/// GC before the exclusive cache-path gate. The read lease is reacquired for generation validation and reservation;
-/// after projected accounting is reserved, the pressure gate is released and the read lease spans the atomic rename.
+/// Lock order: the capacity-admission gate serializes authoritative admission, projected reclamation, and the following
+/// reservation. It is acquired before the cache-path read lease because cache-root handoff orders GC before the
+/// exclusive cache-path gate. The read lease is released before calling the GC reclaimer and reacquired for generation
+/// validation and reservation; after projected accounting is reserved, the pressure gate is released and the read lease
+/// spans the atomic rename.
 /// The `temp_files`, `capacity`, path, reclaimer, and marker standard-library locks are never nested with one another
 /// and are always released before filesystem I/O or `.await`.
 pub struct HlsSegmentCache {
@@ -384,7 +385,7 @@ pub struct HlsSegmentCache {
     capacity: Arc<StdMutex<CacheCapacityState>>,
     capacity_changed: Arc<Notify>,
     capacity_reclaimer: StdRwLock<Option<Weak<dyn HlsCacheCapacityReclaimer>>>,
-    capacity_reclamation_gate: AsyncMutex<()>,
+    capacity_admission_gate: AsyncMutex<()>,
     owned_operation_permits: Arc<Semaphore>,
 }
 
@@ -618,7 +619,7 @@ impl HlsSegmentCache {
             capacity: Arc::new(StdMutex::new(CacheCapacityState::default())),
             capacity_changed: Arc::new(Notify::new()),
             capacity_reclaimer: StdRwLock::new(None),
-            capacity_reclamation_gate: AsyncMutex::new(()),
+            capacity_admission_gate: AsyncMutex::new(()),
             owned_operation_permits: Arc::new(Semaphore::new(MAX_CONCURRENT_OWNED_CACHE_OPERATIONS)),
         }
     }
@@ -728,7 +729,7 @@ impl HlsSegmentCache {
             return Err(cache_object_limit_error(max_object_bytes));
         }
 
-        let _reclamation_gate = self.capacity_reclamation_gate.lock().await;
+        let _admission_gate = self.capacity_admission_gate.lock().await;
         let mut reclamation_attempted = false;
         let mut reclamation_outcome = HlsCacheCapacityReclaimOutcome::default();
         let mut reclamation_pressure: Option<CacheCapacityPressure> = None;
@@ -885,8 +886,10 @@ impl HlsSegmentCache {
         K: HlsCacheObjectKey,
         G: Send + 'static,
     {
+        // Every authoritative admission participates in this gate. Otherwise a new writer that happens to fit after
+        // reclamation can consume the reclaimed bytes before the reclaiming writer performs its retry.
+        let admission_gate = self.capacity_admission_gate.lock().await;
         let mut reclamation_attempted = false;
-        let mut reclamation_gate = None;
         let mut reclamation_outcome = HlsCacheCapacityReclaimOutcome::default();
         let mut reclamation_pressure: Option<CacheCapacityPressure> = None;
         loop {
@@ -945,20 +948,6 @@ impl HlsSegmentCache {
                     let Some(capacity) = hls_cache_capacity_from_io(&error) else {
                         return Err(error);
                     };
-                    if reclamation_gate.is_none() {
-                        log::warn!(
-                            "HLS cache capacity pressure detected: proxy_session={} staged_bytes={} required_session_bytes={} required_global_bytes={}",
-                            safe_proxy_session_id(key.proxy_session_id()),
-                            staged.size,
-                            capacity.required_session_bytes(),
-                            capacity.required_global_bytes(),
-                        );
-                        // GC cache-path handoff takes its run gate before the cache-path write gate. Release this read
-                        // lease before waiting on the pressure gate, then repeat the generation and capacity checks.
-                        drop(commit_gate);
-                        reclamation_gate = Some(self.capacity_reclamation_gate.lock().await);
-                        continue;
-                    }
                     if reclamation_attempted {
                         log::warn!(
                             "HLS cache capacity decision: proxy_session={} resource={} configured_session_bytes={} configured_global_bytes={} current_session_bytes={} current_global_bytes={} staged_bytes={} protected_working_set_bytes={} reclaimable_bytes={} required_session_bytes={} required_global_bytes={} outcome=deferred-protected wake_reason=capacity-or-protection-revision",
@@ -987,8 +976,15 @@ impl HlsSegmentCache {
                         required_global_bytes: capacity.required_global_bytes(),
                         staged_bytes: staged.size,
                     };
-                    // The pressure gate remains held through reclamation and the next authoritative reservation.
-                    // The path read lease cannot: cache-root handoff uses run-gate -> path-write ordering.
+                    log::warn!(
+                        "HLS cache capacity pressure detected: proxy_session={} staged_bytes={} required_session_bytes={} required_global_bytes={}",
+                        safe_proxy_session_id(key.proxy_session_id()),
+                        staged.size,
+                        capacity.required_session_bytes(),
+                        capacity.required_global_bytes(),
+                    );
+                    // The admission gate remains held through reclamation and the next authoritative reservation. The
+                    // path read lease cannot: cache-root handoff uses run-gate -> path-write ordering.
                     drop(commit_gate);
                     reclamation_attempted = true;
                     reclamation_pressure = Some(capacity.pressure());
@@ -1016,7 +1012,7 @@ impl HlsSegmentCache {
                     continue;
                 }
             };
-            drop(reclamation_gate.take());
+            drop(admission_gate);
             let staged_path = staged.path.clone();
             let committed_size = staged.size;
             // Once spawned, the owned mutation deliberately outlives cancellation of the requesting future. This
@@ -1859,18 +1855,20 @@ impl Default for HlsSegmentCache {
 mod tests {
     use super::{
         hls_cache_capacity_from_io, hls_cache_object_limit_from_io, run_owned_cache_operation,
-        CacheInvalidationOutcome, HlsCacheObjectKey, HlsSegmentCache, MapCacheKey, SegmentCacheKey,
+        CacheInvalidationOutcome, HlsCacheCapacityReclaimOutcome, HlsCacheCapacityReclaimRequest,
+        HlsCacheCapacityReclaimer, HlsCacheObjectKey, HlsSegmentCache, MapCacheKey, SegmentCacheKey,
         TransientObjectCacheKey, MAX_CONCURRENT_OWNED_CACHE_OPERATIONS, MAX_TEMP_FILE_CLEANUP_CANDIDATES_PER_RUN,
     };
     use crate::{transient::build_transient_resource_id, HlsOriginResourceFetchError, ProxySessionId};
+    use futures::{future::BoxFuture, FutureExt};
     use std::{
-        collections::HashSet,
+        collections::{HashSet, VecDeque},
         future::Future,
         io,
         pin::Pin,
         sync::{
             atomic::{AtomicBool, Ordering},
-            Arc,
+            Arc, Mutex,
         },
         task::{Context, Poll},
         time::{Duration, SystemTime},
@@ -1893,6 +1891,45 @@ mod tests {
         cache.update_cache_limits(5, 5);
         cache.write_bytes_and_commit(&resident, b"123").await.expect("resident object commits");
         (temp_dir, cache, first, second)
+    }
+
+    struct PausingCapacityReclaimer {
+        cache: Arc<HlsSegmentCache>,
+        victims: Mutex<VecDeque<SegmentCacheKey>>,
+        first_reclaimed: Mutex<Option<oneshot::Sender<()>>>,
+        resume_first: Mutex<Option<oneshot::Receiver<()>>>,
+    }
+
+    impl HlsCacheCapacityReclaimer for PausingCapacityReclaimer {
+        fn reclaim_capacity(
+            &self,
+            _request: HlsCacheCapacityReclaimRequest,
+        ) -> BoxFuture<'_, io::Result<HlsCacheCapacityReclaimOutcome>> {
+            async move {
+                let victim = self.victims.lock().unwrap_or_else(std::sync::PoisonError::into_inner).pop_front();
+                let Some(victim) = victim else {
+                    return Ok(HlsCacheCapacityReclaimOutcome::default());
+                };
+                self.cache.delete_if_inactive(&victim).await?;
+                let first_reclaimed =
+                    self.first_reclaimed.lock().unwrap_or_else(std::sync::PoisonError::into_inner).take();
+                if let Some(first_reclaimed) = first_reclaimed {
+                    let resume_first =
+                        self.resume_first.lock().unwrap_or_else(std::sync::PoisonError::into_inner).take();
+                    let _ = first_reclaimed.send(());
+                    if let Some(resume_first) = resume_first {
+                        let _ = resume_first.await;
+                    }
+                }
+                Ok(HlsCacheCapacityReclaimOutcome {
+                    reclaimed_session_bytes: 10,
+                    reclaimed_global_bytes: 10,
+                    protected_working_set_bytes: 0,
+                    reclaimable_bytes: 10,
+                })
+            }
+            .boxed()
+        }
     }
 
     struct ControlledReader {
@@ -2274,6 +2311,67 @@ mod tests {
 
         assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
         assert_eq!(results.iter().filter(|result| result.is_err()).count(), 1);
+    }
+
+    #[tokio::test]
+    async fn concurrent_commit_cannot_consume_bytes_reclaimed_for_an_in_flight_writer() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let cache = Arc::new(HlsSegmentCache::with_cache_path(temp_dir.path()));
+        let proxy_session_id = ProxySessionId("serialized-reclamation".to_string());
+        let first_resident = SegmentCacheKey::new(proxy_session_id.clone(), 1, "ts");
+        let second_resident = SegmentCacheKey::new(proxy_session_id.clone(), 2, "ts");
+        let first_target = SegmentCacheKey::new(proxy_session_id.clone(), 3, "ts");
+        let second_target = SegmentCacheKey::new(proxy_session_id.clone(), 4, "ts");
+        cache.update_cache_limits(100, 100);
+        cache.write_bytes_and_commit(&first_resident, b"0123456789").await.expect("first resident commits");
+        cache.write_bytes_and_commit(&second_resident, b"0123456789").await.expect("second resident commits");
+        cache.update_cache_limits(25, 25);
+
+        let first_staged = cache
+            .stage_temp_with_deadline(
+                &first_target,
+                &b"abcdefghij"[..],
+                tokio::time::Instant::now() + Duration::from_secs(5),
+            )
+            .await
+            .expect("first target stages");
+        let second_staged = cache
+            .stage_temp_with_deadline(
+                &second_target,
+                &b"klmnopqrst"[..],
+                tokio::time::Instant::now() + Duration::from_secs(5),
+            )
+            .await
+            .expect("second target stages");
+        let (first_reclaimed_tx, first_reclaimed_rx) = oneshot::channel();
+        let (resume_first_tx, resume_first_rx) = oneshot::channel();
+        let reclaimer = Arc::new(PausingCapacityReclaimer {
+            cache: Arc::clone(&cache),
+            victims: Mutex::new(VecDeque::from([first_resident, second_resident])),
+            first_reclaimed: Mutex::new(Some(first_reclaimed_tx)),
+            resume_first: Mutex::new(Some(resume_first_rx)),
+        });
+        cache.install_capacity_reclaimer(&reclaimer);
+
+        let first_cache = Arc::clone(&cache);
+        let first_task = tokio::spawn(async move { first_cache.commit_staged(&first_target, first_staged).await });
+        first_reclaimed_rx.await.expect("first reclamation pauses after deleting one resident");
+
+        let second_cache = Arc::clone(&cache);
+        let second_task = tokio::spawn(async move { second_cache.commit_staged(&second_target, second_staged).await });
+        for _ in 0..100 {
+            tokio::task::yield_now().await;
+        }
+        let paused_usage = cache.capacity_usage(&proxy_session_id).await.expect("paused capacity usage");
+        assert_eq!(paused_usage.session_bytes, 10, "a later commit must wait for the reclaiming writer's retry");
+
+        assert!(resume_first_tx.send(()).is_ok());
+        let (first_result, second_result) = tokio::join!(first_task, second_task);
+        assert!(first_result.expect("first task joins").is_ok());
+        assert!(second_result.expect("second task joins").is_ok());
+        let usage = cache.capacity_usage(&proxy_session_id).await.expect("final capacity usage");
+        assert_eq!(usage.session_bytes, 20);
+        assert!(usage.global_bytes <= 25);
     }
 
     #[tokio::test]

--- a/backend/session/src/active_provider_manager.rs
+++ b/backend/session/src/active_provider_manager.rs
@@ -235,16 +235,6 @@ impl ActiveProviderManager {
         });
     }
 
-    // Reservation ownership is grouped by the `fingerprint|username` prefix and intentionally drops the
-    // trailing session/input suffix. That lets a client switch channels and immediately reuse the same
-    // reserved provider account without waiting for the old channel reservation to expire.
-    // Tradeoff: a new reservation for one channel clears any other reservation in the same family, so
-    // concurrent multi-channel playback for the same client family is not supported by this grouping.
-    // If concurrent streams must be supported, reservation matching must use the full owner identifier.
-    fn reservation_family(owner: &str) -> &str { owner.rsplit_once('|').map_or(owner, |(family, _)| family) }
-
-    fn reservation_family_key(owner: &str) -> Arc<str> { Arc::from(Self::reservation_family(owner)) }
-
     async fn has_foreign_reservation(&self, provider_name: &Arc<str>, session_owner: Option<&str>) -> bool {
         if !self.providers.reservation_blocks_other_sessions(provider_name) {
             return false;
@@ -253,8 +243,7 @@ impl ActiveProviderManager {
         Self::prune_expired_reservations(&mut reservations);
         reservations.get(provider_name).is_some_and(|provider_reservations| {
             session_owner.map_or(!provider_reservations.is_empty(), |owner| {
-                let owner_family = Self::reservation_family(owner);
-                provider_reservations.keys().any(|family| family.as_ref() != owner_family)
+                provider_reservations.keys().any(|reserved_owner| reserved_owner.as_ref() != owner)
             })
         })
     }
@@ -262,34 +251,33 @@ impl ActiveProviderManager {
     async fn get_reserved_provider_for_owner(&self, input_name: &Arc<str>, session_owner: &str) -> Option<Arc<str>> {
         let mut reservations = self.reservations.write().await;
         Self::prune_expired_reservations(&mut reservations);
-        let owner_family = Self::reservation_family(session_owner);
         reservations.iter().find_map(|(provider_name, provider_reservations)| {
-            (provider_reservations.contains_key(owner_family)
+            (provider_reservations.contains_key(session_owner)
                 && self.providers.is_provider_for_input(provider_name, input_name))
             .then(|| provider_name.clone())
         })
     }
 
-    async fn active_reservation_families(&self, provider_name: &Arc<str>) -> HashSet<Arc<str>> {
+    async fn active_reservation_owners(&self, provider_name: &Arc<str>) -> HashSet<Arc<str>> {
         let connections = self.connections.read().await;
-        let mut families = HashSet::new();
+        let mut owners = HashSet::new();
         for per_addr in connections.single.values() {
             for info in per_addr.values() {
                 if info.allocation.get_provider_name().as_ref() == Some(provider_name) {
-                    if let Some(owner) = info.session_owner.as_deref() {
-                        families.insert(Self::reservation_family_key(owner));
+                    if let Some(owner) = info.session_owner.as_ref() {
+                        owners.insert(Arc::clone(owner));
                     }
                 }
             }
         }
         for shared in connections.shared.by_key.values() {
             if shared.allocation.get_provider_name().as_ref() == Some(provider_name) {
-                if let Some(owner) = shared.session_owner.as_deref() {
-                    families.insert(Self::reservation_family_key(owner));
+                if let Some(owner) = shared.session_owner.as_ref() {
+                    owners.insert(Arc::clone(owner));
                 }
             }
         }
-        families
+        owners
     }
 
     async fn reservation_capacity_usage(
@@ -302,14 +290,16 @@ impl ActiveProviderManager {
             return Some((current_connections, max_connections, 0));
         }
 
-        let owner_family = session_owner.map(Self::reservation_family);
-        let active_families = self.active_reservation_families(provider_name).await;
+        let active_owners = self.active_reservation_owners(provider_name).await;
         let mut reservations = self.reservations.write().await;
         Self::prune_expired_reservations(&mut reservations);
         let idle_foreign_reservations = reservations.get(provider_name).map_or(0, |provider_reservations| {
             provider_reservations
                 .keys()
-                .filter(|family| owner_family != Some(family.as_ref()) && !active_families.contains(family.as_ref()))
+                .filter(|reserved_owner| {
+                    let reserved_owner = reserved_owner.as_ref();
+                    session_owner != Some(reserved_owner) && !active_owners.contains(reserved_owner)
+                })
                 .count()
         });
 
@@ -357,19 +347,15 @@ impl ActiveProviderManager {
     pub async fn refresh_provider_reservation(&self, provider_name: &Arc<str>, session_owner: &str, ttl_secs: u64) {
         let mut reservations = self.reservations.write().await;
         Self::prune_expired_reservations(&mut reservations);
-        // Refresh operates on the reservation family, not the exact owner string. This is what allows a
-        // same-client channel switch to move the pinned provider account to the new stream immediately.
-        // The tradeoff is that other reservations from the same family are cleared here as well.
-        let owner_family = Self::reservation_family_key(session_owner);
         reservations.retain(|_, provider_reservations| {
-            provider_reservations.remove(&owner_family);
+            provider_reservations.remove(session_owner);
             !provider_reservations.is_empty()
         });
         if ttl_secs == 0 {
             return;
         }
         reservations.entry(provider_name.clone()).or_default().insert(
-            owner_family,
+            Arc::from(session_owner),
             ProviderReservation { expires_at: TokioInstant::now() + Duration::from_secs(ttl_secs) },
         );
     }
@@ -377,9 +363,8 @@ impl ActiveProviderManager {
     pub async fn clear_provider_reservation(&self, session_owner: &str) {
         let mut reservations = self.reservations.write().await;
         Self::prune_expired_reservations(&mut reservations);
-        let owner_family = Self::reservation_family_key(session_owner);
         reservations.retain(|_, provider_reservations| {
-            provider_reservations.remove(&owner_family);
+            provider_reservations.remove(session_owner);
             !provider_reservations.is_empty()
         });
     }
@@ -2104,20 +2089,21 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn test_same_client_family_can_reuse_reserved_provider_after_channel_switch() {
+    async fn different_session_cannot_take_idle_reservation_from_same_client_family() {
         let app_cfg = create_test_app_config_single_provider_pool();
         let event_manager = Arc::new(EventManager::new());
         let manager = ActiveProviderManager::new(&app_cfg, &event_manager);
 
         let input_name = "provider_1".intern();
-        let first_addr: SocketAddr = "127.0.0.1:43111".parse().unwrap();
-        let second_addr: SocketAddr = "127.0.0.1:43112".parse().unwrap();
+        let Ok(second_addr) = "127.0.0.1:43112".parse() else {
+            return;
+        };
         let owner_channel_1 = "client|ua|user|100";
         let owner_channel_2 = "client|ua|user|200";
 
         manager.refresh_provider_reservation(&input_name, owner_channel_1, 15).await;
 
-        let reacquired = manager
+        let blocked = manager
             .acquire_connection_with_grace_for_session(
                 &input_name,
                 &second_addr,
@@ -2126,12 +2112,87 @@ mod tests {
                 ConnectionKind::Normal,
                 Some(owner_channel_2),
             )
-            .await
-            .expect("same client family should be able to reuse the reserved provider after a channel switch");
+            .await;
+        assert!(blocked.is_none(), "a related but distinct playback must not steal an idle reservation");
 
-        assert_eq!(reacquired.allocation.get_provider_name().as_deref(), Some(input_name.as_ref()));
+        manager.clear_provider_reservation(owner_channel_1).await;
+        let acquired = manager
+            .acquire_connection_with_grace_for_session(
+                &input_name,
+                &second_addr,
+                false,
+                default_user_priority(),
+                ConnectionKind::Normal,
+                Some(owner_channel_2),
+            )
+            .await;
+        assert!(acquired.is_some(), "explicitly clearing the old playback should release its provider");
+        manager.release_connection(&second_addr).await;
+    }
 
+    #[tokio::test(start_paused = true)]
+    async fn concurrent_same_family_playbacks_keep_independent_provider_reservations() {
+        let app_cfg = create_test_app_config_with_dual_provider_pool();
+        let event_manager = Arc::new(EventManager::new());
+        let manager = ActiveProviderManager::new(&app_cfg, &event_manager);
+
+        let input_name = "provider_1".intern();
+        let provider_2 = "provider_2".intern();
+        let Ok(first_addr) = "127.0.0.1:43121".parse() else {
+            return;
+        };
+        let Ok(second_addr) = "127.0.0.1:43122".parse() else {
+            return;
+        };
+        let owner_channel_1 = "proxy|player|user|100";
+        let owner_channel_2 = "proxy|player|user|200";
+
+        let first = manager
+            .acquire_connection_with_grace_for_session(
+                &input_name,
+                &first_addr,
+                false,
+                default_user_priority(),
+                ConnectionKind::Normal,
+                Some(owner_channel_1),
+            )
+            .await;
+        assert!(first.is_some(), "first playback should acquire the preferred provider");
+        let Some(first) = first else {
+            return;
+        };
+        assert_eq!(first.allocation.get_provider_name().as_deref(), Some(input_name.as_ref()));
+        manager.refresh_provider_reservation(&input_name, owner_channel_1, 15).await;
         manager.release_connection(&first_addr).await;
+
+        let second = manager
+            .acquire_connection_with_grace_for_session(
+                &input_name,
+                &second_addr,
+                false,
+                default_user_priority(),
+                ConnectionKind::Normal,
+                Some(owner_channel_2),
+            )
+            .await;
+        assert!(second.is_some(), "parallel playback should acquire the remaining provider");
+        let Some(second) = second else {
+            return;
+        };
+        assert_eq!(second.allocation.get_provider_name().as_deref(), Some(provider_2.as_ref()));
+        manager.refresh_provider_reservation(&provider_2, owner_channel_2, 15).await;
+
+        let reservations = manager.reservations.read().await;
+        assert!(reservations.get(&input_name).is_some_and(|entries| entries.contains_key(owner_channel_1)));
+        assert!(reservations.get(&provider_2).is_some_and(|entries| entries.contains_key(owner_channel_2)));
+        drop(reservations);
+
+        manager.clear_provider_reservation(owner_channel_2).await;
+        let reservations = manager.reservations.read().await;
+        assert!(reservations.get(&input_name).is_some_and(|entries| entries.contains_key(owner_channel_1)));
+        assert!(!reservations.values().any(|entries| entries.contains_key(owner_channel_2)));
+        drop(reservations);
+
         manager.release_connection(&second_addr).await;
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Live playback sessions now receive unique session identifiers, preventing parallel playbacks from being conflated.
  * Improved media segment caching under high write activity to prevent competing operations from interfering with capacity recovery.
  * Provider reservations now remain independent for different channel variants, preventing one playback from reusing or taking over another’s reservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->